### PR TITLE
Phumudzo/fix/965

### DIFF
--- a/shesha-reactjs/src/components/reactTable/index.tsx
+++ b/shesha-reactjs/src/components/reactTable/index.tsx
@@ -134,7 +134,7 @@ export const ReactTable: FC<IReactTableProps> = ({
         // The header can use the table's getToggleAllRowsSelectedProps method
         // to render a checkbox
         Header: ({ getToggleAllRowsSelectedProps: toggleProps, rows }) => (
-          <span className='Phumudzo' style={{ overflow: 'unset', textOverflow: 'unset' }}>
+          <span>
             <IndeterminateCheckbox {...toggleProps()} onChange={onChangeHeader(toggleProps().onChange, rows)} />
           </span>
         ),

--- a/shesha-reactjs/src/components/reactTable/index.tsx
+++ b/shesha-reactjs/src/components/reactTable/index.tsx
@@ -26,7 +26,7 @@ import { useDataTableStore } from '@/providers/index';
 import { useStyles, useMainStyles } from './styles/styles';
 import { IAnchoredColumnProps } from '@/providers/dataTable/interfaces';
 import { DataTableColumn } from '../dataTable/interfaces';
-import {EmptyState} from '..';
+import { EmptyState } from '..';
 
 interface IReactTableState {
   allRows: any[];
@@ -127,14 +127,14 @@ export const ReactTable: FC<IReactTableProps> = ({
         id: 'selection',
         //isVisible: true,
         disableResizing: true,
-        minWidth: 35,
-        width: 35,
-        maxWidth: 35,
+        minWidth: 37,
+        width: 37,
+        maxWidth: 37,
         disableSortBy: true,
         // The header can use the table's getToggleAllRowsSelectedProps method
         // to render a checkbox
         Header: ({ getToggleAllRowsSelectedProps: toggleProps, rows }) => (
-          <span>
+          <span className='Phumudzo' style={{ overflow: 'unset', textOverflow: 'unset' }}>
             <IndeterminateCheckbox {...toggleProps()} onChange={onChangeHeader(toggleProps().onChange, rows)} />
           </span>
         ),


### PR DESCRIPTION
Hi @IvanIlyichev . This PR is addressing [this issue](https://github.com/shesha-io/shesha-framework/issues/965). The header column with multi-select was having a dot at the far right "due" to text-overflow in "th,td" class. So I have increase the width of the select header to give it space to eliminate the need for ellipsis on it.