### PR TITLE
Kanban Cleanups

### DIFF
--- a/shesha-reactjs/src/components/kanban/components/renderColumn.tsx
+++ b/shesha-reactjs/src/components/kanban/components/renderColumn.tsx
@@ -82,8 +82,7 @@ const RenderColumn: React.FC<KanbanColumnProps> = ({
       onClick: toggleFold,
       icon: isCollapsed ? <RightOutlined /> : <LeftOutlined />,
     },
-  ].filter(Boolean); // Filter out any items that are `false` or `undefined`
-  
+  ].filter(Boolean); 
   return (
     <>
       {!column.hidden && (
@@ -94,7 +93,7 @@ const RenderColumn: React.FC<KanbanColumnProps> = ({
           data-column-id={column.id}
         >
           <Flex
-            justify={props.kanbanReadonly || props.readonly ? 'center' : 'space-between'} // Apply space-between when editable (settings dropdown exists)
+            justify={props.kanbanReadonly || props.readonly ? 'center' : 'space-between'}
             align="center"
             className={styles.combinedHeaderStyle}
             style={{ ...(getStyle(props.headerStyles, formData) || {}) }}
@@ -149,12 +148,12 @@ const RenderColumn: React.FC<KanbanColumnProps> = ({
               ) : (
                 columnTasks.map((t) => {
                   const taskDropdownItems: MenuProps['items'] = [
-                    {
+                    props.allowEdit && {
                       key: '1',
                       label: 'Edit',
                       onClick: () => handleEditClick(t),
                     },
-                    {
+                    props.allowDelete && {
                       key: '2',
                       label: (
                         <Popconfirm
@@ -167,7 +166,7 @@ const RenderColumn: React.FC<KanbanColumnProps> = ({
                         </Popconfirm>
                       ),
                     },
-                  ];
+                  ].filter(Boolean);
                   return (
                     <div key={t.id} className={styles.taskContainer} data-id={t.id}>
                       <ConfigurableForm
@@ -177,9 +176,11 @@ const RenderColumn: React.FC<KanbanColumnProps> = ({
                         mode={'readonly'}
                         className={styles.taskContainer}
                       />
-                      <Dropdown trigger={['click']} menu={{ items: taskDropdownItems }} placement="bottomRight">
-                        <Button type="text" className={`${styles.threeDots} three-dots`} icon={<MoreOutlined />} />
-                      </Dropdown>
+                      {props.kanbanReadonly || props.readonly ? null : (
+                        <Dropdown trigger={['click']} menu={{ items: taskDropdownItems }} placement="bottomRight">
+                          <Button type="text" className={`${styles.threeDots} three-dots`} icon={<MoreOutlined />} />
+                        </Dropdown>
+                      )}
                     </div>
                   );
                 })

--- a/shesha-reactjs/src/components/kanban/index.tsx
+++ b/shesha-reactjs/src/components/kanban/index.tsx
@@ -81,11 +81,11 @@ const KanbanReactComponent: React.FC<IKanbanProps> = (props) => {
 
   useEffect(() => {
     if (selectedItem) {
-      form.setFieldsValue(selectedItem);
+      editForm.setFieldsValue(selectedItem);
     } else {
-      form.resetFields();
+      editForm.resetFields();
     }
-  }, [selectedItem, form]);
+  }, [selectedItem, editForm]);
 
   const onEnd = useCallback(
     (evt: any, column: any): Promise<boolean> => {
@@ -248,9 +248,7 @@ const KanbanReactComponent: React.FC<IKanbanProps> = (props) => {
       {items.length === 0 ? (
         <KanbanPlaceholder />
       ) : (
-        <Flex
-          style={{ overflowX: 'auto', overflowY: 'hidden', display: 'flex', gap: addPx(gap) }}
-        >
+        <Flex style={{ overflowX: 'auto', overflowY: 'hidden', display: 'flex', gap: addPx(gap) }}>
           {memoizedFilteredTasks.map(({ column, tasks: columnTasks }) => (
             <KanbanColumn
               props={props}
@@ -280,19 +278,14 @@ const KanbanReactComponent: React.FC<IKanbanProps> = (props) => {
       >
         {selectedItem ? (
           <ConfigurableForm
-            key={selectedItem ? selectedItem : 'new-item'}
+            key={selectedItem}
             initialValues={selectedItem || {}}
             form={editForm}
             formId={editFormId}
             mode="edit"
           />
         ) : (
-          <ConfigurableForm
-            key={selectedItem ? selectedItem : 'new-item'}
-            form={form}
-            formId={createFormId}
-            mode="edit"
-          />
+          <ConfigurableForm key={'new-item'} form={form} formId={createFormId} mode="edit" />
         )}
       </Modal>
     </>

--- a/shesha-reactjs/src/components/kanban/index.tsx
+++ b/shesha-reactjs/src/components/kanban/index.tsx
@@ -18,7 +18,7 @@ import { useRefListItemGroupConfigurator } from '@/providers/refList/provider';
 import { addPx } from '../keyInformationBar/utils';
 
 const KanbanReactComponent: React.FC<IKanbanProps> = (props) => {
-  const { gap, groupingProperty, entityType, createFormId, items, componentName, editFormId } = props;
+  const { gap, groupingProperty, entityType, createFormId, items, componentName, editFormId, maxResultCount } = props;
 
   const [columns, setColumns] = useState([]);
   const [urls, setUrls] = useState({ updateUrl: '', deleteUrl: '', postUrl: '' });
@@ -43,7 +43,7 @@ const KanbanReactComponent: React.FC<IKanbanProps> = (props) => {
       getMetadata({ modelType: entityType.id, dataType: DataTypes.entityReference }).then((resp: any) => {
         const endpoints = resp?.apiEndpoints;
         setUrls({ updateUrl: endpoints.update.url, deleteUrl: endpoints.delete.url, postUrl: endpoints.create.url });
-        refetch({ path: `${resp?.apiEndpoints.list.url}?maxResultCount=1000` })
+        refetch({ path: `${resp?.apiEndpoints.list.url}?maxResultCount=${maxResultCount || 100}` })
           .then((resp) => {
             setTasks(resp.result.items.filter((x: any) => x[`${groupingProperty}`] !== null));
           })

--- a/shesha-reactjs/src/components/kanban/model.ts
+++ b/shesha-reactjs/src/components/kanban/model.ts
@@ -46,4 +46,8 @@ export interface IKanbanProps extends IConfigurableFormComponent {
   componentName: string;
   editFormId: string;
   allowEdit: boolean;
+  allowDelete: boolean;
+  maxResultCount: number;
+  maxWidth: number;
+  minWidth: number;
 }

--- a/shesha-reactjs/src/components/kanban/styles/styles.ts
+++ b/shesha-reactjs/src/components/kanban/styles/styles.ts
@@ -4,7 +4,7 @@ import { createStyles } from '@/styles';
 export const useStyles = createStyles(
   (
     { css, cx, prefixCls },
-    { columnBackgroundColor, fontSize, fontColor, headerBackgroundColor, height, minHeight, maxHeight, isCollapsed }
+    { columnBackgroundColor, fontSize, fontColor, headerBackgroundColor, height, minHeight, maxHeight, isCollapsed, width, minWidth, maxWidth }
   ) => {
     const combinedColumnStyle = cx(
       `${prefixCls}-combined-Column-style`,
@@ -22,9 +22,9 @@ export const useStyles = createStyles(
         max-height: ${addPx(maxHeight) || '500px'};
 
         /* Conditional styles based on isCollapsed */
-        min-width: ${isCollapsed ? '40px' : '300px'};
-        width: ${isCollapsed ? '40px' : '300px'};
-        max-width: ${isCollapsed ? '40px' : '300px'};
+        min-width: ${isCollapsed ? '40px' : addPx(minWidth) || '300px'};
+        width: ${isCollapsed ? '40px' : addPx(width) || '300px'};
+        max-width: ${isCollapsed ? '40px' : addPx(maxWidth) || '300px'};
       `
     );
 
@@ -49,6 +49,7 @@ export const useStyles = createStyles(
                 text-align: center; 
                 white-space: nowrap; 
                 overflow: hidden;
+                padding: '10px 0'
             `
           : `
                 transform: rotate(360deg);

--- a/shesha-reactjs/src/designer-components/kanban/settings.tsx
+++ b/shesha-reactjs/src/designer-components/kanban/settings.tsx
@@ -33,15 +33,17 @@ const KanbanSettings: FC<ISettingsFormFactoryArgs<IKanbanProps>> = (props) => {
           <Input readOnly={readOnly} />
         </SettingsFormItem>
       </SettingsCollapsiblePanel>
-        <SettingsFormItem name="modalFormId" label="Render Form" jsSetting>
-          <FormAutocomplete readOnly={readOnly} convertToFullId={true} />
+      <SettingsFormItem name="modalFormId" label="Render Form" jsSetting>
+        <FormAutocomplete readOnly={readOnly} convertToFullId={true} />
+      </SettingsFormItem>
+      <MetadataProvider dataType="entity" modelType={values?.entityType?.id}>
+        <SettingsFormItem name="groupingProperty" label="Grouping property" jsSetting>
+          <PropertyAutocomplete readOnly={props.readOnly} autoFillProps={false} />
         </SettingsFormItem>
-        <MetadataProvider dataType='entity' modelType={values?.entityType?.id}>
-          <SettingsFormItem name="groupingProperty" label="Grouping property" jsSetting>
-            <PropertyAutocomplete readOnly={props.readOnly} autoFillProps={false} />
-          </SettingsFormItem>
-        </MetadataProvider>
-
+      </MetadataProvider>
+      <SettingsFormItem name="maxResultCount" label="Max Result Count" jsSetting>
+          <Input type="number" disabled={readOnly} />
+        </SettingsFormItem>
       <SettingsCollapsiblePanel header="Columns">
         <SettingsFormItem name="referenceList" label="Reference List" style={{ width: '100%' }}>
           <Autocomplete
@@ -80,12 +82,15 @@ const KanbanSettings: FC<ISettingsFormFactoryArgs<IKanbanProps>> = (props) => {
         </SettingsFormItem>
 
         <Show when={values.allowEdit}>
-          <MetadataProvider modelType={values.entityType?.name}  id={nanoid()}>
+          <MetadataProvider modelType={values.entityType?.name} id={nanoid()}>
             <SettingsFormItem name="editFormId" label="Edit Form" jsSetting>
               <FormAutocomplete readOnly={readOnly} convertToFullId={true} />
             </SettingsFormItem>
           </MetadataProvider>
         </Show>
+        <SettingsFormItem name="allowDelete" label="Allow Delete" valuePropName="checked" jsSetting>
+          <Checkbox disabled={values.readOnly} />
+        </SettingsFormItem>
       </Show>
       <SettingsFormItem name="showIcons" label="Show Icons" valuePropName="checked" jsSetting>
         <Checkbox disabled={values.readOnly} />
@@ -121,6 +126,15 @@ const KanbanSettings: FC<ISettingsFormFactoryArgs<IKanbanProps>> = (props) => {
           <Input type="number" disabled={readOnly} />
         </SettingsFormItem>
         <SettingsFormItem name="maxHeight" label="Max Height" jsSetting>
+          <Input type="number" disabled={readOnly} />
+        </SettingsFormItem>
+        <SettingsFormItem name="width" label="Width" jsSetting>
+          <Input type="number" disabled={readOnly} />
+        </SettingsFormItem>
+        <SettingsFormItem name="minWidth" label="Min Width" jsSetting>
+          <Input type="number" disabled={readOnly} />
+        </SettingsFormItem>
+        <SettingsFormItem name="maxWidth" label="Max Width" jsSetting>
           <Input type="number" disabled={readOnly} />
         </SettingsFormItem>
         <SettingsFormItem name="columnBackgroundColor" label="Background Color" jsSetting>


### PR DESCRIPTION
- Added `maxResultCount` as a setting to limit data fetching.
- Added width properties to the settings.
- Added the ability to allow deleting items.
- Fixed the caching issue with the edit form.
- Ensured that when `readOnly` is checked, items cannot be edited or deleted.
