### PR TITLE
preserve  the icon/link color on selected when it is fixed

### DIFF
--- a/shesha-reactjs/src/components/reactTable/styles/styles.ts
+++ b/shesha-reactjs/src/components/reactTable/styles/styles.ts
@@ -220,10 +220,11 @@ export const useMainStyles = createStyles(({ css, cx, token, prefixCls, iconPref
             .sha-link {
               color: white;
             }
-
             background: ${token.colorPrimary};
             color: white;
+            
           }
+        
 
           .${prefixCls}-form-item {
             .${prefixCls}-form-item-row {
@@ -304,6 +305,10 @@ export const useMainStyles = createStyles(({ css, cx, token, prefixCls, iconPref
             position: sticky;
             z-index: 10;
             opacity: 1;
+             .sha-link {
+              color: ${token.colorPrimary};
+            
+            }
           }
           &.${relativeColumn} {
             display: inline-block;


### PR DESCRIPTION
We have upgraded the dataTable to have some columns fixed on the left or right. So when the action column(s) are anchored
and you select a row we want the color to remain as primary color for better visibility since we don't change the background of those fixed columns.