### PR TITLE
visble text for row in edit mode

### DIFF
--- a/shesha-reactjs/src/components/reactTable/styles/styles.ts
+++ b/shesha-reactjs/src/components/reactTable/styles/styles.ts
@@ -224,6 +224,21 @@ export const useMainStyles = createStyles(({ css, cx, token, prefixCls, iconPref
             }
             background: ${token.colorPrimary};
             color: white;
+
+            .ant-form-item-control-input-content, button, a {
+                    color: white;
+              }
+
+            .sha-form-cell{
+              .ant-form-item-control-input-content, a, button {
+                  color: inherit;
+              }
+            
+              .sha-stored-files-renderer, .ant-upload-list {
+                  color: white;
+              }
+
+            }
           }
 
           .${prefixCls}-form-item {


### PR DESCRIPTION
Addressed the [issue](https://github.com/shesha-io/shesha-framework/issues/1533) where if a row is selected, the information texts become white, however when inline editing, the text remains white making it hard for user to see what they are editing