### PR TITLE
fix: Check if the permission is not already created 

### DIFF
--- a/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
@@ -74,8 +74,11 @@ namespace Shesha.Authorization
             if (permission.Id != Guid.Empty)
             {
                 newPermission = GetPermissionOrNull(permission.Name);
-                if (newPermission != null)
+                var dbPermission = _permissionDefinitionRepository.Get(permission.Id);
+                if (newPermission != null && dbPermission.Name == permission.Name)
+                {
                     return Task.FromResult(newPermission);
+                }
             }
 
             if (!string.IsNullOrEmpty(permission.Parent))

--- a/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
@@ -70,6 +70,14 @@ namespace Shesha.Authorization
         private Task<Abp.Authorization.Permission> _CreatePermissionAsync(PermissionDefinition permission)
         {
             Abp.Authorization.Permission newPermission = null;
+            // Check if the permission is not already created, in which case if it is just return it
+            if (permission.Id != Guid.Empty)
+            {
+                newPermission = GetPermissionOrNull(permission.Name);
+                if (newPermission != null)
+                    return Task.FromResult(newPermission);
+            }
+
             if (!string.IsNullOrEmpty(permission.Parent))
             {
                 // add new permission to parent

--- a/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
@@ -75,7 +75,7 @@ namespace Shesha.Authorization
             {
                 newPermission = GetPermissionOrNull(permission.Name);
                 var dbPermission = _permissionDefinitionRepository.Get(permission.Id);
-                if (newPermission != null && dbPermission.Name == permission.Name)
+                if (newPermission != null && dbPermission.Name.Equals(permission.Name))
                 {
                     return Task.FromResult(newPermission);
                 }


### PR DESCRIPTION
When we export configured permission(s) and then try to import them, either including them when we export forms or just exporting the configured permissions alone, the backend tries to do the operation twice which ends up breaking the first build. 

This change will make sure that if a valid permission of that name already exist, it does not get created twice.