### PR TITLE
sidebarContainerMainAreaBody height fix

### DIFF
--- a/shesha-reactjs/src/components/sidebarContainer/styles/styles.ts
+++ b/shesha-reactjs/src/components/sidebarContainer/styles/styles.ts
@@ -24,7 +24,7 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
       overflow-x: hidden;
 
       .${sidebarContainerMainAreaBody}{
-        height: 85vh;
+        max-height: 85vh;
         overflow-y: auto;
         overflow-x: hidden;
       }


### PR DESCRIPTION
Hi @AlexStepantsov . On Friday I made a PR to allow all three parts of formDesigner to be independently scrollable , that worked. But it also made the height of all components that has "SidebarContainer" to all have height of 85vh hence[ this bug](https://github.com/shesha-io/shesha-framework/issues/981). Please kindly review and feedback. Thanks