### PR TITLE
Thulasizwe/en/635: Key information bar adjustments

### DIFF
--- a/shesha-reactjs/src/components/keyInformationBar/index.tsx
+++ b/shesha-reactjs/src/components/keyInformationBar/index.tsx
@@ -5,49 +5,52 @@ import { Flex } from 'antd';
 import React, { FC } from 'react';
 import { useStyles } from './style';
 import { addPx } from './utils';
-
 export const KeyInformationBar: FC<IKeyInformationBarProps> = (props) => {
 
     const { data } = useFormData();
-    const { columns, hidden, orientation, style, dividerMargin, dividerHeight, dividerWidth, dividerColor, gap, stylingBox } = props;
+    const { columns, hidden, orientation, style, dividerMargin, dividerHeight, dividerWidth, dividerColor, gap, stylingBox, alignItems, backgroundColor } = props;
     const { styles } = useStyles();
 
     const width = addPx(dividerWidth);
     const height = addPx(dividerHeight);
     const margin = dividerMargin ? addPx(dividerMargin) : 0;
 
+
     if (hidden) return null;
 
     const stylingBoxJSON = JSON.parse(stylingBox || '{}');
     const vertical = orientation === "vertical";
     const computedStyle = { ...getStyle(style, data), ...pickStyleFromModel(stylingBoxJSON) };
+    const barStyle = !vertical ? { justifyContent: alignItems, backgroundColor } : { alignItems: alignItems, backgroundColor };
 
     const containerStyle = (item) => ({
         textAlign: item.textAlign,
         display: "flex",
         flexDirection: item.flexDirection ? item.flexDirection : "column",
         alignItems: item.textAlign,
-        maxWidth: `calc(${addPx(item.width)} - ${margin})`,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
     });
 
     const dividerStyle = {
         backgroundColor: dividerColor ?? '#b4b4b4',
-        width: !vertical ? '0.62px' : width,
-        height: vertical ? '0.62px' : height,
+        width: !vertical && width ? '0.62px' : width,
+        height: vertical && height ? '0.62px' : height,
         margin: vertical ? `${margin} 0` : `0 ${margin}`,
     };
 
     return (
-        <Flex vertical={vertical} className={styles.flexContainer} style={computedStyle} >
+        <Flex vertical={vertical} className={styles.flexContainer} style={{ ...computedStyle, ...barStyle }} >
             {columns?.map((item, i) => {
                 const itemWidth = vertical ? "100%" : addPx(item.width);
                 return (
-                    <div key={item.id} className={vertical ? styles.flexItemWrapperVertical : styles.flexItemWrapper} style={{ maxWidth: itemWidth }}>
+                    <div key={item.id} className={vertical ? styles.flexItemWrapperVertical : styles.flexItemWrapper} style={vertical ? { width: itemWidth, justifyContent: alignItems } : { maxWidth: itemWidth }}>
                         <div key={"divider" + i} className={styles.divider} style={{ ...dividerStyle, alignSelf: "center" }} />
-                        <div className={styles.content} style={{ textAlign: item.textAlign, width: itemWidth }}>
+                        <div className={styles.content} style={{ textAlign: item.textAlign, ...(vertical ? { width: itemWidth, justifyContent: alignItems } : { maxWidth: itemWidth }) }}>
                             <ComponentsContainer
                                 containerId={item.id}
                                 gap={gap}
+                                wrapperStyle={{ padding: item.padding, maxWidth: vertical ? '100%' : addPx(item.width), boxSizing: "border-box" }}
                                 style={containerStyle(item)}
                                 dynamicComponents={props?.isDynamic ? item?.components : []}
                             />

--- a/shesha-reactjs/src/components/keyInformationBar/index.tsx
+++ b/shesha-reactjs/src/components/keyInformationBar/index.tsx
@@ -8,7 +8,7 @@ import { addPx } from './utils';
 export const KeyInformationBar: FC<IKeyInformationBarProps> = (props) => {
 
     const { data } = useFormData();
-    const { columns, hidden, orientation, style, dividerMargin, dividerHeight, dividerWidth, dividerColor, gap, stylingBox, alignItems, backgroundColor } = props;
+    const { columns, hidden, orientation, style, dividerMargin, dividerHeight, dividerWidth, dividerThickness = '0.62px', dividerColor, gap, stylingBox, alignItems, backgroundColor } = props;
     const { styles } = useStyles();
 
     const width = addPx(dividerWidth);
@@ -32,10 +32,12 @@ export const KeyInformationBar: FC<IKeyInformationBarProps> = (props) => {
         textOverflow: "ellipsis",
     });
 
+    const divThickness = addPx(dividerThickness) !== '100%' ? addPx(dividerThickness) : '0.62px';
+
     const dividerStyle = {
         backgroundColor: dividerColor ?? '#b4b4b4',
-        width: !vertical && width ? '0.62px' : width,
-        height: vertical && height ? '0.62px' : height,
+        width: !vertical && width ? divThickness ?? '0.62px' : width,
+        height: vertical && height ? divThickness ?? '0.62px' : height,
         margin: vertical ? `${margin} 0` : `0 ${margin}`,
     };
 
@@ -46,7 +48,7 @@ export const KeyInformationBar: FC<IKeyInformationBarProps> = (props) => {
                 return (
                     <div key={item.id} className={vertical ? styles.flexItemWrapperVertical : styles.flexItemWrapper} style={vertical ? { width: itemWidth, justifyContent: alignItems } : { maxWidth: itemWidth }}>
                         <div key={"divider" + i} className={styles.divider} style={{ ...dividerStyle, alignSelf: "center" }} />
-                        <div className={styles.content} style={{ textAlign: item.textAlign, ...(vertical ? { width: itemWidth, justifyContent: alignItems } : { maxWidth: itemWidth }) }}>
+                        <div className={styles.content} style={{ justifyContent: item.textAlign }}>
                             <ComponentsContainer
                                 containerId={item.id}
                                 gap={gap}

--- a/shesha-reactjs/src/components/keyInformationBar/style.ts
+++ b/shesha-reactjs/src/components/keyInformationBar/style.ts
@@ -6,42 +6,66 @@ export const useStyles = createStyles(({ css, cx, token }) => {
     const flexItemWrapperVertical = "flex-item-wrapper-vertical";
     const divider = "divider";
     const content = "content";
-
     const flexContainer = cx("flex-container", css`
         background-color: ${token.colorTextLightSolid};
         flex-wrap: wrap;
-
+        
         .${flexItemWrapper}, .${flexItemWrapperVertical} {
             display: flex;
             min-width: 0px;
             box-sizing: border-box;
             flex: 1;
-            
+           
             .${content} {
-                width: 100%;
-                padding: 0;
-                overflow: hidden;
                 flex: 1;
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                overflow: hidden;
                 .ant-form-item-control-input {
                     min-height: 0;
-                }       
-
-                span {
-                    min-width: 15px;
-                    overflow: hidden;
                 }
 
+                * {
+                    max-width: 100%;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+
+                span, div {
+                    min-width: 15px;
+                    display: block;
+                    width: 100%;
+                }
+                
+                .ant-typography {
+                    margin: unset !important;
+                    padding: 0px !important;
+                    display: block !important;
+                    place-items: unset !important;
+                    grid: none !important;
+                }
+                    
+                &.ant-form-item-control-input-content, .ant-form-item-control-input {
+                    min-height: 0;
+                    width: 100%;
+                }
+
+                button {
+                    max-width: 100%;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
             }
         }
-
+    
         .${flexItemWrapper} {
             flex-direction: row;
         }
-
         .${flexItemWrapperVertical} {
             flex-direction: column;
         }
-
         .${divider}{
             max-height: 100%;
             max-width: 100%;
@@ -49,7 +73,6 @@ export const useStyles = createStyles(({ css, cx, token }) => {
             flex-grow: 0;
         }
     `);
-
     return {
         flexContainer,
         flexItem,

--- a/shesha-reactjs/src/components/keyInformationBar/style.ts
+++ b/shesha-reactjs/src/components/keyInformationBar/style.ts
@@ -22,6 +22,8 @@ export const useStyles = createStyles(({ css, cx, token }) => {
                 flex-direction: row;
                 align-items: center;
                 overflow: hidden;
+                width: 100%;
+                
                 .ant-form-item-control-input {
                     min-height: 0;
                 }
@@ -36,7 +38,6 @@ export const useStyles = createStyles(({ css, cx, token }) => {
                 span, div {
                     min-width: 15px;
                     display: block;
-                    width: 100%;
                 }
                 
                 .ant-typography {
@@ -49,7 +50,7 @@ export const useStyles = createStyles(({ css, cx, token }) => {
                     
                 &.ant-form-item-control-input-content, .ant-form-item-control-input {
                     min-height: 0;
-                    width: 100%;
+                    max-width: 100%;
                 }
 
                 button {

--- a/shesha-reactjs/src/components/keyInformationBar/utils.ts
+++ b/shesha-reactjs/src/components/keyInformationBar/utils.ts
@@ -1,6 +1,6 @@
 
 export const addPx = (value) => {
-    value = value ?? "100%";
+    value = value == null || value === '' || value === undefined ? "100%" : value;
     return /^\d+(\.\d+)?$/.test(value) ? `${value}px` : value;
 };
 

--- a/shesha-reactjs/src/components/keyInformationBar/utils.ts
+++ b/shesha-reactjs/src/components/keyInformationBar/utils.ts
@@ -1,6 +1,6 @@
 
 export const addPx = (value) => {
-    value = value == null || value === '' || value === undefined ? "100%" : value;
+    value = (value == null || value === '' || value === undefined) ? "100%" : value;
     return /^\d+(\.\d+)?$/.test(value) ? `${value}px` : value;
 };
 

--- a/shesha-reactjs/src/designer-components/keyInformationBar/columnsList.tsx
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/columnsList.tsx
@@ -62,7 +62,7 @@ const EditableCell = ({ title, editable, children, dataIndex, record, handleSave
     </Tooltip>
   );
 
-  const textAlignValues = ['start', 'end', 'center', 'left', 'right', "justify", 'initial', 'inherit'];
+  const textAlignValues = ['start', 'end', 'center', 'inherit'];
   const flexDirectionValues = ['row', 'column', 'row-reverse', 'column-reverse'];
 
   const Dropdown = (ref, values) =>
@@ -163,6 +163,7 @@ export const ColumnsList: FC<IProps> = ({ value, onChange, readOnly }) => {
       textAlign: 'center',
       flexDirection: "column",
       components: [],
+      padding: '0px',
     };
     const newColumns = [...columns, newColumn];
     onChange(newColumns);
@@ -204,6 +205,12 @@ export const ColumnsList: FC<IProps> = ({ value, onChange, readOnly }) => {
     {
       title: 'Flex Direction',
       dataIndex: 'flexDirection',
+      editable: !readOnly,
+      width: '20%',
+    },
+    {
+      title: 'Padding',
+      dataIndex: 'padding',
       editable: !readOnly,
       width: '20%',
     },

--- a/shesha-reactjs/src/designer-components/keyInformationBar/index.tsx
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/index.tsx
@@ -38,8 +38,9 @@ const ColumnsComponent: IToolboxComponent<IKeyInformationBarProps> = {
           id: nanoid(),
           width: 200,
           textAlign: 'center',
-          flexDirection: "column",
+          flexDirection: 'column',
           components: [],
+          padding: '0px',
         }
       ],
       orientation: 'horizontal',

--- a/shesha-reactjs/src/designer-components/keyInformationBar/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/interfaces.ts
@@ -5,8 +5,9 @@ export interface KeyInfomationBarItemProps {
   id: string;
   width: number;
   flexDirection?: 'row' | 'column';
-  textAlign: 'left' | 'center' | 'right' | 'justify' | 'initial' | 'inherit' | 'start' | 'end';
+  textAlign?: 'center' | 'inherit' | 'start' | 'end';
   components: IConfigurableFormComponent[];
+  padding?: string;
 }
 
 export interface IKeyInformationBarProps extends IConfigurableFormComponent {
@@ -23,4 +24,5 @@ export interface IKeyInformationBarProps extends IConfigurableFormComponent {
   readOnly?: boolean;
   style?: string;
   stylingBox?: any;
+  backgroundColor?: string;
 }

--- a/shesha-reactjs/src/designer-components/keyInformationBar/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/interfaces.ts
@@ -17,6 +17,7 @@ export interface IKeyInformationBarProps extends IConfigurableFormComponent {
   dividerWidth?: string;
   dividerMargin?: number;
   dividerColor?: string;
+  dividerThickness?: string;
   gap?: number;
   alignItems?: AlignItems;
   orientation?: 'horizontal' | 'vertical';

--- a/shesha-reactjs/src/designer-components/keyInformationBar/settings.tsx
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/settings.tsx
@@ -35,8 +35,20 @@ const KeyInformationBarSettings: FC<ISettingsFormFactoryArgs<IKeyInformationBarP
                 </Select>
             </SettingsFormItem>
 
+            <SettingsFormItem name="backgroundColor" label="Background Color" jsSetting >
+                <ColorPicker readOnly={readOnly} allowClear />
+            </SettingsFormItem>
+
             <SettingsFormItem name="columns" label="Columns">
                 <ColumnsList readOnly={readOnly} />
+            </SettingsFormItem>
+
+            <SettingsFormItem name="alignItems" label="Align Items">
+                <Select >
+                    <Option value="flex-start">Flex Start</Option>
+                    <Option value="flex-end">Flex End</Option>
+                    <Option value="center">Center</Option>
+                </Select>
             </SettingsFormItem>
 
             <SectionSeparator title="Divider" />
@@ -57,7 +69,7 @@ const KeyInformationBarSettings: FC<ISettingsFormFactoryArgs<IKeyInformationBarP
                 </SettingsFormItem>
             </Show>
             <SettingsFormItem name="dividerColor" label="Divider Color" jsSetting >
-                <ColorPicker readOnly={readOnly} />
+                <ColorPicker readOnly={readOnly} allowClear />
             </SettingsFormItem>
             <SectionSeparator title="Style" />
 

--- a/shesha-reactjs/src/designer-components/keyInformationBar/settings.tsx
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/settings.tsx
@@ -43,13 +43,15 @@ const KeyInformationBarSettings: FC<ISettingsFormFactoryArgs<IKeyInformationBarP
                 <ColumnsList readOnly={readOnly} />
             </SettingsFormItem>
 
-            <SettingsFormItem name="alignItems" label="Align Items">
-                <Select >
-                    <Option value="flex-start">Flex Start</Option>
-                    <Option value="flex-end">Flex End</Option>
-                    <Option value="center">Center</Option>
-                </Select>
-            </SettingsFormItem>
+            <Show when={values.orientation === "horizontal"}>
+                <SettingsFormItem name="alignItems" label="Align Items">
+                    <Select >
+                        <Option value="flex-start">Flex Start</Option>
+                        <Option value="flex-end">Flex End</Option>
+                        <Option value="center">Center</Option>
+                    </Select>
+                </SettingsFormItem>
+            </Show>
 
             <SectionSeparator title="Divider" />
 
@@ -68,6 +70,11 @@ const KeyInformationBarSettings: FC<ISettingsFormFactoryArgs<IKeyInformationBarP
                     <Input readOnly={readOnly} />
                 </SettingsFormItem>
             </Show>
+
+            <SettingsFormItem name="dividerThickness" label="Divider Thickness" jsSetting tooltip={tooltip}>
+                <Input readOnly={readOnly} />
+            </SettingsFormItem>
+
             <SettingsFormItem name="dividerColor" label="Divider Color" jsSetting >
                 <ColorPicker readOnly={readOnly} allowClear />
             </SettingsFormItem>


### PR DESCRIPTION
I added the ability to  adjust the padding inside the column, revert to default height when the height property is empty/removed, alignment of the columns, by default the alignment of the columns are left aligned and leaves a huge space on the right. Can we have a flexibility to align the columns? If columns properties are used, it leaves a grey space
[issue](https://github.com/shesha-io/shesha-framework/issues/635#issuecomment-2210855613)