### PR TITLE
Properties associated with previous action persist when switching con…

### DIFF
--- a/shesha-reactjs/src/designer-components/_settings/settingsForm.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/settingsForm.tsx
@@ -3,7 +3,7 @@ import { Form } from "antd";
 import { DEFAULT_FORM_LAYOUT_SETTINGS, ISettingsFormFactoryArgs } from "@/interfaces";
 import { getValuesFromSettings, updateSettingsFromVlues } from './utils';
 import { createNamedContext } from '@/utils/react';
-import { merge } from 'lodash';
+import { mergeWith } from 'lodash';
 
 interface SettingsFormState<TModel> {
     model?: TModel;
@@ -54,7 +54,11 @@ const SettingsForm = <TModel,>(props: PropsWithChildren<SettingsFormProps<TModel
     };
     
     const settingsChange = (changedValues) => {
-      const incomingState = merge({...state.model}, changedValues);
+      const incomingState = mergeWith(
+        {...state.model},
+        changedValues,
+        (objValue, srcValue) => (Array.isArray(objValue) ? srcValue : undefined),
+      );
       setState({model: incomingState, values: getValuesFromSettings(incomingState)});
       onValuesChange(changedValues, incomingState);
       form.setFieldsValue(incomingState);

--- a/shesha-reactjs/src/designer-components/configurableActionsConfigurator/actionArgumensEditor.tsx
+++ b/shesha-reactjs/src/designer-components/configurableActionsConfigurator/actionArgumensEditor.tsx
@@ -85,7 +85,7 @@ export const ActionArgumentsEditor: FC<IActionArgumentsEditorProps> = ({
   if (!argumentsEditor) return null;
 
   return (
-    <Collapse defaultActiveKey={['1']}>
+    <Collapse defaultActiveKey={['1']} key={action.name}>
       <Panel header="Arguments" key="1">
         {argumentsEditor}
       </Panel>


### PR DESCRIPTION
…figurations #1933

DataTable and ButtonGroup configurations require manual refresh to display #1912
Deleting sub-configurations of certain components fails #1931