### PR TITLE
fix(DataTableProvider): Fix row selection toggling

### DIFF
--- a/shesha-reactjs/src/providers/dataTable/reducer.ts
+++ b/shesha-reactjs/src/providers/dataTable/reducer.ts
@@ -1,8 +1,4 @@
-import {
-  DATA_TABLE_CONTEXT_INITIAL_STATE,
-  DEFAULT_PAGE_SIZE_OPTIONS,
-  IDataTableStateContext,
-} from './contexts';
+import { DATA_TABLE_CONTEXT_INITIAL_STATE, DEFAULT_PAGE_SIZE_OPTIONS, IDataTableStateContext } from './contexts';
 import {
   DataTableActionEnums,
   IChangeFilterAction,
@@ -50,7 +46,7 @@ const reducer = handleActions<IDataTableStateContext, any>(
     },
     [DataTableActionEnums.ChangeSelectedRow]: (state: IDataTableStateContext, action: ReduxActions.Action<any>) => {
       const { payload } = action;
-      
+
       return {
         ...state,
         selectedRow: payload?.id === state?.selectedRow?.id ? null : payload,
@@ -214,26 +210,27 @@ const reducer = handleActions<IDataTableStateContext, any>(
       } = action;
 
       const cols = configurableColumns
-        .map<ITableColumn>(col => prepareColumn(col, columns, userConfig))     
-        .filter(c => c !== null);
+        .map<ITableColumn>((col) => prepareColumn(col, columns, userConfig))
+        .filter((c) => c !== null);
 
       const dataCols = getTableDataColumns(cols);
       const configuredTableSorting = dataCols
-        .filter(c => c.defaultSorting !== null && c.defaultSorting !== undefined && c.propertyName)
-        .map<IColumnSorting>(c => ({ id: c.id, desc: c.defaultSorting === 1 }));
+        .filter((c) => c.defaultSorting !== null && c.defaultSorting !== undefined && c.propertyName)
+        .map<IColumnSorting>((c) => ({ id: c.id, desc: c.defaultSorting === 1 }));
 
       const tableSorting =
         userConfig && userConfig.tableSorting && userConfig.tableSorting.length > 0
           ? userConfig.tableSorting
           : configuredTableSorting;
 
-      const userFilters = userConfig?.selectedFilterIds?.length > 0 && state.predefinedFilters?.length > 0
-        ? userConfig?.selectedFilterIds?.filter(x => {
-            return state.predefinedFilters?.find(f => {
-              return f.id === x;
-            });
-          }) ?? []
-        : [];
+      const userFilters =
+        userConfig?.selectedFilterIds?.length > 0 && state.predefinedFilters?.length > 0
+          ? userConfig?.selectedFilterIds?.filter((x) => {
+              return state.predefinedFilters?.find((f) => {
+                return f.id === x;
+              });
+            }) ?? []
+          : [];
 
       const selectedStoredFilterIds = state?.selectedStoredFilterIds?.length
         ? [...state.selectedStoredFilterIds]
@@ -263,8 +260,8 @@ const reducer = handleActions<IDataTableStateContext, any>(
       const { payload: appliedFiltersColumnIds } = action;
 
       const currentFilter = getDirtyFilter(state);
-      const filter = appliedFiltersColumnIds.map<ITableFilter>(id => {
-        const existingFilter = currentFilter.find(f => f.columnId === id);
+      const filter = appliedFiltersColumnIds.map<ITableFilter>((id) => {
+        const existingFilter = currentFilter.find((f) => f.columnId === id);
         if (existingFilter) return existingFilter;
 
         const column = getTableDataColumn(state.columns, id);
@@ -313,7 +310,7 @@ const reducer = handleActions<IDataTableStateContext, any>(
 
       const currentFilter = getDirtyFilter(state);
 
-      const filter = currentFilter.map<ITableFilter>(f => ({
+      const filter = currentFilter.map<ITableFilter>((f) => ({
         ...f,
         filterOption: f.columnId === filterColumnId ? filterOptionValue : f.filterOption,
       }));
@@ -334,7 +331,7 @@ const reducer = handleActions<IDataTableStateContext, any>(
 
       const currentFilter = getDirtyFilter(state);
 
-      const filter = currentFilter.map<ITableFilter>(f => ({
+      const filter = currentFilter.map<ITableFilter>((f) => ({
         ...f,
         filter: f.columnId === filterColumnId ? filterValue : f.filter,
       }));
@@ -351,15 +348,15 @@ const reducer = handleActions<IDataTableStateContext, any>(
     ) => {
       const { predefinedFilters, userConfig } = action.payload;
 
-      const uc = userConfig?.selectedFilterIds?.filter(x => {
-        return predefinedFilters?.find(f => {
+      const uc = userConfig?.selectedFilterIds?.filter((x) => {
+        return predefinedFilters?.find((f) => {
           return f.id === x;
         });
       });
 
-      const selectedStoredFilterIds = 
-        (!Boolean(state.selectedStoredFilterIds) || state.selectedStoredFilterIds.length === 0) 
-        && predefinedFilters?.length > 0
+      const selectedStoredFilterIds =
+        (!Boolean(state.selectedStoredFilterIds) || state.selectedStoredFilterIds.length === 0) &&
+        predefinedFilters?.length > 0
           ? Boolean(uc) && uc.length > 0
             ? uc
             : [predefinedFilters[0].id]
@@ -368,7 +365,7 @@ const reducer = handleActions<IDataTableStateContext, any>(
       return {
         ...state,
         predefinedFilters,
-        selectedStoredFilterIds
+        selectedStoredFilterIds,
       };
     },
 
@@ -417,7 +414,9 @@ const reducer = handleActions<IDataTableStateContext, any>(
       state: IDataTableStateContext,
       action: ReduxActions.Action<ISetRowDataPayload>
     ) => {
-      const { payload: { rowData, rowIndex } } = action;
+      const {
+        payload: { rowData, rowIndex },
+      } = action;
       const { tableData } = state;
 
       const newData = [...tableData];
@@ -428,7 +427,7 @@ const reducer = handleActions<IDataTableStateContext, any>(
         tableData: newData,
       };
     },
-    
+
     [DataTableActionEnums.SetDataFetchingMode]: (
       state: IDataTableStateContext,
       action: ReduxActions.Action<DataFetchingMode>


### PR DESCRIPTION
Previously, when toggling the selection of table rows, the logic was flawed and didn't handle all conditions. This commit corrects the  method to properly handle row selection toggling.

BREAKING CHANGE: The row toggling behavior is now different and might affect consumers who relied on the previous flawed behavior.