### PR TITLE
Chart enhancements + bug fix

### DIFF
--- a/shesha-reactjs/src/designer-components/charts/hooks.ts
+++ b/shesha-reactjs/src/designer-components/charts/hooks.ts
@@ -16,24 +16,13 @@ import { aggregateData, aggregateValues, getPredictableColor, getPropertyValue, 
  * @returns title for the chart
  */
 export const useGeneratedTitle = (): string => {
-  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, title, legendProperty, dataMode, entityType, chartType } = useChartDataStateContext();
+  const { axisProperty: xProperty, valueProperty: yProperty, aggregationMethod, title, legendProperty, dataMode, entityType, simpleOrPivot } = useChartDataStateContext();
   
   const entityTypeArray = dataMode === 'entityType' ? entityType?.split('.') : undefined;
   const entityClassName = dataMode === 'entityType' ? entityTypeArray[entityTypeArray?.length - 1] : '';
-  switch (chartType) {
-    case 'bar':
-    case 'line':
-      return dataMode === 'entityType' ?
-        (title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} vs ${yProperty} (${aggregationMethod})${legendProperty ? `, grouped by ${legendProperty}` : ''}`) :
-        (title?.trim().length > 0 ? title : ``);
-    case 'polarArea':
-    case 'pie':
-      return dataMode === 'entityType' ?
-        (title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} by ${yProperty} (${aggregationMethod})`) :
-        (title?.trim().length > 0 ? title : ``);
-    default:
-      return '';
-  }
+  return dataMode === 'entityType' ?
+    (title?.trim().length > 0 ? title : `${entityClassName}: ${xProperty} vs ${yProperty} (${aggregationMethod})${legendProperty && simpleOrPivot === 'pivot' ? `, grouped by ${legendProperty}` : ''}`) :
+    (title?.trim().length > 0 ? title : ``);
 };
 
 /**

--- a/shesha-reactjs/src/designer-components/charts/utils.ts
+++ b/shesha-reactjs/src/designer-components/charts/utils.ts
@@ -32,13 +32,15 @@ function removePropertyDuplicates(str) {
 }
 
 /**
+ * Function to convert an array of nested properties to object format
+ * @example convertNestedPropertiesToObjectFormat(['a.b.c', 'a.b.d', 'a.e']) => 'a { b { c }, a { b { d }, a { e }'
  * @param array array of nested properties
  * @returns the array in object format
  */
-function convertNestedPropertiesToObjectFormat(array) {
+function convertNestedPropertiesToObjectFormat(array?: string[]) {
   if (!array) return '';
 
-  return array?.map(path => {
+  return array?.filter(path => path && path?.trim() !== '').map(path => {
     let parts = path.split('.');
     let result = '';
     let indentation = 0;
@@ -73,12 +75,11 @@ function convertNestedPropertiesToObjectFormat(array) {
  * @returns getChartData mutate path and queryParams
  */
 export const getChartDataRefetchParams = (entityType: string, dataProperty: string, filters: string, legendProperty?: string, axisProperty?: string, filterProperties?: string[], orderBy?: string, orderDirection?: TOrderDirection) => {
-  filterProperties = convertNestedPropertiesToObjectFormat(filterProperties);
   return {
     path: `/api/services/app/Entities/GetAll`,
     queryParams: {
       entityType: entityType,
-      properties: removePropertyDuplicates((removePropertyDuplicates((dataProperty + (legendProperty ? ',' + legendProperty : '') + (axisProperty ? ',' + axisProperty : ''))?.replace(/(\w+)\.(\w+)/, '$1{$2}')) + ", " + filterProperties).replace(/\s/g, '')),
+      properties: removePropertyDuplicates((convertNestedPropertiesToObjectFormat([dataProperty, legendProperty, axisProperty]) + ", " + convertNestedPropertiesToObjectFormat(filterProperties)).replace(/\s/g, '')),
       filter: filters,
       sorting: orderBy ? `${orderBy} ${orderDirection ?? 'asc'}` : '',
       maxResultCount: -1

--- a/shesha-reactjs/src/designer-components/charts/utils.ts
+++ b/shesha-reactjs/src/designer-components/charts/utils.ts
@@ -367,12 +367,6 @@ function getPredictableColorHSL(value: string): string {
     hash += (value.charCodeAt(i) * (i + 1)) ** 3.5;  // Raising to 3.5 to exaggerate differences
   }
 
-  if (value === 'true') {
-    hash += 124356;  // Arbitrary number to differentiate 'true'
-  } else if (value === 'false') {
-    hash += 653421;  // Arbitrary number to differentiate 'false'
-  }
-
   // Use the hash to calculate the hue (0 - 360 degrees on the color wheel)
   const hue = Math.abs(hash % 360);
 
@@ -394,7 +388,26 @@ function getPredictableColorHSL(value: string): string {
  */
 export function getPredictableColor(input: string | number): string {
   if (typeof input === 'string') {
-    return getPredictableColorHSL(input.toString());
+    switch (input.toLocaleLowerCase()) {
+      case 'true':
+        return 'hsla(120, 100%, 20%, 0.75)';
+      case 'false':
+        return 'hsla(0, 100%, 20%, 0.75)';
+      case 'unknown':
+        return 'hsla(0, 0%, 50%, 0.75)';
+      case 'undefined':
+        return 'hsla(0, 0%, 20%, 0.75)';
+      case 'null':
+        return 'hsla(0, 100%, 20%, 0.75)';
+      case '':
+        return 'hsla(240, 100%, 20%, 0.75)';
+      case 'none':
+        return 'hsla(0, 0%, 75%, 0.75)';
+      case 'not disclosed':
+        return 'hsla(20, 20%, 90%, 0.75)';
+      default:
+        return getPredictableColorHSL(input.toString());
+    }
   }
 
   // If the input is a number, convert it to a string and return the color


### PR DESCRIPTION
> Bug fix for deeply nested chart properties
> 
> ![image](https://github.com/user-attachments/assets/30b2697f-a6e4-4391-9980-e5238364aa21)
 must be 
> 
> ![image](https://github.com/user-attachments/assets/fcf68009-aed4-451f-9089-2a9e7bbd0b4b)
> 
> So that for example y-axis can be like so
> ![image](https://github.com/user-attachments/assets/e66b9e7b-7633-4006-a54e-71eff37d86bc)


> Faster reflist items stringification on fetching of data

> Standard colors for 'null', 'undefined' and adjacent words