### PR TITLE
using key to force re-render

### DIFF
--- a/shesha-reactjs/src/designer-components/sizableColumns/sizableColumns.tsx
+++ b/shesha-reactjs/src/designer-components/sizableColumns/sizableColumns.tsx
@@ -28,7 +28,12 @@ const SizableColumnsComponent: IToolboxComponent<ISizableColumnComponentProps> =
 
     return (
       <ParentProvider model={model}>
-        <SizableColumns cursor="col-resize" style={style} sizes={columns.map((col) => col.size)}>
+        <SizableColumns
+          key={`split-${columns?.length}`}
+          cursor="col-resize"
+          style={style}
+          sizes={columns?.map((col) => col.size)}
+        >
           {columns &&
             columns.map((col) => (
               <Fragment key={col.id}>


### PR DESCRIPTION
Hi @IvanIlyichev  . Please assist with this PR addressing the issue raised [here](https://github.com/shesha-io/shesha-framework/issues/1847). We have previous discussed it where we added up making use of key to ensure re-render  of 'SizableColumns' for accurate representation of the current columns.