### PR TITLE
Alexs/fix

### DIFF
--- a/shesha-core/src/Shesha.Framework/ConfigurationItems/ConfigurableModuleBootstrapper.cs
+++ b/shesha-core/src/Shesha.Framework/ConfigurationItems/ConfigurableModuleBootstrapper.cs
@@ -61,7 +61,6 @@ namespace Shesha.ConfigurationItems
                     var dbModules = await _moduleRepo.GetAll().ToListAsync();
                     var moduleTypes = _typeFinder
                         .Find(type => type != null && type.IsPublic && !type.IsGenericType && !type.IsAbstract && type != typeof(SheshaModule) && typeof(SheshaModule).IsAssignableFrom(type))
-                        .Where(x => !_startupSession.AssemblyStaysUnchanged(x.Assembly))
                         .ToList();
                     foreach (var type in moduleTypes) 
                     {

--- a/shesha-core/src/Shesha.Framework/Swagger/SwaggerHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Swagger/SwaggerHelper.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Shesha.Domain;
 using Shesha.DynamicEntities;
+using Shesha.DynamicEntities.Dtos;
 using Shesha.JsonEntities;
 using Shesha.Reflection;
 using Shesha.Services;
@@ -156,8 +157,10 @@ namespace Shesha.Swagger
                     var test = typeName + modelType.GetGenericArguments().Select(genericArg => GetSchemaId(genericArg)).Aggregate((previous, current) => previous + current);
                     return test;
                 } 
-                else
+                else if (modelType.HasInterface(typeof(IDynamicDtoProxy)))
                     return "Proxy" + GetSchemaId(modelType.BaseType);
+                else
+                    return modelType.Name;
             }
 
             if (!modelType.IsConstructedGenericType) return modelType.Name.Replace("[]", "Array");

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Common.Application/Services/OrganisationTestAppService.cs
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Common.Application/Services/OrganisationTestAppService.cs
@@ -1,0 +1,68 @@
+﻿using Abp.Dependency;
+using Abp.Domain.Repositories;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Shesha;
+using Shesha.Domain;
+using Shesha.DynamicEntities;
+using Shesha.DynamicEntities.Dtos;
+using Shesha.Specifications;
+using Shesha.Swagger;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace Boxfusion.SheshaFunctionalTests.Common.Application.Services
+{
+    public class OrganisationTestAppService : DynamicCrudAppService<Organisation, DynamicDto<Organisation, Guid>, Guid>, ITransientDependency
+    {
+        private IActionDescriptorChangeProvider _changeProvider;
+        private ApplicationPartManager _applicationPartManager;
+        private ISwaggerProvider _swaggerProvider;
+
+        public OrganisationTestAppService(IRepository<Organisation, Guid> repository,
+            IActionDescriptorChangeProvider changeProvider,
+            ApplicationPartManager applicationPartManager,
+            ISwaggerProvider swaggerProvider
+            ) : base(repository)
+        {
+            _changeProvider = changeProvider;
+            _applicationPartManager = applicationPartManager;
+            _swaggerProvider = swaggerProvider;
+        }
+
+        public void Test()
+        {
+            /*var provider = (DynamicEntityControllerFeatureProvider)_applicationPartManager
+                .FeatureProviders.Where(p => p is DynamicEntityControllerFeatureProvider).FirstOrDefault();
+
+            provider.PopulateFeature(_applicationPartManager.ApplicationParts, )*/
+
+            // Notify change
+            SheshaActionDescriptorChangeProvider.Instance.HasChanged = true;
+            SheshaActionDescriptorChangeProvider.Instance.TokenSource.Cancel();
+            (_swaggerProvider as CachingSwaggerProvider)?.ClearCache();
+        }
+
+        [DisableSpecifications]
+        public async Task GetUnfilteredAsync()
+        {
+            var persons = await AsyncQueryableExecuter.ToListAsync(Repository.GetAll());
+        }
+
+        public async Task GetDefaultFilteredAsync()
+        {
+            var persons = await AsyncQueryableExecuter.ToListAsync(Repository.GetAll());
+        }
+
+        //[ApplySpecifications(typeof(Age18PlusSpecification), typeof(HasNoAccountSpecification))]
+        public async Task GetFilteredAsync()
+        {
+            var persons = await AsyncQueryableExecuter.ToListAsync(Repository.GetAll());
+        }
+    }
+
+    public class OrganisationTest : Organisation
+    {
+        [CascadeUpdateRules(true, true)]
+        public override Address PrimaryAddress { get => base.PrimaryAddress; set => base.PrimaryAddress = value; }
+    }
+}

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Common.Application/Services/Persons/Dtos/PersonDynamicDto.cs
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Common.Application/Services/Persons/Dtos/PersonDynamicDto.cs
@@ -1,0 +1,12 @@
+﻿using Shesha.Domain;
+using Shesha.DynamicEntities.Dtos;
+using System;
+
+namespace Boxfusion.SheshaFunctionalTests.Common.Application.Services.Persons.Dtos
+{
+    public class PersonDynamicDto : DynamicDto<Person, Guid>
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Common.Application/Services/Persons/PersonTestAppService.cs
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Common.Application/Services/Persons/PersonTestAppService.cs
@@ -1,0 +1,74 @@
+﻿using Abp.Auditing;
+using Abp.Authorization;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using Shesha;
+using Shesha.Domain;
+using Shesha.DynamicEntities;
+using Shesha.DynamicEntities.Dtos;
+using Shesha.Specifications;
+using System.ComponentModel.DataAnnotations;
+
+namespace Boxfusion.SheshaFunctionalTests.Common.Application.Services.Persons
+{
+
+    public class PersonTestDto : DynamicDto<Person, Guid>
+    {
+        public virtual string FirstNameOld { get; set; }
+
+        public virtual string LastName { get; set; }
+
+        public virtual string MiddleName { get; set; }
+
+        public virtual Guid Address { get; set; }
+    }
+
+
+    [AbpAuthorize]
+    public class PersonTestAppService : DynamicCrudAppService<Person, DynamicDto<Person, Guid>, Guid>, ITransientDependency
+    {
+        public PersonTestAppService(IRepository<Person, Guid> repository) : base(repository)
+        {
+        }
+
+        public void Test(DynamicDto<Person, Guid> input)
+        {
+        }
+
+        public void TestDto([DynamicBinder(UseDtoForEntityReferences = true, UseDynamicDtoProxy = true)] DynamicDto<Person, Guid> input)
+        {
+        }
+
+        public async Task TestPersonAsync(PersonTestDto input)
+        {
+            var p = new Person();
+            await MapDynamicDtoToEntityAsync<PersonTestDto, Person, Guid>(input, p);
+        }
+
+        public void TestPersonDto([DynamicBinder(UseDtoForEntityReferences = true, UseDynamicDtoProxy = true)] PersonTestDto input)
+        {
+        }
+
+        public override async Task<DynamicDto<Person, Guid>> UpdateAsync([DynamicBinder(UseDtoForEntityReferences = true, UseDynamicDtoProxy = true)] DynamicDto<Person, Guid> input)
+        {
+            return await base.UpdateAsync(input);
+        }
+
+        [DisableSpecifications]
+        public async Task GetUnfilteredAsync()
+        {
+            var persons = await AsyncQueryableExecuter.ToListAsync(Repository.GetAll());
+        }
+
+        public async Task GetDefaultFilteredAsync()
+        {
+            var persons = await AsyncQueryableExecuter.ToListAsync(Repository.GetAll());
+        }
+
+        //[ApplySpecifications(typeof(Age18PlusSpecification), typeof(HasNoAccountSpecification))]
+        public async Task GetFilteredAsync()
+        {
+            var persons = await AsyncQueryableExecuter.ToListAsync(Repository.GetAll());
+        }
+    }
+}

--- a/shesha-reactjs/src/components/dataTable/cell/dataCell.tsx
+++ b/shesha-reactjs/src/components/dataTable/cell/dataCell.tsx
@@ -7,7 +7,7 @@ import React, { FC, useRef } from 'react';
 import StringCell from './default/stringCell';
 import TimeCell from './default/timeCell';
 import { CustomErrorBoundary } from '@/components';
-import { DEFAULT_FORM_SETTINGS, useForm } from '@/providers';
+import { DEFAULT_FORM_SETTINGS, FormItemProvider, useForm } from '@/providers';
 import { getActualModel, upgradeComponent, useAvailableConstantsData } from '@/providers/form/utils';
 import { getInjectables } from './utils';
 import { IColumnEditorProps, standardCellComponentTypes } from '@/providers/datatableColumnsConfigurator/models';
@@ -114,11 +114,14 @@ const ComponentWrapper: FC<IComponentWrapperProps> = (props) => {
 
   return (
     <CustomErrorBoundary>
-      <component.Factory
-        model={componentModel}
-        componentRef={componentRef}
-        form={allData.form?.formInstance}
-      />
+      {/* set namePrefix = '' to reset subForm prefix */}
+      <FormItemProvider namePrefix=''> 
+        <component.Factory
+          model={componentModel}
+          componentRef={componentRef}
+          form={allData.form?.formInstance}
+        />
+      </FormItemProvider>
     </CustomErrorBoundary>
   );
 };

--- a/shesha-reactjs/src/providers/dynamicModal/renderer.tsx
+++ b/shesha-reactjs/src/providers/dynamicModal/renderer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { FC, PropsWithChildren, useContext, useEffect, useRef } from 'react';
 import { DynamicModal } from '@/components/dynamicModal';
 import { DynamicModalInstanceContext, DynamicModalRendererContext } from './contexts';
 import { useDynamicModals } from '.';
@@ -30,14 +30,14 @@ const DynamicModalRenderer: FC<PropsWithChildren<IDynamicModalRendererProps>> = 
   const { instances, removeModal } = useDynamicModals();
   const children = useRef([]);
 
-  const registerChildren = useCallback(() => (id: string) => {
+  const registerChildren = (id: string) => {
     if (children.current.indexOf(id) === -1) 
       children.current = [...children.current, id];
-  }, [props.id]);
-  const unregisterChildren = useCallback( () => (id: string) => {
+  };
+  const unregisterChildren = (id: string) => {
     if (children.current.indexOf(id) !== -1) 
       children.current = children.current.filter((i) => i !== id);
-  }, [props.id]);
+  };
 
   const renderInstances = () => {
     const rendered = [];
@@ -62,7 +62,7 @@ const DynamicModalRenderer: FC<PropsWithChildren<IDynamicModalRendererProps>> = 
     return rendered;
   };
 
-  const context = useMemo(() => ({registerChildren, unregisterChildren}), [registerChildren, unregisterChildren]);
+  const context = {registerChildren, unregisterChildren};
 
   return (
     <DynamicModalRendererContext.Provider value={context}>

--- a/shesha-reactjs/src/utils/configurationFramework/actions.tsx
+++ b/shesha-reactjs/src/utils/configurationFramework/actions.tsx
@@ -6,7 +6,7 @@ import { ConfigurationItemVersionStatus } from './models';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { FormConfigurationDto } from '@/providers/form/api';
 import { getEntityFilterByIds } from '@/utils/graphQl';
-import { getFileNameFromResponse } from '@/utils/fetchers';
+import { axiosHttp, getFileNameFromResponse } from '@/utils/fetchers';
 import { IAbpWrappedGetEntityResponse, IAbpWrappedResponse } from '@/interfaces/gql';
 import { IAjaxResponseBase } from '@/interfaces/ajaxResponse';
 import { IErrorInfo } from '@/interfaces/errorInfo';
@@ -64,12 +64,12 @@ interface UpdateItemStatusArgs extends IHasHttpSettings {
   onFail?: (e: any) => void;
 }
 export const updateItemStatus = (props: UpdateItemStatusArgs) => {
-  const url = `${props.backendUrl}/api/services/app/ConfigurationItem/UpdateStatus`;
+  const url = `/api/services/app/ConfigurationItem/UpdateStatus`;
   const httpPayload = {
     filter: getEntityFilterByIds([props.id]),
     status: props.status,
   };
-  return axios
+  return axiosHttp(props.backendUrl)
     .put<any, AxiosResponse<IAbpWrappedGetEntityResponse<FormConfigurationDto>>>(url, httpPayload, {
       headers: props.httpHeaders,
     })
@@ -174,8 +174,8 @@ export interface IDeleteItemResponse {
 export const deleteItem = (payload: IDeleteItemPayload): Promise<IDeleteItemResponse> => {
   if (!payload.id) throw 'Id must not be null';
   return new Promise<IDeleteItemResponse>((resolve) => {
-    const url = `${payload.backendUrl}/api/services/app/ConfigurationItem/Delete?id=${payload.id}`;
-    return axios
+    const url = `/api/services/app/ConfigurationItem/Delete?id=${payload.id}`;
+    return axiosHttp(payload.backendUrl)
       .delete<any, AxiosResponse<IAbpWrappedResponse<string>>>(url, { headers: payload.httpHeaders })
       .then((response) => {
         resolve({ id: response.data.result });
@@ -196,11 +196,11 @@ export interface ICreateNewItemVersionResponse {
 export const createNewVersionRequest = (
   payload: ICreateNewItemVersionPayload
 ): Promise<AxiosResponse<IAbpWrappedGetEntityResponse<FormConfigurationDto>>> => {
-  const url = `${payload.backendUrl}/api/services/app/ConfigurationItem/CreateNewVersion`;
+  const url = `/api/services/app/ConfigurationItem/CreateNewVersion`;
   const httpPayload = {
     id: payload.id,
   };
-  return axios.post<any, AxiosResponse<IAbpWrappedGetEntityResponse<FormConfigurationDto>>>(url, httpPayload, {
+  return axiosHttp(payload.backendUrl).post<any, AxiosResponse<IAbpWrappedGetEntityResponse<FormConfigurationDto>>>(url, httpPayload, {
     headers: payload.httpHeaders,
   });
 };
@@ -245,11 +245,11 @@ export interface ICancelItemVersionResponse {
 export const itemCancelVersion = (payload: ICancelItemVersionPayload): Promise<ICancelItemVersionResponse> => {
   return new Promise((resolve, reject) => {
     const onOk = () => {
-      const url = `${payload.backendUrl}/api/services/app/ConfigurationItem/CancelVersion`;
+      const url = `/api/services/app/ConfigurationItem/CancelVersion`;
       const httpPayload = {
         id: payload.id,
       };
-      return axios
+      return axiosHttp(payload.backendUrl)
         .post<any, AxiosResponse<IAbpWrappedGetEntityResponse<FormConfigurationDto>>>(url, httpPayload, {
           headers: payload.httpHeaders,
         })


### PR DESCRIPTION
Existing migration forms do not automatically update on application startup when a new version is embedded #2302
Deleting a configuration form on the frontend throws a 401 unauthorized error while the user is logged in #2301
Inline editing fails to display values for dataTable within a subform #2291
Fix Modal Dialog renderer
Swagger: Added handling of classes inherited from DynamicDto