### PR TITLE
Charts fallback title enhancements

### DIFF
--- a/shesha-reactjs/src/designer-components/charts/components/bar/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/bar/index.tsx
@@ -26,7 +26,6 @@ ChartJS.register(
 const BarChart: React.FC<BarChartProps> = ({ data }) => {
   const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showLegend, showTitle, title, legendPosition, showXAxisScale, showXAxisTitle, showYAxisScale, showYAxisTitle, stacked, legendProperty } = useChartDataStateContext();
 
-
   if (!data || !data.datasets || !data.labels) {
     if (!data)
       throw new Error('BarChart: No data to display. Please check the data source');
@@ -44,7 +43,7 @@ const BarChart: React.FC<BarChartProps> = ({ data }) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim() || `${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
+        text: title?.trim().length > 0 ? title : `${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
       },
     },
     scales: {

--- a/shesha-reactjs/src/designer-components/charts/components/bar/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/bar/index.tsx
@@ -46,7 +46,7 @@ const BarChart: React.FC<BarChartProps> = ({ data }) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim().length > 0 ? title : `${entityClassName}: ${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
+        text: title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} vs ${yProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
       },
     },
     scales: {

--- a/shesha-reactjs/src/designer-components/charts/components/bar/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/bar/index.tsx
@@ -24,7 +24,10 @@ ChartJS.register(
 );
 
 const BarChart: React.FC<BarChartProps> = ({ data }) => {
-  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showLegend, showTitle, title, legendPosition, showXAxisScale, showXAxisTitle, showYAxisScale, showYAxisTitle, stacked, legendProperty } = useChartDataStateContext();
+  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showLegend, showTitle, title, legendPosition, showXAxisScale, showXAxisTitle, showYAxisScale, showYAxisTitle, stacked, legendProperty, entityType } = useChartDataStateContext();
+
+  const entityTypeArray = entityType.split('.');
+  const entityClassName = entityTypeArray[entityTypeArray.length - 1];
 
   if (!data || !data.datasets || !data.labels) {
     if (!data)
@@ -43,7 +46,7 @@ const BarChart: React.FC<BarChartProps> = ({ data }) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim().length > 0 ? title : `${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
+        text: title?.trim().length > 0 ? title : `${entityClassName}: ${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
       },
     },
     scales: {

--- a/shesha-reactjs/src/designer-components/charts/components/line/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/line/index.tsx
@@ -61,7 +61,7 @@ const LineChart: React.FC<ILineChartProps> = ({ data }) => {
             },
             title: {
                 display: showTitle ? true : false,
-                text: title?.trim() || `${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
+                text: title?.trim().length > 0 ? title : `${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
             }
         },
         scales: {

--- a/shesha-reactjs/src/designer-components/charts/components/line/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/line/index.tsx
@@ -64,7 +64,7 @@ const LineChart: React.FC<ILineChartProps> = ({ data }) => {
             },
             title: {
                 display: showTitle ? true : false,
-                text: title?.trim().length > 0 ? title : `${entityClassName}: ${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
+                text: title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} vs ${yProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
             }
         },
         scales: {

--- a/shesha-reactjs/src/designer-components/charts/components/line/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/line/index.tsx
@@ -27,7 +27,10 @@ ChartJS.register(
 );
 
 const LineChart: React.FC<ILineChartProps> = ({ data }) => {
-    const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showLegend, showTitle, title, legendPosition, showXAxisScale, showXAxisTitle, showYAxisScale, showYAxisTitle, tension, legendProperty, strokeColor, dataMode, borderWidth } = useChartDataStateContext();
+    const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showLegend, showTitle, title, legendPosition, showXAxisScale, showXAxisTitle, showYAxisScale, showYAxisTitle, tension, legendProperty, strokeColor, dataMode, borderWidth, entityType } = useChartDataStateContext();
+
+    const entityTypeArray = entityType.split('.');
+    const entityClassName = entityTypeArray[entityTypeArray.length - 1];
 
     if (!data || !data.datasets || !data.labels) {
         if (!data)
@@ -61,7 +64,7 @@ const LineChart: React.FC<ILineChartProps> = ({ data }) => {
             },
             title: {
                 display: showTitle ? true : false,
-                text: title?.trim().length > 0 ? title : `${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
+                text: title?.trim().length > 0 ? title : `${entityClassName}: ${yProperty} vs ${xProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`,
             }
         },
         scales: {

--- a/shesha-reactjs/src/designer-components/charts/components/pie/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/pie/index.tsx
@@ -46,7 +46,6 @@ ChartJS.register(
 const PieChart = ({ data }: IPieChartProps) => {
   const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showXAxisScale, showTitle, title, legendPosition } = useChartDataStateContext();
 
-
   if (!data || !data.datasets || !data.labels) {
     if (!data)
       throw new Error('PieChart: No data to display. Please check the data source');
@@ -68,7 +67,7 @@ const PieChart = ({ data }: IPieChartProps) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim() || `${yProperty} by ${xProperty} (${aggregationMethod})`,
+        text: title?.trim().length > 0 ? title :  `${yProperty} by ${xProperty} (${aggregationMethod})`,
       },
     },
     layout: {

--- a/shesha-reactjs/src/designer-components/charts/components/pie/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/pie/index.tsx
@@ -70,7 +70,7 @@ const PieChart = ({ data }: IPieChartProps) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim().length > 0 ? title :  `${entityClassName}: ${yProperty} by ${xProperty} (${aggregationMethod})`,
+        text: title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} by ${yProperty} (${aggregationMethod})`,
       },
     },
     layout: {

--- a/shesha-reactjs/src/designer-components/charts/components/pie/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/pie/index.tsx
@@ -44,7 +44,10 @@ ChartJS.register(
 );
 
 const PieChart = ({ data }: IPieChartProps) => {
-  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showXAxisScale, showTitle, title, legendPosition } = useChartDataStateContext();
+  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showXAxisScale, showTitle, title, legendPosition, entityType } = useChartDataStateContext();
+
+  const entityTypeArray = entityType.split('.');
+  const entityClassName = entityTypeArray[entityTypeArray.length - 1];
 
   if (!data || !data.datasets || !data.labels) {
     if (!data)
@@ -67,7 +70,7 @@ const PieChart = ({ data }: IPieChartProps) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim().length > 0 ? title :  `${yProperty} by ${xProperty} (${aggregationMethod})`,
+        text: title?.trim().length > 0 ? title :  `${entityClassName}: ${yProperty} by ${xProperty} (${aggregationMethod})`,
       },
     },
     layout: {

--- a/shesha-reactjs/src/designer-components/charts/components/polarArea/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/polarArea/index.tsx
@@ -61,7 +61,7 @@ const PolarAreaChart = ({ data }: IPolarAreaChartProps) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim() || `${yProperty} by ${xProperty} (${aggregationMethod})`,
+        text: title?.trim().length > 0 ? title : `${yProperty} by ${xProperty} (${aggregationMethod})`,
       },
     },
     layout: {

--- a/shesha-reactjs/src/designer-components/charts/components/polarArea/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/polarArea/index.tsx
@@ -64,7 +64,7 @@ const PolarAreaChart = ({ data }: IPolarAreaChartProps) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim().length > 0 ? title : `${entityClassName}: ${yProperty} by ${xProperty} (${aggregationMethod})`,
+        text: title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} by ${yProperty} (${aggregationMethod})`,
       },
     },
     layout: {

--- a/shesha-reactjs/src/designer-components/charts/components/polarArea/index.tsx
+++ b/shesha-reactjs/src/designer-components/charts/components/polarArea/index.tsx
@@ -24,7 +24,10 @@ ChartJS.register(
 );
 
 const PolarAreaChart = ({ data }: IPolarAreaChartProps) => {
-  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showXAxisScale, showTitle, title, legendPosition } = useChartDataStateContext();
+  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, showXAxisScale, showTitle, title, legendPosition, entityType } = useChartDataStateContext();
+
+  const entityTypeArray = entityType.split('.');
+  const entityClassName = entityTypeArray[entityTypeArray.length - 1];
 
   if (!data || !data.datasets || !data.labels) {
     if (!data)
@@ -61,7 +64,7 @@ const PolarAreaChart = ({ data }: IPolarAreaChartProps) => {
       },
       title: {
         display: showTitle ? true : false,
-        text: title?.trim().length > 0 ? title : `${yProperty} by ${xProperty} (${aggregationMethod})`,
+        text: title?.trim().length > 0 ? title : `${entityClassName}: ${yProperty} by ${xProperty} (${aggregationMethod})`,
       },
     },
     layout: {

--- a/shesha-reactjs/src/designer-components/charts/settings.ts
+++ b/shesha-reactjs/src/designer-components/charts/settings.ts
@@ -428,7 +428,7 @@ export const settingsForm = new DesignerToolbarSettings()
             label: 'Allow Chart Filter',
             parentId: 'root',
             description: 'Allow users to filter the chart data directly from the chart.',
-            defaultValue: true,
+            defaultValue: false,
           })
           .addPropertyAutocomplete({
             id: nanoid(),

--- a/shesha-reactjs/src/designer-components/charts/utils.ts
+++ b/shesha-reactjs/src/designer-components/charts/utils.ts
@@ -62,7 +62,7 @@ export const getChartDataRefetchParams = (entityType: string, dataProperty: stri
     path: `/api/services/app/Entities/GetAll`,
     queryParams: {
       entityType: entityType,
-      properties: removePropertyDuplicates((dataProperty + (legendProperty ? ',' + legendProperty : '') + (axisProperty ? ',' + axisProperty : ''))?.replace(/(\w+)\.(\w+)/, '$1{$2}')) + ", " + filterProperties,
+      properties: removePropertyDuplicates((removePropertyDuplicates((dataProperty + (legendProperty ? ',' + legendProperty : '') + (axisProperty ? ',' + axisProperty : ''))?.replace(/(\w+)\.(\w+)/, '$1{$2}')) + ", " + filterProperties).replace(/\s/g, '')),
       filter: filters,
       sorting: orderBy ? `${orderBy} ${orderDirection ?? 'asc'}` : '',
       maxResultCount: -1

--- a/shesha-reactjs/src/providers/chartData/context.tsx
+++ b/shesha-reactjs/src/providers/chartData/context.tsx
@@ -65,7 +65,7 @@ export const INITIAL_STATE: IChartDataContext = {
   dataMode: 'entityType',
   chartType: 'pivot',
   showTitle: true,
-  title: 'Chart Title',
+  title: '',
   showLegend: true,
   legendPosition: 'top',
   entityType: 'entity',


### PR DESCRIPTION
When the configurator selects that the chart should have a title but then they don't provide the title, the fallback title that shows should be the one that informs about the parameters of the chart


![image](https://github.com/user-attachments/assets/bea4018e-414c-4571-877f-32ee9ecc323b)
