### PR TITLE
fix: Panel header background color

### DIFF
--- a/shesha-reactjs/src/components/panel/index.tsx
+++ b/shesha-reactjs/src/components/panel/index.tsx
@@ -19,6 +19,7 @@ export interface ICollapsiblePanelProps extends CollapseProps {
   noContentPadding?: boolean;
   loading?: boolean;
   collapsedByDefault?: boolean;
+  headerColor?: string;
   bodyColor?: string;
   isSimpleDesign?: boolean;
   hideCollapseContent?: boolean;
@@ -40,6 +41,7 @@ const StyledCollapse: any = styled(Collapse)<
 >`
   .ant-collapse-header {
     visibility: ${({ hideCollapseContent }) => (hideCollapseContent ? 'hidden' : 'visible')};
+    background-color: ${({ headerColor }) => headerColor} !important;;
   }
 
   .ant-collapse-content {
@@ -65,6 +67,7 @@ export const CollapsiblePanel: FC<Omit<ICollapsiblePanelProps, 'radiusLeft' | 'r
   collapsible,
   ghost,
   bodyColor = 'unset',
+  headerColor = 'unset',
   isSimpleDesign,
   hideCollapseContent,
   hideWhenEmpty = false,
@@ -85,6 +88,7 @@ export const CollapsiblePanel: FC<Omit<ICollapsiblePanelProps, 'radiusLeft' | 'r
       style={{...style, borderTopLeftRadius: dynamicBorderRadius, borderTopRightRadius: dynamicBorderRadius}}
       ghost={ghost}
       bodyColor={bodyColor}
+      headerColor={headerColor}
       hideCollapseContent={hideCollapseContent}
     >
       <Panel

--- a/shesha-reactjs/src/designer-components/collapsiblePanel/collapsiblePanelComponent.tsx
+++ b/shesha-reactjs/src/designer-components/collapsiblePanel/collapsiblePanelComponent.tsx
@@ -49,7 +49,6 @@ const CollapsiblePanelComponent: IToolboxComponent<ICollapsiblePanelComponentPro
     const styling = JSON.parse(model.stylingBox || '{}');
 
     const getPanelStyle = {
-      backgroundColor: headerColor,
       ...pickStyleFromModel(styling),
       ...(executeFunction(model?.style, { data, globalState }) || {}),
     };
@@ -75,9 +74,10 @@ const CollapsiblePanelComponent: IToolboxComponent<ICollapsiblePanelComponentPro
           showArrow={collapsible !== 'disabled' && expandIconPosition !== 'hide'}
           ghost={ghost}
           dynamicBorderRadius={model?.borderRadius}
-          style={{...getPanelStyle}}
+          style={{ ...getPanelStyle }}
           className={model.className}
           bodyColor={bodyColor}
+          headerColor={headerColor}
           isSimpleDesign={isSimpleDesign}
           hideCollapseContent={hideCollapseContent}
           hideWhenEmpty={hideWhenEmpty}


### PR DESCRIPTION
header background color was not passing through directly to the header styles and was being overriden in situations where it was, 

![image](https://github.com/user-attachments/assets/5743e106-99e0-400e-9ce1-ac087704fbb2)


resolves https://github.com/shesha-io/shesha-framework/issues/2266