### PR TITLE
query builder: replaced reflist widget with the one not linked to for…

### DIFF
--- a/shesha-reactjs/src/components/queryBuilder/widgets/refListDropDown/index.tsx
+++ b/shesha-reactjs/src/components/queryBuilder/widgets/refListDropDown/index.tsx
@@ -1,7 +1,7 @@
 import { BaseWidget, BasicConfig, SelectFieldSettings } from '@react-awesome-query-builder/antd';
 import { CustomFieldSettings } from '@/providers/queryBuilder/models';
 import React from 'react';
-import { Dropdown } from '@/components/dropdown/dropdown';
+import { RefListSimpleDropdown } from './simpleDropdown';
 
 export type RefListDropdownWidgetType = BaseWidget & SelectFieldSettings;
 const RefListDropdownWidget: RefListDropdownWidgetType = {
@@ -9,7 +9,7 @@ const RefListDropdownWidget: RefListDropdownWidgetType = {
   jsType: 'number',
   type: 'refList',
   factory: props => {
-    const { fieldDefinition, value, setValue } = props;
+    const { fieldDefinition, value, setValue, readonly } = props;
     const customSettings = fieldDefinition.fieldSettings as CustomFieldSettings;
 
     const onChange = v => {
@@ -17,13 +17,13 @@ const RefListDropdownWidget: RefListDropdownWidgetType = {
     };
 
     return (
-      <Dropdown
-        dataSourceType='referenceList'
-        referenceListId={{ module: customSettings.referenceListModule, name: customSettings.referenceListName }}
-        value={value}
+      <RefListSimpleDropdown
         onChange={onChange}
+        referenceListId={{ module: customSettings.referenceListModule, name: customSettings.referenceListName }}
         style={{ minWidth: '150px' }}
         size="small"
+        value={value}
+        readOnly={readonly}
       />
     );
   },

--- a/shesha-reactjs/src/components/queryBuilder/widgets/refListDropDown/simpleDropdown.tsx
+++ b/shesha-reactjs/src/components/queryBuilder/widgets/refListDropDown/simpleDropdown.tsx
@@ -1,0 +1,60 @@
+import { ReferenceListItemDto } from '@/apis/referenceList';
+import GenericRefListDropDown from '@/components/refListDropDown/genericRefListDropDown';
+import { IGenericRefListDropDownProps, IncomeValueFunc, ISelectOption, OutcomeValueFunc } from '@/components/refListDropDown/models';
+import React, { FC, useCallback } from 'react';
+
+export type IRefListSimpleDropdownProps = Pick<IGenericRefListDropDownProps, 'onChange' | 'referenceListId' | 'style' | 'size' | 'value' | 'readOnly'>;
+
+export const RefListSimpleDropdown: FC<IRefListSimpleDropdownProps> = (props) => {
+    const { value, onChange, referenceListId, style, size, readOnly } = props;
+
+    const incomeValueFunc: IncomeValueFunc = useCallback((value: any, _args?: any) => {
+        return value;
+    }, []);
+
+    const outcomeValueFunc: OutcomeValueFunc = useCallback((value: ReferenceListItemDto, _args?: any) => {
+        return !!value ? value.itemValue : null;
+    }, []);
+
+    const getLabeledValue = useCallback((value: any, options: ISelectOption<any>[]) => {
+        if (value === undefined) 
+            return undefined;
+        const itemValue = incomeValueFunc(value, {});
+        const item = options?.find(i => i.value === itemValue);
+        return {
+            // fix for designer when switch mode
+            value: typeof itemValue === 'object' ? null : itemValue,
+            label: item?.label ?? 'unknown',
+            data: item?.data,
+        };
+    }, [incomeValueFunc]);
+
+    const getOptionFromFetchedItem = useCallback((fetchedItem: ReferenceListItemDto, args?: any): ISelectOption<any> => {
+        const label = fetchedItem.item;
+
+        const value = incomeValueFunc(outcomeValueFunc(fetchedItem, args), {});
+
+        return {
+            // fix for designer when switch mode
+            value: typeof value === 'object' ? null : value,
+            label,
+            data: outcomeValueFunc(fetchedItem, args),
+        };
+    }, [outcomeValueFunc, incomeValueFunc]);    
+
+    return (
+        <GenericRefListDropDown<any>
+            value={value}
+            onChange={onChange}
+            referenceListId={referenceListId}
+            style={style}
+            size={size}
+            readOnly={readOnly}
+
+            getLabeledValue={getLabeledValue}
+            getOptionFromFetchedItem={getOptionFromFetchedItem}
+            incomeValueFunc={incomeValueFunc}
+            outcomeValueFunc={outcomeValueFunc}
+        />
+    );
+};


### PR DESCRIPTION
…ms functionality