### PR TITLE
fix: View type reset on page reload

### DIFF
--- a/shesha-reactjs/src/hocs/withAuth.tsx
+++ b/shesha-reactjs/src/hocs/withAuth.tsx
@@ -1,19 +1,16 @@
 import React, { ComponentType, FC, Fragment, useEffect } from 'react';
+import { /*IdleTimerRenderer,*/ OverlayLoader } from '@/components';
 import { useAuth, useShaRouting } from '@/providers';
 import { useLoginUrl } from '@/hooks/useLoginUrl';
-import SheshaLoader from '@/components/sheshaLoader';
 
 export interface IComponentWithAuthProps {
   unauthorizedRedirectUrl: string;
   landingPage: string;
   children: (query: NodeJS.Dict<string | string[]>) => React.ReactElement;
 }
-
 export const ComponentWithAuth: FC<IComponentWithAuthProps> = (props) => {
   const { landingPage, unauthorizedRedirectUrl } = props;
-  const { isCheckingAuth, loginInfo, checkAuth, getAccessToken, isLoggedIn, isFetchingUserInfo, token } = useAuth();
-
-  const loading = isFetchingUserInfo || (!isFetchingUserInfo && !loginInfo && token) || !isLoggedIn;
+  const { isCheckingAuth, loginInfo, checkAuth, getAccessToken, isLoggedIn } = useAuth();
 
   const { goingToRoute, router } = useShaRouting();
 
@@ -31,10 +28,10 @@ export const ComponentWithAuth: FC<IComponentWithAuthProps> = (props) => {
     }
   }, [isCheckingAuth]);
 
-  return loading ? (
-    <SheshaLoader message='Initializing...' />
-  ) : (
+  return isLoggedIn ? (
     <Fragment>{props.children(router?.query)}</Fragment>
+  ) : (
+    <OverlayLoader loading={true} loadingText="Initializing..." />
   );
 };
 

--- a/shesha-reactjs/src/providers/auth/index.tsx
+++ b/shesha-reactjs/src/providers/auth/index.tsx
@@ -1,9 +1,10 @@
 import { useMutate } from '@/hooks';
 import useThunkReducer from '@/hooks/thunkReducer';
-import React, { FC, MutableRefObject, PropsWithChildren, useContext, useEffect } from 'react';
+import React, { FC, MutableRefObject, PropsWithChildren, useContext, useEffect, useMemo } from 'react';
 import { sessionGetCurrentLoginInfo } from '@/apis/session';
 import { AuthenticateModel, AuthenticateResultModelAjaxResponse } from '@/apis/tokenAuth';
 import { ResetPasswordVerifyOtpResponse } from '@/apis/user';
+import { OverlayLoader } from '@/components/overlayLoader';
 import { IAccessToken } from '@/interfaces';
 import { IHttpHeaders } from '@/interfaces/accessToken';
 import { IErrorInfo } from '@/interfaces/errorInfo';
@@ -362,11 +363,21 @@ const AuthProvider: FC<PropsWithChildren<IAuthProviderProps>> = ({
     dispatch(resetPasswordSuccessAction());
   };
 
+  const showLoader = useMemo(() => {
+    return !!(
+      (state.isFetchingUserInfo || (!state.isFetchingUserInfo && !state.loginInfo && state.token)) // Done fetching user info but the state is not yet updated
+    );
+  }, [state.isFetchingUserInfo, state.loginInfo, state.token]);
+
   //#endregion
 
   const getAccessToken = () => {
     return state.token;
   };
+
+  if (showLoader) {
+    return <OverlayLoader loading={true} loadingText="Initializing..." />;
+  }
 
   /* NEW_ACTION_DECLARATION_GOES_HERE */
 


### PR DESCRIPTION
Essentially undoes the red pill fix #1763 to allow the provider to have time to read the local storage  on time, which this PR https://github.com/shesha-io/shesha-framework/pull/1763 prevents

Related issues:
- https://github.com/shesha-io/shesha-framework/issues/1768
- https://github.com/shesha-io/shesha-framework/issues/1769