### PR TITLE
Changed the default value of the edit mode of a tab item to inherited

### DIFF
--- a/shesha-reactjs/src/designer-components/tabs/index.tsx
+++ b/shesha-reactjs/src/designer-components/tabs/index.tsx
@@ -107,8 +107,8 @@ const TabsComponent: IToolboxComponent<ITabsComponentProps> = {
     })
     .add<ITabsComponentProps>(1, (prev) => {
       const newModel = {...prev};
-      newModel.tabs = newModel.tabs.map(x => migrateReadOnly(x, 'editable'));
-      return newModel ;
+      newModel.tabs = newModel.tabs.map(x => migrateReadOnly(x, 'inherited'));
+      return newModel;
     })
   ,
   settingsFormFactory: (props) => <TabSettingsForm {...props} />,

--- a/shesha-reactjs/src/designer-components/tabs/settings.tsx
+++ b/shesha-reactjs/src/designer-components/tabs/settings.tsx
@@ -29,7 +29,7 @@ const TabSettings: FC<ISettingsFormFactoryArgs<ITabsComponentProps>> = (props) =
       name: `Tab${count + 1}`,
       key: id,
       title: `Tab ${count + 1}`,
-      editMode: 'editable',
+      editMode: 'inherited',
       selectMode: 'editable',
       components: [],
     };


### PR DESCRIPTION
This is connected to this issue:
https://github.com/shesha-io/shesha-framework/issues/1568