### PR TITLE
modelTypeExpression fix

### DIFF
--- a/shesha-reactjs/src/designer-components/propertyAutocomplete/index.tsx
+++ b/shesha-reactjs/src/designer-components/propertyAutocomplete/index.tsx
@@ -24,8 +24,13 @@ export const PropertyAutocompleteComponent: IToolboxComponent<IPropertyAutocompl
     const { data: formData } = useFormData();
     const { modelType: modelTypeExpression } = model;
 
-    const modelType = modelTypeExpression ? evaluateString(modelTypeExpression, { data: formData }) : null;
+    let modelType = modelTypeExpression ? evaluateString(modelTypeExpression, { data: formData }) : null;
 
+
+    if (typeof formData?.entityTypeShortAlias == 'object' && formData.entityTypeShortAlias.hasOwnProperty('_code')) {
+
+      modelType = new Function('data', formData?.entityTypeShortAlias?._code)({ data: formData });
+    }
     return (
       <ConditionalWrap
         condition={Boolean(modelType)}

--- a/shesha-reactjs/src/designer-components/queryBuilder/queryBuilderWithModelType.tsx
+++ b/shesha-reactjs/src/designer-components/queryBuilder/queryBuilderWithModelType.tsx
@@ -11,7 +11,14 @@ export interface IQueryBuilderWithModelType {
 export const QueryBuilderWithModelType: FC<PropsWithChildren<IQueryBuilderWithModelType>> = (props) => {
   const { formData } = useForm();
   const { modelType: modelTypeExpression } = props;
-  const modelType = evaluateString(modelTypeExpression, { data: formData });
+
+  let modelType = modelTypeExpression ? evaluateString(modelTypeExpression, { data: formData }) : null;
+
+
+  if (typeof formData?.entityTypeShortAlias == 'object' && formData.entityTypeShortAlias.hasOwnProperty('_code')) {
+
+    modelType = new Function('data', formData?.entityTypeShortAlias?._code)({ data: formData });
+  }
 
   return (
     <ConditionalWrap


### PR DESCRIPTION
Hi @IvanIlyichev . I am tasked with this [issue](https://github.com/shesha-io/shesha-framework/issues/1390). After days of debugging I found that the 'modelType' when entityType is on 'js-mode' is always undefined resulting in no results on Display Property this is also the case for queryBuilder. My assumption for this bug is that the entityType for 'js-mode' is being saved as an object {_code:'......',} which make sense since the value must be dynamic. Given my pushed code can you please guide on how I can best achieve the task requirements. Here is the quick link to reproduce the [bug](https://function-adminportal-test.shesha.dev/shesha/forms-designer?id=5dd998ca-5b36-441f-9f5b-113df4ae29b7).