### PR TITLE
Alexs/fix

### DIFF
--- a/shesha-core/src/Shesha.Core/Migrations/M20240501141100.cs
+++ b/shesha-core/src/Shesha.Core/Migrations/M20240501141100.cs
@@ -9,18 +9,29 @@ namespace Shesha.Migrations
         public override void Up()
         {
             IfDatabase("SqlServer").Execute.Sql(@"
-with data as (
+with cte as (select 
+	id, name, row_number() over (partition by name order by id) as name_rank
+	from Core_ShaRoles),
+names as (select
+	id,
+	case
+		when name_rank = 1 then name
+		else concat(name, name_rank - 1) 
+	end as nameRank
+from cte
+),
+data as (
 	select 
-		Id, 
+		sr.Id, 
 		Description, 
-		(case when coalesce(Namespace, '') <> '' then CONCAT(Namespace, '.', Name) else Name end) as Name, 
+		(case when coalesce(Namespace, '') <> '' then CONCAT(Namespace, '.', nameRank) else nameRank end) as Name, 
 		1 as VersionNo, 
 		3 as VersionStatusLkp, 
 		(select id from Frwk_Modules where Name = 'Shesha') as ModuleId, 
-		'shesha-role' as ItemType, 
+		'role' as ItemType, 
 		1 as IsLast,
-		(case when coalesce(Namespace, '') <> '' then CONCAT(Namespace, '.', Name) else Name end) as Label,
-		Id as OriginId,
+		(case when coalesce(Namespace, '') <> '' then CONCAT(Namespace, '.', nameRank) else nameRank end) as Label,
+		sr.Id as OriginId,
 		CreationTime, 
 		CreatorUserId, 
 		LastModificationTime, 
@@ -28,8 +39,8 @@ with data as (
 		IsDeleted, 
 		DeletionTime, 
 		DeleterUserId
-	from 
-		Core_ShaRoles
+	from Core_ShaRoles sr
+	inner join names on names.id = sr.id
 )
 insert into Frwk_ConfigurationItems (Id, Description, Name, VersionNo, VersionStatusLkp, ModuleId, ItemType, IsLast, Label, OriginId,
 	CreationTime, CreatorUserId, LastModificationTime, LastModifierUserId, IsDeleted, DeletionTime, DeleterUserId)
@@ -85,6 +96,75 @@ GO
 ALTER TABLE [dbo].[Core_ShaRoles] CHECK CONSTRAINT [FK_Core_ShaRoles_Frwk_ConfigurationItems]
 GO
 ");
+
+            IfDatabase("PostgreSql").Execute.Sql(@"
+with ""cte"" as (select 
+""Id"", ""Name"", row_number() over (partition by ""Name"" order by ""Id"") as ""name_rank""
+from ""Core_ShaRoles""),
+""names"" as (
+select
+	""Id"",
+	case
+		when ""name_rank"" = 1 then ""Name""
+		else concat(""Name"", ""name_rank"" - 1) 
+	end as ""nameRank""
+from ""cte""
+),
+data as (
+	select 
+		sr.""Id"", 
+		""Description"", 
+		(case when coalesce(""NameSpace"", '') <> '' then CONCAT(""NameSpace"", '.', ""nameRank"") else ""nameRank"" end) as ""Name"", 
+		1 as ""VersionNo"", 
+		3 as ""VersionStatusLkp"", 
+		(select mm.""Id"" from ""Frwk_Modules"" mm where mm.""Name"" = 'Shesha') as ""ModuleId"",
+		'role' as ""ItemType"", 
+		true as ""IsLast"",
+		(case when coalesce(""NameSpace"", '') <> '' then CONCAT(""NameSpace"", '.', ""nameRank"") else ""nameRank"" end) as ""Label"",
+		sr.""Id"" as ""OriginId"",
+		""CreationTime"", 
+		""CreatorUserId"", 
+		""LastModificationTime"", 
+		""LastModifierUserId"", 
+		""IsDeleted"", 
+		""DeletionTime"", 
+		""DeleterUserId""
+	from ""Core_ShaRoles"" sr
+	inner join names on ""names"".""Id"" = sr.""Id""
+)
+insert into ""Frwk_ConfigurationItems"" 
+	(""Id"", ""Description"", ""Name"", ""VersionNo"", ""VersionStatusLkp"", ""ModuleId"", ""ItemType"", ""IsLast"", ""Label"", ""OriginId"",
+	""CreationTime"", ""CreatorUserId"", ""LastModificationTime"", ""LastModifierUserId"", ""IsDeleted"", ""DeletionTime"", ""DeleterUserId"")
+select ""Id"", ""Description"", ""Name"", ""VersionNo"", ""VersionStatusLkp"", ""ModuleId"", ""ItemType"", ""IsLast"", ""Label"", ""OriginId"",
+	""CreationTime"", ""CreatorUserId"", ""LastModificationTime"", ""LastModifierUserId"", ""IsDeleted"", ""DeletionTime"", ""DeleterUserId""
+from data
+where
+	not exists (select 1 from ""Frwk_ConfigurationItems"" ci where ci.""Name"" = data.""Name"" and ci.""ItemType"" = data.""ItemType"")
+	and not exists (select 1 from data rd where rd.""Name"" = data.""Name"" and data.""CreationTime"" < rd.""CreationTime"");
+
+DROP INDEX ""IX_Core_ShaRoles_CreatorUserId] ON [dbo].[Core_ShaRoles];
+DROP INDEX ""IX_Core_ShaRoles_DeleterUserId] ON [dbo].[Core_ShaRoles];
+DROP INDEX ""IX_Core_ShaRoles_LastModifierUserId] ON [dbo].[Core_ShaRoles];
+DROP INDEX ""IX_Core_ShaRoles_TenantId] ON [dbo].[Core_ShaRoles];
+
+ALTER TABLE ""Core_ShaRoles"" DROP CONSTRAINT ""FK_Core_ShaRoles_CreatorUserId_AbpUsers_Id"";
+ALTER TABLE ""Core_ShaRoles"" DROP CONSTRAINT ""FK_Core_ShaRoles_DeleterUserId_AbpUsers_Id"";
+ALTER TABLE ""Core_ShaRoles"" DROP CONSTRAINT ""FK_Core_ShaRoles_LastModifierUserId_AbpUsers_Id"";
+ALTER TABLE ""Core_ShaRoles"" DROP CONSTRAINT ""FK_Core_ShaRoles_TenantId_AbpTenants_Id"";
+
+alter table ""Core_ShaRoles"" drop column ""CreationTime"";
+alter table ""Core_ShaRoles"" drop column ""CreatorUserId"";
+alter table ""Core_ShaRoles"" drop column ""LastModificationTime"";
+alter table ""Core_ShaRoles"" drop column ""lastModifierUserId"";
+alter table ""Core_ShaRoles"" drop column ""IsDeleted"";
+alter table ""Core_ShaRoles"" drop column ""DeleterUserId"";
+alter table ""Core_ShaRoles"" drop column ""DeletionTime"";
+alter table ""Core_ShaRoles"" drop column ""TenantId"";
+
+ALTER TABLE ""Core_ShaRoles"" ADD CONSTRAINT ""FK_Core_ShaRoles_Frwk_ConfigurationItems"" FOREIGN KEY(""Id"")
+REFERENCES ""Frwk_ConfigurationItems"" (""Id"")
+");
+
         }
     }
 }

--- a/shesha-core/src/Shesha.Core/Migrations/M20240502101000.cs
+++ b/shesha-core/src/Shesha.Core/Migrations/M20240502101000.cs
@@ -18,6 +18,11 @@ go
 alter table Core_ShaRoles drop column Description;
 go
 ");
+
+            IfDatabase("PostgreSql").Execute.Sql(@"
+alter table ""Core_ShaRoles"" drop column ""Name"";
+alter table ""Core_ShaRoles"" drop column ""Description"";
+");
         }
     }
 }

--- a/shesha-core/src/Shesha.Core/Migrations/M20240506113900.cs
+++ b/shesha-core/src/Shesha.Core/Migrations/M20240506113900.cs
@@ -13,6 +13,8 @@ update ci set ItemType = 'role'
 from Frwk_ConfigurationItems ci
 where ItemType = 'shesha-role'
 ");
+
+            // not needed for Postgre
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/Migrations/M20240501134700.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/M20240501134700.cs
@@ -52,6 +52,33 @@ GO
 ALTER TABLE [dbo].[Frwk_PermissionDefinitions] CHECK CONSTRAINT [FK_Frwk_PermissionDefinitions_Frwk_ConfigurationItems]
 GO
 ");
+
+            IfDatabase("PostgreSql").Execute.Sql(@"
+insert into ""Frwk_ConfigurationItems"" (""Id"", ""Description"", ""Name"", ""VersionNo"", ""VersionStatusLkp"", ""ModuleId"",
+   ""ItemType"", ""IsLast"", ""Label"", ""OriginId"", ""CreationTime"", ""CreatorUserId"", ""LastModificationTime"", ""LastModifierUserId"",
+   ""IsDeleted"", ""DeletionTime"", ""DeleterUserId"")
+select ""Id"", ""Description"", ""Name"", 1, 3, (select ""Id"" from ""Frwk_Modules"" where ""Name"" = 'Shesha'), 'permission-definition',
+	true, ""DisplayName"", ""Id"", ""CreationTime"", ""CreatorUserId"", ""LastModificationTime"", ""LastModifierUserId"", ""IsDeleted"",
+	""DeletionTime"", ""DeleterUserId""
+from ""Frwk_PermissionDefinitions"";
+
+ALTER TABLE ""Frwk_PermissionDefinitions"" DROP CONSTRAINT ""FK_Frwk_PermissionDefinitions_CreatorUserId_AbpUsers_Id"";
+ALTER TABLE ""Frwk_PermissionDefinitions"" DROP CONSTRAINT ""FK_Frwk_PermissionDefinitions_DeleterUserId_AbpUsers_Id"";
+ALTER TABLE ""Frwk_PermissionDefinitions"" DROP CONSTRAINT ""FK_Frwk_PermissionDefinitions_LastModifierUserId_AbpUsers_Id"";
+ALTER TABLE ""Frwk_PermissionDefinitions"" DROP CONSTRAINT ""FK_Frwk_PermissionDefinitions_TenantId_AbpTenants_Id"";
+
+alter table ""Frwk_PermissionDefinitions"" drop column ""CreationTime"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""CreatorUserId"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""LastModificationTime"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""LastModifierUserId"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""IsDeleted"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""DeleterUserId"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""DeletionTime"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""TenantId"";
+
+ALTER TABLE ""Frwk_PermissionDefinitions"" ADD CONSTRAINT ""FK_Frwk_PermissionDefinitions_Frwk_ConfigurationItems"" FOREIGN KEY(""Id"")
+REFERENCES ""Frwk_ConfigurationItems"" (""Id"");
+");
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/Migrations/M20240502101400.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/M20240502101400.cs
@@ -16,6 +16,13 @@ go
 alter table Frwk_PermissionDefinitions drop column DisplayName;
 go
 ");
+
+            IfDatabase("PostgreSql").Execute.Sql(@"
+alter table ""Frwk_PermissionDefinitions"" drop column ""Name"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""Description"";
+alter table ""Frwk_PermissionDefinitions"" drop column ""DisplayName"";
+");
+
         }
     }
 }

--- a/shesha-reactjs/src/designer-components/text/typography.tsx
+++ b/shesha-reactjs/src/designer-components/text/typography.tsx
@@ -21,10 +21,10 @@ const TypographyComponent: FC<ITextTypographyProps> = ({
   const { formMode } = useForm();
   const { data: formData } = useFormData();
 
-  const val = typeof value === 'string' 
+  const val = typeof value === 'string'
     ? value 
     : isMoment(value)
-      ? value.format(dateFormat)
+      ? value.isValid() ? value.format(dateFormat) : ''
       : value?.toString();
 
   const contentEvaluation = evaluateString(val, formData);


### PR DESCRIPTION
Migrations fail on PostgreSql #1531
By default, a text component bound to a datetime property should display empty if the property is empty, instead of showing invalid #1617