### PR TITLE
DynamicSettingDefinitionProvider: skip settings not linked to modules

### DIFF
--- a/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/Settings/SettingsDbHelper.cs
+++ b/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/Settings/SettingsDbHelper.cs
@@ -225,6 +225,7 @@ where
             {
                 command.AddParameter("@settingId", settingId);
                 command.AddParameter("@appId", appId);
+                command.AddParameter("@userId", userId);
             });
         }
 

--- a/shesha-core/src/Shesha.Framework/Settings/Attributes/SettingAttribute.cs
+++ b/shesha-core/src/Shesha.Framework/Settings/Attributes/SettingAttribute.cs
@@ -12,6 +12,19 @@ namespace Shesha.Settings
         public bool IsClientSpecific { get; set; }
         public string EditorFormName { get; set; }
         public bool IsUserSpecific { get; set; }
+
+        public SettingAttribute(string name) : this(name, false, null, false) 
+        { 
+        }
+
+        public SettingAttribute(string name, bool isClientSpecific) : this(name, isClientSpecific, null, false) 
+        {
+        }
+
+        public SettingAttribute(string name, bool isClientSpecific, string editorFormName) : this(name, isClientSpecific, editorFormName, false)
+        { 
+        }
+
         public SettingAttribute(string name, bool isClientSpecific = false, string editorFormName = null, bool isUserSpecific = false)
         {
             Name = name;

--- a/shesha-core/src/Shesha.Framework/Settings/DynamicSettingDefinitionProvider.cs
+++ b/shesha-core/src/Shesha.Framework/Settings/DynamicSettingDefinitionProvider.cs
@@ -1,20 +1,8 @@
-﻿using Abp.Configuration;
-using Abp.Dependency;
+﻿using Abp.Dependency;
 using Abp.Domain.Repositories;
-using Newtonsoft.Json.Linq;
-using Shesha.Attributes;
-using Shesha.ConfigurationItems;
-using Shesha.ConfigurationItems.Specifications;
 using Shesha.Domain;
-using Shesha.Extensions;
-using Shesha.Modules;
-using Shesha.Reflection;
-using Shesha.Settings.Ioc;
-using Shesha.Utilities;
 using System;
 using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace Shesha.Settings
 {
@@ -37,7 +25,7 @@ namespace Shesha.Settings
         public void Define(ISettingDefinitionContext context)
         {
             var settings = context.GetAll();
-            var dbSettings = _settingConfigurationRepository.GetAll().ToList();
+            var dbSettings = _settingConfigurationRepository.GetAll().Where(sc => sc.Module != null).ToList();
 
             var dynamicallyCreatedSettings = dbSettings
                 .Where(c => !settings.Any(d => d.Value.Name == c.Name && d.Value.ModuleName == c.Module.Name))


### PR DESCRIPTION
SettingAttribute: added overloads to prevent crash at runtime when constructor signature mismatches
SettingsDbHelper: fixed GetSettingValueId