### PR TITLE
persist selected row

### DIFF
--- a/shesha-reactjs/src/components/reactTable/tableRow.tsx
+++ b/shesha-reactjs/src/components/reactTable/tableRow.tsx
@@ -92,7 +92,9 @@ export const TableRow: FC<ISortableRowProps> = (props) => {
         setSelected(-1);
       }
     };
-    document.addEventListener('click', onClickOutside);
+    const tableRowsSection=document.getElementsByClassName(styles.tbody)[0] as HTMLElement;
+    
+    tableRowsSection.addEventListener('click', onClickOutside);
   }, []);
 
   const rowId = row.original.id ?? row.id;


### PR DESCRIPTION
Hi @IvanIlyichev . I was tasked to do this [item](https://github.com/shesha-io/shesha-framework/issues/1114). My changes are merely just making sure that we move away from the entire 'document' and just focus on the "table body" to avoid deSelect when clicking outside as per item stipulated.