### PR TITLE
entityPicker dynamic size and style fix

### DIFF
--- a/shesha-reactjs/src/components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/components/entityPicker/index.tsx
@@ -53,6 +53,7 @@ export const EntityPickerEditableInner = (props: IEntityPickerProps) => {
     value,
     mode,
     size,
+    style,
     useButtonPicker,
     pickerButtonProps,
     onSelect,
@@ -298,7 +299,7 @@ export const EntityPickerEditableInner = (props: IEntityPickerProps) => {
               options={options}
               suffixIcon={null} // hide arrow              
               onChange={handleMultiChange}
-              style={{ width: 'calc(100% - 32px)' }}
+              style={{ ...style, width: 'calc(100% - 32px)' }}
               loading={selection.loading}
             >
               {''}

--- a/shesha-reactjs/src/components/formDesigner/components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/components/entityPicker/index.tsx
@@ -8,7 +8,7 @@ import { DataTypes } from '@/interfaces/dataTypes';
 import { useForm } from '@/providers';
 import { IConfigurableColumnsProps } from '@/providers/datatableColumnsConfigurator/models';
 import { FormIdentifier, IConfigurableFormComponent } from '@/providers/form/models';
-import { executeExpression, validateConfigurableComponentSettings } from '@/providers/form/utils';
+import { executeExpression, getStyle, validateConfigurableComponentSettings } from '@/providers/form/utils';
 import { ITableViewProps } from '@/providers/tableViewSelectorConfigurator/models';
 import ConfigurableFormItem from '../formItem';
 import { migrateV0toV1 } from './migrations/migrate-v1';
@@ -49,8 +49,8 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
   icon: <EllipsisOutlined />,
   dataTypeSupported: ({ dataType }) => dataType === DataTypes.entityReference,
   Factory: ({ model }) => {
-    const { filters, modalWidth, customWidth, widthUnits } = model;
-    const { formMode } = useForm();
+    const { filters, modalWidth, customWidth, widthUnits, style } = model;
+    const { formMode, formData } = useForm();
 
     const entityPickerFilter = useMemo<ITableViewProps[]>(() => {
       return [
@@ -99,6 +99,7 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
     }
 
     const width = modalWidth === 'custom' && customWidth ? `${customWidth}${widthUnits}` : modalWidth;
+    const computedStyle = getStyle(style, formData) ?? {};
 
     return (
       <ConfigurableFormItem model={model} initialValue={model.defaultValue}>
@@ -107,7 +108,7 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
           <EntityPicker
             incomeValueFunc={incomeValueFunc}
             outcomeValueFunc={outcomeValueFunc}
-
+            style={computedStyle}
             formId={model.id}
             readOnly={model.readOnly}
             displayEntityKey={model.displayEntityKey}
@@ -131,6 +132,7 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
             configurableColumns={model.items ?? []}
             value={value}
             onChange={onChange}
+            size={model.size}
           />
         );
         }}


### PR DESCRIPTION
I have addressed the sizing and styling issues of the entity picker, as reported in GitHub [Issues](https://github.com/shesha-io/shesha-framework/issues/576)
This PR ensures that the entity picker now adheres to the desired behavior, size and style dynamically adjust based on the specified settings.