### PR TITLE
Clicking on js button on property configurations toggles between the modes

### DIFF
--- a/shesha-reactjs/src/components/autocomplete/entityAutocomplete.tsx
+++ b/shesha-reactjs/src/components/autocomplete/entityAutocomplete.tsx
@@ -25,7 +25,6 @@ export const EntityAutocomplete = <TValue,>(props: IEntityAutocompleteProps<TVal
     //allowInherited,
     onChange,
     disabled,
-    bordered = true,
     style,
     size,
     mode,
@@ -190,8 +189,8 @@ export const EntityAutocomplete = <TValue,>(props: IEntityAutocompleteProps<TVal
 
   return (
     <Select<CustomLabeledValue<TValue> | CustomLabeledValue<TValue>[]>
-      className="sha-dropdown"
-      dropdownStyle={{...style, height: 'auto'}}
+      // className="sha-dropdown"
+      dropdownStyle={{ ...style, height: 'auto' }}
       showSearch={!disableSearch}
       labelInValue={true}
       notFoundContent={notFoundContent}
@@ -207,19 +206,19 @@ export const EntityAutocomplete = <TValue,>(props: IEntityAutocompleteProps<TVal
       loading={loading}
       placeholder={selectPlaceholder}
       disabled={disabled}
-      variant={!bordered ? 'borderless' : undefined}
       onSelect={handleSelect}
       style={style}
-      size={size}
+      variant='outlined'
       ref={selectRef}
+      size={size}
       mode={value && mode === 'multiple' ? mode : undefined} // When mode is multiple and value is null, the control shows an empty tag
     >
       {options?.map(({ value: localValue, label, data }) => (
-      
-       <Select.Option value={localValue} key={localValue} data={data}>
+
+        <Select.Option value={localValue} key={localValue} data={data}>
           {label}
         </Select.Option>
-        
+
       ))}
     </Select>
   );

--- a/shesha-reactjs/src/components/autocomplete/models.tsx
+++ b/shesha-reactjs/src/components/autocomplete/models.tsx
@@ -108,7 +108,7 @@ export interface ICommonAutocompleteProps<TValue = any> extends IReadOnly {
 
 export interface IAutocompleteProps<TValue = any>
   extends IEntityAutocompleteProps<TValue>,
-    IUrlAutocompleteProps<TValue> {
+  IUrlAutocompleteProps<TValue> {
   /**
    * Data source of this Autocomplete
    */

--- a/shesha-reactjs/src/designer-components/_settings/settingsFormItem.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/settingsFormItem.tsx
@@ -123,7 +123,7 @@ const SettingsFormItem: FC<ISettingsFormItemProps> = (props) => {
     }, [settingsPanel, props.name]);
 
     const { propertyFilter } = useSettingsForm<any>();
-    return !Boolean(propertyFilter) || typeof propertyFilter === 'function' && propertyFilter(props.name?.toString())
+    return !propertyFilter || typeof propertyFilter === 'function' && propertyFilter(props.name?.toString())
         ? <SettingsFormComponent {...props} />
         : null;
 };

--- a/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
+++ b/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
@@ -75,7 +75,7 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
           },
           {
             match: 'pageContext',
-            data: {...pageContext?.getFull()} ?? {},
+            data: { ...pageContext?.getFull() } ?? {},
           },
         ],
         propertyMetadataAccessor
@@ -112,10 +112,10 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
       useRawValues
         ? item[value]
         : {
-            id: item[value],
-            _displayName: item[displayText],
-            _className: model.entityTypeShortAlias,
-          };
+          id: item[value],
+          _displayName: item[displayText],
+          _className: model.entityTypeShortAlias,
+        };
 
     const getOptionFromFetchedItem = (item: object): ISelectOption => {
       const { dataSourceType, keyPropName, useRawValues, valuePropName } = model;
@@ -169,23 +169,20 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
 
     const styling = JSON.parse(model.stylingBox || '{}');
     const stylingBoxAsCSS = pickStyleFromModel(styling);
-  
+
     const additionalStyles: CSSProperties = removeUndefinedProps({
       height: toSizeCssProp(model.height),
       width: toSizeCssProp(model.width),
       fontWeight: model.fontWeight,
-      borderWidth: model.hideBorder ? '0px' : model.borderSize, //this is handled in the entityAutcomplete.tsx
-      borderRadius: model.borderRadius,
-      borderStyle: model.hideBorder ? 'none' : model.borderType,
-      borderColor: model.borderColor,
-      backgroundColor: model.backgroundColor,
+      border: model.borderSize === 0 ? null : `${toSizeCssProp(model.borderSize) || '1px'} ${model.borderType || 'solid'} ${model.borderColor || '#d9d9d9'}`,
+      backgroundColor: model.backgroundColor || 'white',
       fontSize: model.fontSize,
-      overflow: 'hidden', //this allows us to retain the borderRadius even when the component is active
+      borderRadius: model.borderRadius || '8px',
       ...stylingBoxAsCSS,
     });
     const jsStyle = getStyle(model.style, data);
-    const finalStyle = removeUndefinedProps({...jsStyle, ...additionalStyles});
-    
+    const finalStyle = removeUndefinedProps({ ...jsStyle, ...additionalStyles });
+
     const defaultValue = getDefaultValue();
 
     const autocompleteProps: IAutocompleteProps = {
@@ -193,7 +190,6 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
       typeShortAlias: model.entityTypeShortAlias,
       entityDisplayProperty: model.entityDisplayProperty,
       allowInherited: true /*hardcoded for now*/,
-      bordered: !model.hideBorder,
       dataSourceUrl,
       dataSourceType: model.dataSourceType,
       mode: model.mode,
@@ -223,20 +219,20 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
     return (
       <ConfigurableFormItem {...formProps}>
         {(value, onChange) => {
-          const customEvent =  customDropDownEventHandler(eventProps);
+          const customEvent = customDropDownEventHandler(eventProps);
           const onChangeInternal = (...args: any[]) => {
             customEvent.onChange(args[0], args[1]);
-            if (typeof onChange === 'function') 
+            if (typeof onChange === 'function')
               onChange(...args);
           };
-         
-          
+
+
           return (
-          model.useRawValues ? (
-            <Autocomplete.Raw {...autocompleteProps} {...customEvent} value={value} onChange={onChangeInternal}/>
-          ) : (
-            <Autocomplete.EntityDto {...autocompleteProps} {...customEvent} value={value} onChange={onChangeInternal}/>
-          ));
+            model.useRawValues ? (
+              <Autocomplete.Raw {...autocompleteProps} {...customEvent} value={value} onChange={onChangeInternal} />
+            ) : (
+              <Autocomplete.EntityDto {...autocompleteProps} {...customEvent} value={value} onChange={onChangeInternal} />
+            ));
         }}
       </ConfigurableFormItem>
     );

--- a/shesha-reactjs/src/designer-components/autocomplete/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/autocomplete/interfaces.ts
@@ -41,4 +41,5 @@ export interface IAutocompleteComponentProps extends IConfigurableFormComponent 
   stylingBox?: string;
   height?: string | number;
   backgroundColor?: string;
+  variant?: 'borderless' | 'outlined' | 'filled';
 }

--- a/shesha-reactjs/src/designer-components/autocomplete/settingsForm.json
+++ b/shesha-reactjs/src/designer-components/autocomplete/settingsForm.json
@@ -756,28 +756,13 @@
             "textType": "text"
           },
           {
-            "id": "7e4876d8-1ed4-4576-9f5b-46cfd77d8643",
-            "type": "checkbox",
-            "propertyName": "hideBorder",
-            "label": "Hide border",
-            "parentId": "y9SNudmMM0Wd1Sc_YI1ng",
-            "hidden": false,
-            "validate": {},
-            "version": 2
-          },
-          {
             "id": "295d003b-d261-4f5e-8de2-2a278f303c18",
             "type": "numberField",
             "propertyName": "borderSize",
             "label": "Border Width",
             "parentId": "pnlfdd49-41aa-41d6-a29e-76fa00590b75",
             "description": "To see your changes, check 'Hide Border'.",
-            "version": 3,
-            "hidden": {
-              "_code": "return getSettingValue(data?.hideBorder) == true;",
-              "_mode": "code",
-              "_value": false
-            }
+            "version": 3
           },
           {
             "id": "89accb3c-29a6-4636-a186-42916c9b10cc",
@@ -795,11 +780,6 @@
             "parentId": "pnlfdd49-41aa-41d6-a29e-76fa00590b75",
             "label": "Border Type",
             "dataSourceType": "values",
-            "hidden": {
-              "_code": "return getSettingValue(data?.hideBorder) == true;",
-              "_mode": "code",
-              "_value": false
-            },
             "values": [
               {
                 "label": "Solid",
@@ -836,12 +816,7 @@
             "title": "",
             "fontSize": "",
             "allowClear": true,
-            "showText": true,
-            "hidden": {
-              "_code": "return getSettingValue(data?.hideBorder) == true;",
-              "_mode": "code",
-              "_value": false
-            }
+            "showText": true
           },
           {
             "id": "edb5da32-d1c5-4167-bb05-37c89475601a",
@@ -868,8 +843,7 @@
             "validate": {},
             "settingsValidationErrors": [],
             "jsSetting": false
-            }
-          
+          }
         ]
       },
       "collapsible": "header",

--- a/shesha-reactjs/src/designer-components/keyInformationBar/settings.tsx
+++ b/shesha-reactjs/src/designer-components/keyInformationBar/settings.tsx
@@ -1,6 +1,5 @@
 import { CodeEditor } from '../codeEditor/codeEditor';
 import React, { FC } from 'react';
-import SectionSeparator from '@/components/sectionSeparator';
 import SettingsForm, { useSettingsForm } from '@/designer-components/_settings/settingsForm';
 import SettingsFormItem from '@/designer-components/_settings/settingsFormItem';
 import StyleBox from '../styleBox/components/box';
@@ -8,98 +7,108 @@ import { Checkbox, Input, InputNumber, Select } from 'antd';
 import { ISettingsFormFactoryArgs } from '@/interfaces';
 import ColumnsList from './columnsList';
 import { IKeyInformationBarProps } from './interfaces';
-import { ColorPicker, Show } from '@/components';
 import { strings } from '@/components/keyInformationBar/utils';
 import SettingsCollapsiblePanel from '../_settings/settingsCollapsiblePanel';
 import PermissionAutocomplete from '@/components/permissionAutocomplete';
+import { ContextPropertyAutocomplete } from '../contextPropertyAutocomplete';
+import { useFormDesignerState } from '@/providers/formDesigner';
+import { useForm } from '@/providers';
+import { ColorPicker } from '@/components';
 
 const KeyInformationBarSettings: FC<ISettingsFormFactoryArgs<IKeyInformationBarProps>> = (props) => {
     const { readOnly } = props;
     const { Option } = Select;
-    const { values } = useSettingsForm<IKeyInformationBarProps>();
+    const { values, model, onValuesChange } = useSettingsForm<IKeyInformationBarProps>();
 
+    const designerModelType = useFormDesignerState(false)?.formSettings?.modelType;
+    const { formSettings } = useForm();
     const tooltip = strings.tooltip;
+
+    const isVertical = values.orientation === "vertical";
 
     return (
         <>
-            <SettingsFormItem name="componentName" label="Component Name" required>
-                <Input readOnly={readOnly} />
-            </SettingsFormItem>
+            <SettingsCollapsiblePanel header="Display">
+                <ContextPropertyAutocomplete
+                    id="415cc8ec-2fd1-4c5a-88e2-965153e16069"
+                    readOnly={readOnly}
+                    defaultModelType={designerModelType ?? formSettings.modelType}
+                    formData={model}
+                    onValuesChange={onValuesChange}
+                />
 
-            <SettingsFormItem name="hidden" label="Hidden" valuePropName="checked" jsSetting>
-                <Checkbox disabled={readOnly} />
-            </SettingsFormItem>
+                <SettingsFormItem name="componentName" label="Component Name" required jsSetting>
+                    <Input readOnly={readOnly} />
+                </SettingsFormItem>
 
-            <SettingsFormItem name="orientation" label="Orientation">
-                <Select >
-                    <Option value="horizontal">Horizontal</Option>
-                    <Option value="vertical">Vertical</Option>
-                </Select>
-            </SettingsFormItem>
+                <SettingsFormItem name="hidden" label="Hidden" valuePropName="checked" jsSetting>
+                    <Checkbox disabled={readOnly} />
+                </SettingsFormItem>
 
-            <SettingsFormItem name="backgroundColor" label="Background Color" jsSetting >
-                <ColorPicker readOnly={readOnly} allowClear />
-            </SettingsFormItem>
+                <SettingsFormItem name="orientation" label="Orientation" jsSetting>
+                    <Select >
+                        <Option value="horizontal">Horizontal</Option>
+                        <Option value="vertical">Vertical</Option>
+                    </Select>
+                </SettingsFormItem>
 
-            <SettingsFormItem name="columns" label="Columns">
-                <ColumnsList readOnly={readOnly} />
-            </SettingsFormItem>
+                <SettingsFormItem name="backgroundColor" label="Background Color" jsSetting >
+                    <ColorPicker readOnly={readOnly} allowClear />
+                </SettingsFormItem>
 
-            <Show when={values.orientation === "horizontal"}>
-                <SettingsFormItem name="alignItems" label="Align Items">
+                <SettingsFormItem name="columns" label="Columns">
+                    <ColumnsList readOnly={readOnly} />
+                </SettingsFormItem>
+
+                <SettingsFormItem name="alignItems" label="Align Items" jsSetting hidden={isVertical}>
                     <Select >
                         <Option value="flex-start">Flex Start</Option>
                         <Option value="flex-end">Flex End</Option>
                         <Option value="center">Center</Option>
                     </Select>
                 </SettingsFormItem>
-            </Show>
 
-            <SectionSeparator title="Divider" />
-
-            <SettingsFormItem name="dividerMargin" label="Divider Margin" jsSetting tooltip={tooltip}>
-                <Input readOnly={readOnly} />
-            </SettingsFormItem>
-
-            <Show when={values.orientation === "horizontal"}>
-                <SettingsFormItem name="dividerHeight" label="Divider Height" jsSetting tooltip={tooltip}>
+                <SettingsFormItem name="dividerMargin" label="Divider Margin" jsSetting>
                     <Input readOnly={readOnly} />
                 </SettingsFormItem>
-            </Show>
 
-            <Show when={values.orientation === "vertical"}>
-                <SettingsFormItem name="dividerWidth" label="Divider Width" jsSetting tooltip={tooltip}>
+
+                <SettingsFormItem name="dividerHeight" label="Divider Height" jsSetting tooltip={tooltip} hidden={isVertical}>
                     <Input readOnly={readOnly} />
                 </SettingsFormItem>
-            </Show>
 
-            <SettingsFormItem name="dividerThickness" label="Divider Thickness" jsSetting tooltip={tooltip}>
-                <Input readOnly={readOnly} />
-            </SettingsFormItem>
+                <SettingsFormItem name="dividerWidth" label="Divider Width" jsSetting tooltip={tooltip} hidden={!isVertical}>
+                    <Input readOnly={readOnly} />
+                </SettingsFormItem>
 
-            <SettingsFormItem name="dividerColor" label="Divider Color" jsSetting >
-                <ColorPicker readOnly={readOnly} allowClear />
-            </SettingsFormItem>
-            <SectionSeparator title="Style" />
+                <SettingsFormItem name="dividerThickness" label="Divider Thickness" jsSetting tooltip={tooltip}>
+                    <Input readOnly={readOnly} />
+                </SettingsFormItem>
 
-            <SettingsFormItem name="style" label="Style">
-                <CodeEditor
-                    propertyName="style"
-                    readOnly={readOnly}
-                    mode="dialog"
-                    label="Style"
-                    description="A script that returns the style of the element as an object. This should conform to CSSProperties"
-                />
-            </SettingsFormItem>
+                <SettingsFormItem name="dividerColor" label="Divider Color" jsSetting >
+                    <ColorPicker readOnly={readOnly} allowClear />
+                </SettingsFormItem>
+            </SettingsCollapsiblePanel>
 
-            <SettingsFormItem name="gap" label="Gap" jsSetting>
-                <InputNumber readOnly={readOnly} />
-            </SettingsFormItem>
+            <SettingsCollapsiblePanel header="Style">
+                <SettingsFormItem name="style" label="Style">
+                    <CodeEditor
+                        propertyName="style"
+                        readOnly={readOnly}
+                        mode="dialog"
+                        label="Style"
+                        description="A script that returns the style of the element as an object. This should conform to CSSProperties"
+                    />
+                </SettingsFormItem>
 
+                <SettingsFormItem name="gap" label="Gap" jsSetting>
+                    <InputNumber readOnly={readOnly} />
+                </SettingsFormItem>
 
-            <SettingsFormItem name="stylingBox">
-                <StyleBox />
-            </SettingsFormItem>
+                <SettingsFormItem name="stylingBox">
+                    <StyleBox />
+                </SettingsFormItem>
+            </SettingsCollapsiblePanel>
 
             <SettingsCollapsiblePanel header="Security">
                 <SettingsFormItem


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/shesha-io/shesha-framework/issues/1957) when you click on the JS in any property on the key information bar component, it will not allow you to revert to the value property configurations. (in all the properties except the Hidden property).