### PR TITLE
configurable header and primary borders

### DIFF
--- a/shesha-reactjs/src/components/panel/index.tsx
+++ b/shesha-reactjs/src/components/panel/index.tsx
@@ -1,11 +1,13 @@
-import React, { FC } from 'react';
-import { Collapse, Skeleton } from 'antd';
+import React, { FC, useEffect, useRef, useState } from 'react';
+import { Collapse, Skeleton, theme } from 'antd';
 import { CollapseProps } from 'antd/lib/collapse';
 import classNames from 'classnames';
 import styled from 'styled-components';
 import { useStyles } from './styles/styles';
 
 const { Panel } = Collapse;
+const { useToken } = theme;
+
 
 export interface ICollapsiblePanelProps extends CollapseProps {
   isActive?: boolean;
@@ -24,6 +26,9 @@ export interface ICollapsiblePanelProps extends CollapseProps {
   isSimpleDesign?: boolean;
   hideCollapseContent?: boolean;
   hideWhenEmpty?: boolean;
+  parentPanel?: boolean;
+  primaryColor?: string;
+  readonly?: boolean;
   dynamicBorderRadius?: number;
 }
 
@@ -36,17 +41,23 @@ export interface ICollapsiblePanelProps extends CollapseProps {
  * 
  */
 
-const StyledCollapse: any = styled(Collapse)<
+const StyledCollapse: any = styled(Collapse) <
   Omit<ICollapsiblePanelProps, 'collapsible' | 'showArrow' | 'header' | 'extraClassName' | 'extra' | 'radius'>
 >`
   .ant-collapse-header {
     visibility: ${({ hideCollapseContent }) => (hideCollapseContent ? 'hidden' : 'visible')};
-    background-color: ${({ headerColor }) => headerColor} !important;;
+    border-top: ${({ parentPanel, primaryColor }) => (parentPanel ? 'none' : `3px solid  ${primaryColor}`)};
+    border-left: ${({ parentPanel, primaryColor }) => (!parentPanel ? 'none' : `3px solid  ${primaryColor}`)};
+    font-size: ${({ parentPanel }) => (parentPanel ? '13px' : '16px')};
+    font-weight: 'bold';
+    
   }
-
-  .ant-collapse-content {
-    .ant-collapse-content-box > .sha-components-container {
-      background-color: ${({ bodyColor }) => bodyColor};
+  >.ant-collapse-item >.ant-collapse-header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 55px;
+    background-color: ${({ bodyColor }) => bodyColor};
     }
   }
 `;
@@ -71,13 +82,35 @@ export const CollapsiblePanel: FC<Omit<ICollapsiblePanelProps, 'radiusLeft' | 'r
   isSimpleDesign,
   hideCollapseContent,
   hideWhenEmpty = false,
+  readonly,
   dynamicBorderRadius
 }) => {
   // Prevent the CollapsiblePanel from collapsing every time you click anywhere on the extra and header
   const onContainerClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => event?.stopPropagation();
-  const { styles } = useStyles({borderRadius: dynamicBorderRadius});
+  const { styles } = useStyles({ borderRadius: dynamicBorderRadius });
+  const [parentPanel, setParentPanel] = useState(false);
+  const panelRef = useRef(null);
+  const { token } = useToken();
+
+
+  useEffect(() => {
+    let currentElement = panelRef.current;
+
+    const currentElementParent = !readonly ?
+      currentElement.parentElement.parentElement?.parentElement?.parentElement?.parentElement?.parentElement?.parentElement?.parentElement
+      : currentElement.parentElement.parentElement?.parentElement.parentElement;
+
+    if (currentElementParent.className.includes('ant-collapse')) {
+      setParentPanel(true);
+    } else {
+      setParentPanel(false);
+    };
+
+  }, []);
+
 
   const shaCollapsiblePanelStyle = isSimpleDesign ? {} : styles.shaCollapsiblePanel;
+
 
   return (
     <StyledCollapse
@@ -85,17 +118,21 @@ export const CollapsiblePanel: FC<Omit<ICollapsiblePanelProps, 'radiusLeft' | 'r
       onChange={onChange}
       expandIconPosition={expandIconPosition}
       className={classNames(shaCollapsiblePanelStyle, className, { [styles.noContentPadding]: noContentPadding, [styles.hideWhenEmpty]: hideWhenEmpty })}
-      style={{...style, borderTopLeftRadius: dynamicBorderRadius, borderTopRightRadius: dynamicBorderRadius}}
+      style={{ ...style, borderTopLeftRadius: dynamicBorderRadius, borderTopRightRadius: dynamicBorderRadius }}
       ghost={ghost}
       bodyColor={bodyColor}
       headerColor={headerColor}
       hideCollapseContent={hideCollapseContent}
+      parentPanel={parentPanel}
+      primaryColor={token.colorPrimary}
     >
       <Panel
         key="1"
         collapsible={collapsible}
         showArrow={showArrow}
         header={header || ' '}
+        className='sha-panel'
+        ref={panelRef}
         extra={
           <span onClick={onContainerClick} className={extraClassName}>
             {extra}

--- a/shesha-reactjs/src/components/panel/styles/styles.ts
+++ b/shesha-reactjs/src/components/panel/styles/styles.ts
@@ -1,6 +1,6 @@
 import { createStyles } from '@/styles';
 
-export const useStyles = createStyles(({ css, cx, token, prefixCls }, {borderRadius}) => {
+export const useStyles = createStyles(({ css, cx, token, prefixCls }, { borderRadius }) => {
   const extraMargin = "28px";
 
   const noContentPadding = "no-content-padding";
@@ -33,14 +33,18 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, {borderRad
       &:not(.${prefixCls}-collapse-ghost) {
         > .${prefixCls}-collapse-item {
           > .${prefixCls}-collapse-header {
-            border-left: 3px solid ${token.colorPrimary};
             border-top-left-radius: ${borderRadius ?? token.borderRadiusLG}px;
             border-top-right-radius: ${borderRadius ?? token.borderRadiusLG}px;
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
             background-color: #f0f0f0;
-            height: 45px;
             margin:'auto 0px';
+            min-height: 50px;
+            height: auto;
+            width: auto;
+            padding: 0;
+            padding-left:10px;
+            padding-top:5px;
           }
         }
       }
@@ -111,7 +115,10 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, {borderRad
       .${prefixCls}-collapse-arrow {
         padding-top: 3px !important;
         margin-top: -3px !important;
-      }    
+      }  
+      .ant-collapse-expand-icon{
+        margin-right:10px;
+      } 
     `);
 
   return {

--- a/shesha-reactjs/src/designer-components/_settings/settingsCollapsiblePanel.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/settingsCollapsiblePanel.tsx
@@ -2,8 +2,9 @@ import React, { FC, useContext, useState } from 'react';
 import { CollapsiblePanel, ICollapsiblePanelProps } from '@/components';
 import { useSettingsForm } from './settingsForm';
 import { createNamedContext } from '@/utils/react';
+import { useForm } from '@/providers';
 
-interface ISettingsCollapsiblePanelProps extends ICollapsiblePanelProps { }
+interface ISettingsCollapsiblePanelProps extends Omit<ICollapsiblePanelProps, 'readonly'> { }
 
 export interface ISettingsCollapsiblePanelActionsContext {
     registerField: (name: string) => void;
@@ -14,6 +15,8 @@ export const SettingsCollapsiblePanelActionsContext = createNamedContext<ISettin
 const SettingsCollapsiblePanel: FC<ISettingsCollapsiblePanelProps> = (props) => {
     const [fields, setFields] = useState([]);
     const { propertyFilter } = useSettingsForm<any>();
+    const { formMode } = useForm();
+
 
     const registerField = (name: string) => {
         if (!Boolean(fields.find(x => (x === name))))
@@ -28,8 +31,8 @@ const SettingsCollapsiblePanel: FC<ISettingsCollapsiblePanelProps> = (props) => 
     return (
         <SettingsCollapsiblePanelActionsContext.Provider value={settingsCollapsiblePanelActions}>
             {show
-            ? <CollapsiblePanel ghost={true} expandIconPosition='start' {...props} />
-            : null}
+                ? <CollapsiblePanel ghost={true} expandIconPosition='start' {...props} readonly={formMode !== 'designer'} />
+                : null}
         </SettingsCollapsiblePanelActionsContext.Provider>
     );
 };

--- a/shesha-reactjs/src/designer-components/collapsiblePanel/collapsiblePanelComponent.tsx
+++ b/shesha-reactjs/src/designer-components/collapsiblePanel/collapsiblePanelComponent.tsx
@@ -54,19 +54,28 @@ const CollapsiblePanelComponent: IToolboxComponent<ICollapsiblePanelComponentPro
     };
 
     const headerComponents = model?.header?.components ?? [];
+
+    const hasCustomHeader = model?.hasCustomHeader;
+
     const extra =
-      headerComponents?.length > 0 || formMode === 'designer' ? (
+      ((headerComponents?.length > 0 || formMode === 'designer') && !hasCustomHeader) ? (
         <ComponentsContainer
           containerId={model.header?.id}
           direction="horizontal"
-          dynamicComponents={model?.isDynamic ? headerComponents : []}
+          dynamicComponents={model?.isDynamic ? model.header?.components : []}
         />
       ) : null;
 
     return (
       <ParentProvider model={model}>
         <CollapsiblePanel
-          header={evaluatedLabel}
+          header={hasCustomHeader ?
+            <ComponentsContainer
+              containerId={model.customHeader.id}
+              dynamicComponents={(model?.isDynamic) ? model?.customHeader?.components : []}
+            /> :
+            evaluatedLabel
+          }
           expandIconPosition={expandIconPosition !== 'hide' ? (expandIconPosition as ExpandIconPosition) : 'start'}
           collapsedByDefault={collapsedByDefault}
           extra={extra}
@@ -74,9 +83,10 @@ const CollapsiblePanelComponent: IToolboxComponent<ICollapsiblePanelComponentPro
           showArrow={collapsible !== 'disabled' && expandIconPosition !== 'hide'}
           ghost={ghost}
           dynamicBorderRadius={model?.borderRadius}
-          style={{...getPanelStyle}}
+          style={{ ...getPanelStyle }}
           className={model.className}
           bodyColor={bodyColor}
+          readonly={formMode !== 'designer'}
           headerColor={headerColor}
           isSimpleDesign={isSimpleDesign}
           hideCollapseContent={hideCollapseContent}
@@ -138,8 +148,12 @@ const CollapsiblePanelComponent: IToolboxComponent<ICollapsiblePanelComponentPro
       .add<ICollapsiblePanelComponentProps>(4, (prev) => migrateVisibility(prev))
       .add<ICollapsiblePanelComponentProps>(5, (prev) => ({ ...migrateFormApi.properties(prev) }))
       .add<ICollapsiblePanelComponentProps>(6, (prev) => removeComponents(prev))
+      .add<ICollapsiblePanelComponentProps>(7, (prev) => ({
+        ...prev,
+        customHeader: { id: nanoid(), components: [] }
+      }))
   ,
-  customContainerNames: ['header', 'content'],
+  customContainerNames: ['header', 'content', 'customHeader'],
 };
 
 export default CollapsiblePanelComponent;

--- a/shesha-reactjs/src/designer-components/collapsiblePanel/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/collapsiblePanel/interfaces.ts
@@ -23,6 +23,8 @@ export interface ICollapsiblePanelComponentProps extends IConfigurableFormCompon
   isSimpleDesign?: boolean;
   hideCollapseContent?: boolean;
   borderRadius?: number;
+  hasCustomHeader?: boolean;
+  customHeader?: ICollapsiblePanelContent;
 }
 
 export interface ICollapsiblePanelComponentPropsV0 extends IConfigurableFormComponent {

--- a/shesha-reactjs/src/designer-components/collapsiblePanel/settingsForm.json
+++ b/shesha-reactjs/src/designer-components/collapsiblePanel/settingsForm.json
@@ -43,6 +43,14 @@
             "textType": "text"
           },
           {
+            "id": "cfd7d45e-c7e3-4a27-987b-dc525c412558",
+            "type": "checkbox",
+            "propertyName": "hasCustomHeader",
+            "parentId": "b8954bf6-f76d-4139-a850-c99bf06c8b69",
+            "label": "Custom Header",
+            "version": 1
+          },
+          {
             "id": "57a40a33-7e08-4ce4-9f08-a34d24a83338",
             "type": "dropdown",
             "propertyName": "expandIconPosition",


### PR DESCRIPTION
Hi @AlexStepantsov . This PR addressing the issue raised [here](https://github.com/shesha-io/shesha-framework/issues/699). I have ensured that the parent panel(outer) has a border-top with primary-color and the subsequent children to have a border-left with primary color. Finally I have added the custom Header option to allow user flexibility if the don't like a default header's layout.