### PR TITLE
When you use {{data.id}} on filters, it does not pass the id #1295 (R…

### DIFF
--- a/shesha-reactjs/src/components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/components/entityPicker/index.tsx
@@ -12,7 +12,6 @@ import { hasDynamicFilter } from '@/providers/dataTable/utils';
 import { IModalProps } from '@/providers/dynamicModal/models';
 import { useEntitySelectionData } from '@/utils/entity';
 import GlobalTableFilter from '@/components/globalTableFilter';
-import camelCaseKeys from 'camelcase-keys';
 import { DataTable } from '@/components/dataTable';
 import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
 import TablePager from '@/components/tablePager';
@@ -153,12 +152,10 @@ export const EntityPickerEditableInner = (props: IEntityPickerProps) => {
   const propertyMetadataAccessor = useNestedPropertyMetadatAccessor(entityType);
 
   const evaluateDynamicFiltersHelper = () => {
-    const data = !isEmpty(formData) ? camelCaseKeys(formData, { deep: true, pascalCase: true }) : formData;
-
     evaluateDynamicFilters(
       filters,
       [
-        { match: 'data', data: data },
+        { match: 'data', data: formData },
         { match: 'globalState', data: globalState },
       ],
       propertyMetadataAccessor

--- a/shesha-reactjs/src/components/formDesigner/components/dataSource/dataSource.tsx
+++ b/shesha-reactjs/src/components/formDesigner/components/dataSource/dataSource.tsx
@@ -46,8 +46,6 @@ const DataSourceAccessor: FC<IDataSourceComponentProps> = ({ id, propertyName: n
   const propertyMetadataAccessor = useNestedPropertyMetadatAccessor(modelType);
 
   const debounceEvaluateDynamicFiltersHelper = () => {
-    //const data = Boolean(formData) ? camelCaseKeys(formData, { deep: true, pascalCase: true }) : formData;
-
     evaluateDynamicFilters(
       filters,
       [

--- a/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
+++ b/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
@@ -1,7 +1,5 @@
 import { FileSearchOutlined } from '@ant-design/icons';
 import { message } from 'antd';
-import camelCaseKeys from 'camelcase-keys';
-import { isEmpty } from 'lodash';
 import moment from 'moment';
 import React, { Key } from 'react';
 import { Autocomplete, IAutocompleteProps, ISelectOption } from '@/components/autocomplete';
@@ -58,14 +56,12 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
     const evaluatedFilters = useAsyncMemo(async () => {
       if (!filter) return '';
 
-      const localFormData = !isEmpty(data) ? camelCaseKeys(data, { deep: true, pascalCase: true }) : data;
-
       const response = await evaluateDynamicFilters(
         [{ expression: filter } as any],
         [
           {
             match: 'data',
-            data: localFormData,
+            data: data,
           },
           {
             match: 'globalState',

--- a/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/tableViewSelector.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/tableViewSelector.tsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import camelCaseKeys from 'camelcase-keys';
 import React, { FC, MutableRefObject, useEffect } from 'react';
 import TableViewSelectorRenderer from '@/components/tableViewSelectorRenderer';
 import { Alert } from 'antd';
@@ -53,10 +52,8 @@ export const TableViewSelector: FC<ITableViewSelectorProps> = ({
 
     //#region Filters
     const debounceEvaluateDynamicFiltersHelper = () => {
-        const data = !_.isEmpty(formData) ? camelCaseKeys(formData, { deep: true, pascalCase: true }) : formData;
-
         const match = [
-            { match: 'data', data: data },
+            { match: 'data', data: formData },
             { match: 'globalState', data: globalState },
         ];
 

--- a/shesha-reactjs/src/providers/dataTable/filters/evaluateFilter.ts
+++ b/shesha-reactjs/src/providers/dataTable/filters/evaluateFilter.ts
@@ -3,9 +3,7 @@ import { useAsyncMemo } from "@/hooks/useAsyncMemo";
 import { IMatchData } from "@/providers/form/utils";
 import { NestedPropertyMetadatAccessor } from "@/providers/metadataDispatcher/contexts";
 import { evaluateDynamicFilters } from "@/utils/index";
-import { isEmpty } from "lodash";
 import { FilterExpression, IStoredFilter } from "../interfaces";
-import camelCaseKeys from 'camelcase-keys';
 import { useFormData, useGlobalState } from "@/providers/index";
 
 interface IMatchDataWithPreparation extends IMatchData {
@@ -60,8 +58,7 @@ export const useFormEvaluatedFilter = (args: UseFormEvaluatedFilterArgs) => {
         mappings:  [
             {
               match: 'data',
-              data: formData,
-              prepare: (data) => (!isEmpty(data) ? camelCaseKeys(data, { deep: true, pascalCase: true }) : data)
+              data: formData,              
             },
             {
               match: 'globalState',

--- a/shesha-reactjs/src/providers/dataTable/index.tsx
+++ b/shesha-reactjs/src/providers/dataTable/index.tsx
@@ -1,4 +1,3 @@
-import camelCaseKeys from 'camelcase-keys';
 import React, {
   FC,
   PropsWithChildren,
@@ -539,7 +538,7 @@ export const DataTableProviderWithRepository: FC<PropsWithChildren<IDataTablePro
   };
 
   const changeActionedRow = (val: any) => {
-    dispatch(changeActionedRowAction(val ? camelCaseKeys(val, { deep: true }) : null));
+    dispatch(changeActionedRowAction(val));
   };
 
   const changeSelectedStoredFilterIds = (selectedFilterIds: string[]) => {


### PR DESCRIPTION
…emoved usage of camelCaseKeys, legacy conversion to PascalCase was wrong and didn't work because of bug in the version 2.1.0 of camelCaseKeys)