### PR TITLE
Fix for the ready-only switch component.

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/components/switch/switch.tsx
+++ b/shesha-reactjs/src/components/formDesigner/components/switch/switch.tsx
@@ -32,10 +32,10 @@ const SwitchComponent: IToolboxComponent<ISwitchComponentProps> = {
       <ConfigurableFormItem model={model} valuePropName="checked" initialValue={model?.defaultValue}>
         {(value, onChange) => {
           return model.readOnly ? (
-              <ReadOnlyDisplayFormItem type="switch" disabled={model.readOnly} value={value} />
-            ) : (
-              <Switch className="sha-switch" disabled={model.readOnly} style={style} size={size as SwitchSize} checked={value} onChange={onChange}/>
-            );
+            <ReadOnlyDisplayFormItem type="switch" disabled={model.readOnly} checked={value} />
+          ) : (
+            <Switch className="sha-switch" disabled={model.readOnly} style={style} size={size as SwitchSize} checked={value} onChange={onChange} />
+          );
         }}
       </ConfigurableFormItem>
     );

--- a/shesha-reactjs/src/components/formDesigner/components/switch/switch.tsx
+++ b/shesha-reactjs/src/components/formDesigner/components/switch/switch.tsx
@@ -31,11 +31,11 @@ const SwitchComponent: IToolboxComponent<ISwitchComponentProps> = {
     return (
       <ConfigurableFormItem model={model} valuePropName="checked" initialValue={model?.defaultValue}>
         {(value, onChange) => {
-           return model.readOnly ? (
-             <ReadOnlyDisplayFormItem type="switch" disabled={model.readOnly} checked={value} />
-           ) : (
-             <Switch className="sha-switch" disabled={model.readOnly} style={style} size={size as SwitchSize} checked={value} onChange={onChange} />
-           );
+          return model.readOnly ? (
+              <ReadOnlyDisplayFormItem type="switch" disabled={model.readOnly} checked={value} />
+            ) : (
+              <Switch className="sha-switch" disabled={model.readOnly} style={style} size={size as SwitchSize} checked={value} onChange={onChange} />
+            );
         }}
       </ConfigurableFormItem>
     );

--- a/shesha-reactjs/src/components/formDesigner/components/switch/switch.tsx
+++ b/shesha-reactjs/src/components/formDesigner/components/switch/switch.tsx
@@ -31,11 +31,11 @@ const SwitchComponent: IToolboxComponent<ISwitchComponentProps> = {
     return (
       <ConfigurableFormItem model={model} valuePropName="checked" initialValue={model?.defaultValue}>
         {(value, onChange) => {
-          return model.readOnly ? (
-            <ReadOnlyDisplayFormItem type="switch" disabled={model.readOnly} checked={value} />
-          ) : (
-            <Switch className="sha-switch" disabled={model.readOnly} style={style} size={size as SwitchSize} checked={value} onChange={onChange} />
-          );
+           return model.readOnly ? (
+             <ReadOnlyDisplayFormItem type="switch" disabled={model.readOnly} checked={value} />
+           ) : (
+             <Switch className="sha-switch" disabled={model.readOnly} style={style} size={size as SwitchSize} checked={value} onChange={onChange} />
+           );
         }}
       </ConfigurableFormItem>
     );


### PR DESCRIPTION
This pull request resolves https://github.com/shesha-io/shesha-framework/issues/665.

The issue was caused by the incorrect prop being used to pass the value of a read-only switch into the read-only component. There is also a small format fix on an existing line.