### PR TITLE
Thulasizwe/en/1741: Section separator - clean up

### DIFF
--- a/shesha-reactjs/src/components/sectionSeparator/index.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/index.tsx
@@ -3,6 +3,7 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import { ConfigProvider, Divider, Space, Tooltip } from 'antd';
 import Show from '@/components/show';
 import { useStyles } from './styles/styles';
+import { addPx } from './utils';
 
 export interface ISectionSeparatorProps {
   id?: string;
@@ -42,6 +43,8 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
 }) => {
   const { styles } = useStyles();
 
+  const vertical = orientation === 'vertical';
+
   const borderStyle = {
     '--border-thickness': `${lineThickness || 2}px`,
     '--border-style': dashed ? 'dashed' : 'solid',
@@ -78,9 +81,9 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
     );
   };
 
-  const commonStyle = { ...containerStyle, minWidth: "100px", width: `${lineWidth}px` };
+  const commonStyle = { ...containerStyle, minWidth: "100px", width: lineWidth ? addPx(lineWidth) : '100%' };
 
-  if (inline || orientation === 'vertical') {
+  if (inline || vertical) {
     return (
       <div style={commonStyle}>
         <ConfigProvider
@@ -89,7 +92,7 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
               colorSplit: lineColor || styles.primaryColor,
               colorText: fontColor || '#000',
               lineWidth: lineThickness || 2,
-              fontSize: lineHeight || fontSize,
+              fontSize: addPx(lineHeight) || addPx(fontSize),
               margin: 8
             },
           }}
@@ -99,6 +102,7 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
             orientation={labelAlign || 'left'}
             orientationMargin={noMargin ? '0' : null}
             dashed={dashed}
+            style={vertical ? { top: 0 } : {}}
           >
             {titleComponent()}
           </Divider>

--- a/shesha-reactjs/src/components/sectionSeparator/index.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/index.tsx
@@ -53,19 +53,31 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
     marginBottom: '8px',
   } as CSSProperties;
 
+
   const renderTitle = () => {
 
     const titleStyles = {
       ...titleStyle,
-      fontSize: fontSize,
-      ...(fontColor && { color: fontColor }),
+      fontSize: fontSize || 14,
+      color: fontColor || '#000',
     };
 
-    return <Title labelAlign={labelAlign} title={title} tooltip={tooltip} classes={styles} titleStyles={{ ...titleStyles, }} inline={inline} titleMargin={titleMargin} />;
+    return <Title
+      labelAlign={labelAlign}
+      title={title}
+      tooltip={tooltip}
+      classes={styles}
+      titleStyles={{ ...titleStyles, }}
+      titleMargin={titleMargin} />;
   };
 
   const defaultWidth = vertical ? 'max-content' : '100%';
-  const commonStyle = { ...containerStyle, width: lineWidth && !vertical ? addPx(lineWidth) : defaultWidth, margin: vertical ? 8 : '8px 0px' };
+  const commonStyle = {
+    ...containerStyle,
+    width: lineWidth && !vertical ? addPx(lineWidth)
+      : defaultWidth, margin: vertical ? 8 : '8px 0px'
+  };
+
   const dividerMargin = Number((titleMargin / 100).toFixed(2));
 
   if (inline || vertical) {
@@ -78,8 +90,9 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
                 colorSplit: lineColor || styles.primaryColor,
                 colorText: fontColor || '#000',
                 lineWidth: lineThickness || 2,
-                fontSize: addPx(lineHeight) || addPx(fontSize),
-                orientationMargin: dividerMargin || 0.05
+                fontSize: addPx(lineHeight) || addPx(fontSize) || 14,
+                orientationMargin: dividerMargin || 0.05,
+                margin: 8,
               },
             },
           }}

--- a/shesha-reactjs/src/components/sectionSeparator/index.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/index.tsx
@@ -81,7 +81,7 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
     );
   };
 
-  const commonStyle = { ...containerStyle, minWidth: "100px", width: lineWidth ? addPx(lineWidth) : '100%' };
+  const commonStyle = { ...containerStyle, minWidth: "100px", width: lineWidth ? addPx(lineWidth) : '100%', margin: 8 };
 
   if (inline || vertical) {
     return (
@@ -93,7 +93,6 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
               colorText: fontColor || '#000',
               lineWidth: lineThickness || 2,
               fontSize: addPx(lineHeight) || addPx(fontSize),
-              margin: 8
             },
           }}
         >

--- a/shesha-reactjs/src/components/sectionSeparator/index.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/index.tsx
@@ -66,7 +66,6 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
       labelAlign={labelAlign}
       title={title}
       tooltip={tooltip}
-      classes={styles}
       titleStyles={{ ...titleStyles, }}
       titleMargin={titleMargin} />;
   };

--- a/shesha-reactjs/src/components/sectionSeparator/index.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/index.tsx
@@ -1,9 +1,8 @@
 import React, { CSSProperties, FC, ReactNode } from 'react';
-import { QuestionCircleOutlined } from '@ant-design/icons';
-import { ConfigProvider, Divider, Space, Tooltip } from 'antd';
-import Show from '@/components/show';
+import { ConfigProvider, Divider } from 'antd';
 import { useStyles } from './styles/styles';
 import { addPx } from './utils';
+import Title from './title';
 
 export interface ISectionSeparatorProps {
   id?: string;
@@ -17,14 +16,15 @@ export interface ISectionSeparatorProps {
   dashed?: boolean;
   lineColor?: string;
   lineThickness?: number;
-  lineWidth?: number;
-  lineHeight?: number;
-  noMargin?: boolean;
+  lineWidth?: string;
+  lineHeight?: string;
+  titleMargin?: number;
   labelAlign?: 'left' | 'center' | 'right';
   orientation?: 'horizontal' | 'vertical';
 }
 
 export const SectionSeparator: FC<ISectionSeparatorProps> = ({
+  id,
   labelAlign,
   fontSize,
   fontColor,
@@ -39,7 +39,7 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
   titleStyle,
   tooltip,
   title,
-  noMargin
+  titleMargin
 }) => {
   const { styles } = useStyles();
 
@@ -50,11 +50,10 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
     '--border-style': dashed ? 'dashed' : 'solid',
     '--border-color': lineColor || styles.primaryColor,
     textAlign: `${labelAlign || 'left'}`,
-    marginBottom: '8px'
+    marginBottom: '8px',
   } as CSSProperties;
 
-  const titleComponent = () => {
-    if (!title) return null;
+  const renderTitle = () => {
 
     const titleStyles = {
       ...titleStyle,
@@ -62,48 +61,37 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
       ...(fontColor && { color: fontColor }),
     };
 
-    return (
-      <span style={{
-        ...titleStyles
-      }}>
-        <Space size="small" style={{
-          flexWrap: "nowrap",
-        }}>
-
-          {title}
-          <Show when={Boolean(tooltip?.trim())}>
-            <Tooltip title={tooltip}>
-              <QuestionCircleOutlined className={`tooltip-question-icon ${styles.helpIcon}`} />
-            </Tooltip>
-          </Show>
-        </Space>
-      </span>
-    );
+    return <Title labelAlign={labelAlign} title={title} tooltip={tooltip} classes={styles} titleStyles={{ ...titleStyles, }} inline={inline} titleMargin={titleMargin} />;
   };
 
-  const commonStyle = { ...containerStyle, minWidth: "100px", width: lineWidth ? addPx(lineWidth) : '100%', margin: 8 };
+  const defaultWidth = vertical ? 'max-content' : '100%';
+  const commonStyle = { ...containerStyle, width: lineWidth && !vertical ? addPx(lineWidth) : defaultWidth, margin: vertical ? 8 : '8px 0px' };
+  const dividerMargin = Number((titleMargin / 100).toFixed(2));
 
   if (inline || vertical) {
     return (
-      <div style={commonStyle}>
+      <div style={commonStyle} key={id}>
         <ConfigProvider
           theme={{
-            token: {
-              colorSplit: lineColor || styles.primaryColor,
-              colorText: fontColor || '#000',
-              lineWidth: lineThickness || 2,
-              fontSize: addPx(lineHeight) || addPx(fontSize),
+            components: {
+              Divider: {
+                colorSplit: lineColor || styles.primaryColor,
+                colorText: fontColor || '#000',
+                lineWidth: lineThickness || 2,
+                fontSize: addPx(lineHeight) || addPx(fontSize),
+                orientationMargin: dividerMargin || 0.05
+              },
             },
           }}
         >
           <Divider
             type={orientation}
             orientation={labelAlign || 'left'}
-            orientationMargin={noMargin ? '0' : null}
             dashed={dashed}
             style={vertical ? { top: 0 } : {}}
+            orientationMargin={titleMargin === 0 ? '0' : null}
           >
-            {titleComponent()}
+            {renderTitle()}
           </Divider>
         </ConfigProvider>
       </div>
@@ -111,9 +99,9 @@ export const SectionSeparator: FC<ISectionSeparatorProps> = ({
   }
 
   return (
-    <div style={commonStyle}>
+    <div style={commonStyle} key={id}>
       <div className={styles.shaSectionSeparator} style={borderStyle}>
-        {titleComponent()}
+        {renderTitle()}
       </div>
     </div>
   );

--- a/shesha-reactjs/src/components/sectionSeparator/styles/styles.ts
+++ b/shesha-reactjs/src/components/sectionSeparator/styles/styles.ts
@@ -1,5 +1,5 @@
-import { createStyles } from '@/styles';
-import { sheshaStyles } from '@/styles';
+import { createStyles, sheshaStyles } from '@/styles';
+
 
 export const useStyles = createStyles(({ css, cx, token }) => {
     const primaryColor = token.colorPrimary;
@@ -10,7 +10,7 @@ export const useStyles = createStyles(({ css, cx, token }) => {
 
         .${helpIcon} {
             fontSize: 14;
-            color: #aaa;
+            color: #aaa !important;
             margin: auto;
         };
 

--- a/shesha-reactjs/src/components/sectionSeparator/styles/styles.ts
+++ b/shesha-reactjs/src/components/sectionSeparator/styles/styles.ts
@@ -4,15 +4,10 @@ import { createStyles, sheshaStyles } from '@/styles';
 export const useStyles = createStyles(({ css, cx, token }) => {
     const primaryColor = token.colorPrimary;
     const helpIcon = "help-icon-question-circle";
+    const titleContainer = 'title-container';
     const shaSectionSeparator = cx("sha-section-separator", css`
         font-weight: 500;
         height: ${sheshaStyles.pageHeadingHeight}px;
-
-        .${helpIcon} {
-            fontSize: 14;
-            color: #aaa !important;
-            margin: auto;
-        };
 
         ::after {
             content: '';
@@ -20,9 +15,15 @@ export const useStyles = createStyles(({ css, cx, token }) => {
             display: block;
             border-bottom: var(--border-thickness) var(--border-style) var(--border-color);
             };
+
+        .${titleContainer} {
+            display: flex;
+            vertical-align: middle;
+            width: 100%
+        }
     `);
 
     return {
-        shaSectionSeparator, primaryColor, helpIcon
+        shaSectionSeparator, primaryColor, helpIcon, titleContainer
     };
 });

--- a/shesha-reactjs/src/components/sectionSeparator/styles/styles.ts
+++ b/shesha-reactjs/src/components/sectionSeparator/styles/styles.ts
@@ -17,9 +17,9 @@ export const useStyles = createStyles(({ css, cx, token }) => {
             };
 
         .${titleContainer} {
-            display: flex;
-            vertical-align: middle;
-            width: 100%
+            flexWrap: nowrap;
+            alignItems: center;
+            width: 100%;
         }
     `);
 

--- a/shesha-reactjs/src/components/sectionSeparator/title.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/title.tsx
@@ -2,36 +2,37 @@ import React, { CSSProperties, ReactNode, useRef } from 'react';
 import { Tooltip } from 'antd';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import Show from '../show';
+import { useStyles } from './styles/styles';
 
 interface TitleProps {
     title: string | ReactNode;
     tooltip?: string;
-    classes?: any;
     titleStyles?: CSSProperties;
     titleMargin?: number;
     labelAlign?: 'left' | 'center' | 'right';
-    color?: string;
 }
 
 const Title: React.FC<TitleProps> = ({
     title,
     tooltip,
-    classes,
     titleStyles,
     labelAlign,
     titleMargin
 }) => {
 
     const titleRef = useRef<HTMLDivElement>(null);
+    const { styles } = useStyles();
 
     if (!title) return null;
 
     const marginWidth = `${titleMargin || 0}%`;
 
     return (
-        <div className={classes.titleContainer} style={{ justifyContent: labelAlign, flexWrap: 'nowrap' }} ref={titleRef}>
+        <div className={styles.titleContainer} style={{
+            justifyContent: labelAlign, display: 'flex'
+        }} ref={titleRef}>
             <div style={{ width: labelAlign === 'left' ? marginWidth : 0 }} ></div>
-            <span style={{ ...titleStyles, whiteSpace: 'nowrap', paddingRight: '8px' }}>{title}</span>
+            <span style={{ ...titleStyles, whiteSpace: 'nowrap', paddingRight: '8px', }}>{title}</span>
             <Show when={Boolean(tooltip?.trim())}>
                 <Tooltip title={tooltip}>
                     <QuestionCircleOutlined

--- a/shesha-reactjs/src/components/sectionSeparator/title.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/title.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactNode, useRef } from 'react';
-import { Space, Tooltip } from 'antd';
+import { Tooltip } from 'antd';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import Show from '../show';
 
@@ -8,9 +8,9 @@ interface TitleProps {
     tooltip?: string;
     classes?: any;
     titleStyles?: CSSProperties;
-    inline?: boolean;
     titleMargin?: number;
     labelAlign?: 'left' | 'center' | 'right';
+    color?: string;
 }
 
 const Title: React.FC<TitleProps> = ({
@@ -18,36 +18,30 @@ const Title: React.FC<TitleProps> = ({
     tooltip,
     classes,
     titleStyles,
-    inline,
     labelAlign,
-    titleMargin,
+    titleMargin
 }) => {
 
-    const titleRef = useRef<HTMLSpanElement>(null);
+    const titleRef = useRef<HTMLDivElement>(null);
 
     if (!title) return null;
 
-    const getMarginStyle = () => {
-        if (inline || labelAlign === 'center') return null;
-
-        return labelAlign === 'left'
-            ? { marginLeft: `calc(${titleMargin || 0}%)` }
-            : { marginRight: `calc(${titleMargin || 0}%)` };
-    };
+    const marginWidth = `${titleMargin || 0}%`;
 
     return (
-        <span style={{ ...titleStyles, ...getMarginStyle() }} ref={titleRef}>
-            <Space size="small" style={{ flexWrap: 'nowrap' }}>
-                <span >{title}</span>
-                <Show when={Boolean(tooltip?.trim())}>
-                    <Tooltip title={tooltip}>
-                        <QuestionCircleOutlined
-                            className={`tooltip-question-icon ${classes.helpIcon}`}
-                        />
-                    </Tooltip>
-                </Show>
-            </Space>
-        </span>
+        <div className={classes.titleContainer} style={{ justifyContent: labelAlign, flexWrap: 'nowrap' }} ref={titleRef}>
+            <div style={{ width: labelAlign === 'left' ? marginWidth : 0 }} ></div>
+            <span style={{ ...titleStyles, whiteSpace: 'nowrap', paddingRight: '8px' }}>{title}</span>
+            <Show when={Boolean(tooltip?.trim())}>
+                <Tooltip title={tooltip}>
+                    <QuestionCircleOutlined
+                        className={`tooltip-question-icon`}
+                        style={{ color: '#aaa' }}
+                    />
+                </Tooltip>
+            </Show>
+            <div style={{ width: labelAlign === 'right' ? marginWidth : 0 }} ></div>
+        </div>
     );
 };
 

--- a/shesha-reactjs/src/components/sectionSeparator/title.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/title.tsx
@@ -25,19 +25,19 @@ const Title: React.FC<TitleProps> = ({
 
     if (!title) return null;
 
-    const marginWidth = `${titleMargin || 0}%`;
+    const marginWidth = `calc(${titleMargin || 0}% - ${((titleRef.current?.clientWidth + 14) / 2) || 0}px)`; // 14 is the width of the question mark icon
 
     return (
         <div className={styles.titleContainer} style={{
             justifyContent: labelAlign, display: 'flex'
-        }} ref={titleRef}>
+        }}>
             <div style={{ width: labelAlign === 'left' ? marginWidth : 0 }} ></div>
-            <span style={{ ...titleStyles, whiteSpace: 'nowrap', paddingRight: '8px', }}>{title}</span>
+            <span ref={titleRef} style={{ ...titleStyles, whiteSpace: 'nowrap' }}>{title}</span>
             <Show when={Boolean(tooltip?.trim())}>
                 <Tooltip title={tooltip}>
                     <QuestionCircleOutlined
                         className={`tooltip-question-icon`}
-                        style={{ color: '#aaa' }}
+                        style={{ color: '#aaa', marginLeft: '8px' }}
                     />
                 </Tooltip>
             </Show>

--- a/shesha-reactjs/src/components/sectionSeparator/title.tsx
+++ b/shesha-reactjs/src/components/sectionSeparator/title.tsx
@@ -1,0 +1,54 @@
+import React, { CSSProperties, ReactNode, useRef } from 'react';
+import { Space, Tooltip } from 'antd';
+import { QuestionCircleOutlined } from '@ant-design/icons';
+import Show from '../show';
+
+interface TitleProps {
+    title: string | ReactNode;
+    tooltip?: string;
+    classes?: any;
+    titleStyles?: CSSProperties;
+    inline?: boolean;
+    titleMargin?: number;
+    labelAlign?: 'left' | 'center' | 'right';
+}
+
+const Title: React.FC<TitleProps> = ({
+    title,
+    tooltip,
+    classes,
+    titleStyles,
+    inline,
+    labelAlign,
+    titleMargin,
+}) => {
+
+    const titleRef = useRef<HTMLSpanElement>(null);
+
+    if (!title) return null;
+
+    const getMarginStyle = () => {
+        if (inline || labelAlign === 'center') return null;
+
+        return labelAlign === 'left'
+            ? { marginLeft: `calc(${titleMargin || 0}%)` }
+            : { marginRight: `calc(${titleMargin || 0}%)` };
+    };
+
+    return (
+        <span style={{ ...titleStyles, ...getMarginStyle() }} ref={titleRef}>
+            <Space size="small" style={{ flexWrap: 'nowrap' }}>
+                <span >{title}</span>
+                <Show when={Boolean(tooltip?.trim())}>
+                    <Tooltip title={tooltip}>
+                        <QuestionCircleOutlined
+                            className={`tooltip-question-icon ${classes.helpIcon}`}
+                        />
+                    </Tooltip>
+                </Show>
+            </Space>
+        </span>
+    );
+};
+
+export default Title;

--- a/shesha-reactjs/src/components/sectionSeparator/utils.ts
+++ b/shesha-reactjs/src/components/sectionSeparator/utils.ts
@@ -1,0 +1,9 @@
+
+export const addPx = (value) => {
+    value = value ?? "100%";
+    return /^\d+(\.\d+)?$/.test(value) ? `${value}px` : value;
+};
+
+export const strings = {
+    tooltip: 'You can use any unit (%, px, em, etc). px by default if without unit',
+};

--- a/shesha-reactjs/src/designer-components/sectionSeprator/index.tsx
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/index.tsx
@@ -37,7 +37,7 @@ const SectionSeparatorComponent: IToolboxComponent<ISectionSeparatorComponentPro
       label: 'Section',
       lineThickness: 2,
       labelAlign: "left",
-      
+      orientation: "horizontal",
     };
   },
   migrator: (m) => m

--- a/shesha-reactjs/src/designer-components/sectionSeprator/index.tsx
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/index.tsx
@@ -43,6 +43,7 @@ const SectionSeparatorComponent: IToolboxComponent<ISectionSeparatorComponentPro
     .add<ISectionSeparatorComponentProps>(0, (prev) => migratePropertyName(migrateCustomFunctions(prev)))
     .add<ISectionSeparatorComponentProps>(1, (prev) => ({ ...migrateFormApi.properties(prev) }))
     .add<ISectionSeparatorComponentProps>(2, (prev) => ({ ...prev, labelAlign: "left" }))
+    .add<ISectionSeparatorComponentProps>(3, (prev) => ({ ...prev, titleMargin: prev['noMargin'] ? 0 : null }))
   ,
 };
 

--- a/shesha-reactjs/src/designer-components/sectionSeprator/index.tsx
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/index.tsx
@@ -36,7 +36,8 @@ const SectionSeparatorComponent: IToolboxComponent<ISectionSeparatorComponentPro
       ...model,
       label: 'Section',
       lineThickness: 2,
-      labelAlign: "left"
+      labelAlign: "left",
+      
     };
   },
   migrator: (m) => m

--- a/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
@@ -132,6 +132,7 @@ export const getSettings = (data: any) =>
                 id: "b920ef96-ae27-4a01-bfad-b5b7d07218da"
               }
             ],
+            defaultValue: "horizontal",
             dataSourceType: "values"
           })
           .addCheckbox({
@@ -153,7 +154,6 @@ export const getSettings = (data: any) =>
             description: "Line Thickness in pixels (px)",
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Line Thickness",
-            defaultValue: 2,
           })
           .addTextField({
             id: "3b8bv360-f47e-48ae-b4c3-f5cc36f934a9",

--- a/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
@@ -1,3 +1,4 @@
+import { strings } from '@/components/sectionSeparator/utils';
 import { DesignerToolbarSettings } from '@/interfaces/toolbarSettings';
 
 export const getSettings = (data: any) =>
@@ -33,17 +34,29 @@ export const getSettings = (data: any) =>
             parentId: 'root',
             label: 'Hidden',
           })
+          .addNumberField({
+            id: "3b8b9e3f-f10c-48ae-b4c3-f5cc36f934m5",
+            propertyName: "titleMargin",
+            parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
+            description: "Distance between text and edge, which should be a number between 0 and 100",
+            label: "Title Margin",
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
+            min: 0,
+            max: 100,
+          })
           .addTextField({
             id: '46d07439-4c18-468c-89e1-60c002ce96c5',
             propertyName: 'label',
             parentId: 'root',
             label: 'Label',
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
           })
           .addCheckbox({
             id: '3b8b9e3f-M5f90-48ae-b4c3-f5cc36f934d9',
             propertyName: 'hideLabel',
             parentId: 'root',
             label: 'Hide Label',
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
           })
           .addDropdown({
             id: "57a40a33-7e08-4ce4-9f08-a34d24a83338",
@@ -68,7 +81,8 @@ export const getSettings = (data: any) =>
               }
             ],
             dataSourceType: "values",
-            defaultValue: "left"
+            defaultValue: "left",
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
           })
           .addColorPicker({
             id: "3b8b9e3f-f47e-48ae-b4c3-f5cc36f934d9",
@@ -76,6 +90,7 @@ export const getSettings = (data: any) =>
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Font Color",
             allowClear: true,
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
           })
           .addNumberField({
             id: "3b8b9e3f-f47e-48ae-b4c3-f5cc36f934a9",
@@ -83,25 +98,22 @@ export const getSettings = (data: any) =>
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Font Size",
             defaultValue: 14,
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
+
           })
           .addCheckbox({
             id: "3b8b9e3f-f47e-48ae-b4c3-f5cc36f934m5",
             propertyName: "inline",
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
-            label: "Inline"
-          })
-          .addCheckbox({
-            id: "3b8b9e3f-f10c-48ae-b4c3-f5cc36f934m5",
-            propertyName: "noMargin",
-            parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
-            label: "No Margin",
-            hidden: { _code: 'return !getSettingValue(data?.inline);', _mode: 'code', _value: true } as any,
+            label: "Inline",
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
           })
           .addTextArea({
             id: '2d32fe70-99a0-4825-ae6c-8b933004e119',
             propertyName: 'description',
             parentId: 'root',
             label: 'Description',
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
           })
           .addDropdown({
             id: "57a40a33-7e08-4ce4-9f08-a34d00783338",
@@ -138,6 +150,7 @@ export const getSettings = (data: any) =>
           .addNumberField({
             id: "3b8b9e3f-f47e-48ae-b4c3-f90c36f934d9",
             propertyName: "lineThickness",
+            description: "Line Thickness in pixels (px)",
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Line Thickness",
             defaultValue: 2,
@@ -147,12 +160,14 @@ export const getSettings = (data: any) =>
             propertyName: "lineWidth",
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Line Width",
+            description: `${strings.tooltip}. This is only applicable when the orientation is horizontal`,
             hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
             defaultValue: '100%',
           })
           .addTextField({
             id: "3b8bv360-f47e-48ae-b4c3-f5coMp6f934a9",
             propertyName: "lineHeight",
+            description: `${strings.tooltip}. This is only applicable when the orientation is vertical`,
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Line Height",
             hidden: { _code: 'return getSettingValue(data?.orientation) === "horizontal";', _mode: 'code', _value: true } as any,
@@ -211,6 +226,7 @@ export const getSettings = (data: any) =>
               'A script that returns the style of the element as an object. This should conform to CSSProperties',
             exposedVariables: [{ name: 'data', description: 'Form values', type: 'object' }],
             wrapInTemplate: true,
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
             templateSettings: {
               functionName: 'getTitleStyle',
             },

--- a/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
@@ -97,7 +97,7 @@ export const getSettings = (data: any) =>
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             description: "Distance between text and edge, which should be a number between 0 and 100",
             label: "Title Margin",
-            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical" || getSettingValue(data?.labelAlign) === "center";', _mode: 'code', _value: true } as any,
             min: 0,
             max: 100,
           })

--- a/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
@@ -147,7 +147,7 @@ export const getSettings = (data: any) =>
             propertyName: "lineWidth",
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Line Width",
-            hidden: { _code: 'return getSettingValue(data?.orientation) !== "vertical;', _mode: 'code', _value: true } as any,
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
             defaultValue: '100%',
           })
           .addTextField({
@@ -155,7 +155,7 @@ export const getSettings = (data: any) =>
             propertyName: "lineHeight",
             parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
             label: "Line Height",
-            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical;', _mode: 'code', _value: true } as any,
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "horizontal";', _mode: 'code', _value: true } as any,
           })
           .toJson(),
       },

--- a/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/settings.ts
@@ -34,16 +34,6 @@ export const getSettings = (data: any) =>
             parentId: 'root',
             label: 'Hidden',
           })
-          .addNumberField({
-            id: "3b8b9e3f-f10c-48ae-b4c3-f5cc36f934m5",
-            propertyName: "titleMargin",
-            parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
-            description: "Distance between text and edge, which should be a number between 0 and 100",
-            label: "Title Margin",
-            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
-            min: 0,
-            max: 100,
-          })
           .addTextField({
             id: '46d07439-4c18-468c-89e1-60c002ce96c5',
             propertyName: 'label',
@@ -100,6 +90,16 @@ export const getSettings = (data: any) =>
             defaultValue: 14,
             hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
 
+          })
+          .addNumberField({
+            id: "3b8b9e3f-f10c-48ae-b4c3-f5cc36f934m5",
+            propertyName: "titleMargin",
+            parentId: "1BCC52E8-FD3B-4309-AD9B-099CDB729441",
+            description: "Distance between text and edge, which should be a number between 0 and 100",
+            label: "Title Margin",
+            hidden: { _code: 'return getSettingValue(data?.orientation) === "vertical";', _mode: 'code', _value: true } as any,
+            min: 0,
+            max: 100,
           })
           .addCheckbox({
             id: "3b8b9e3f-f47e-48ae-b4c3-f5cc36f934m5",


### PR DESCRIPTION
- Refining the title margin
-  Keeping the hint icon consistent (in size and color)
- Hidding non-applicable configs 
- Added migration to replace noMargin property with titleMargin