### PR TITLE
chore: deselect the selected component when going into preview

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
@@ -1,14 +1,14 @@
-import { ComponentPropertiesTitle } from '../componentPropertiesTitle';
-import ParentProvider from '@/providers/parentProvider';
-import React, { FC } from 'react';
-import Toolbox from '../toolbox';
 import { ConfigurableFormRenderer, SidebarContainer } from '@/components';
-import { DebugPanel } from '../debugPanel';
-import { MetadataProvider, useCanvas, useForm } from '@/providers';
-import { useFormDesignerState } from '@/providers/formDesigner';
-import { useStyles } from '../styles/styles';
-import { ComponentPropertiesPanel } from '../componentPropertiesPanel';
 import ConditionalWrap from '@/components/conditionalWrapper';
+import { MetadataProvider, useCanvas, useForm } from '@/providers';
+import { useFormDesignerActions, useFormDesignerState } from '@/providers/formDesigner';
+import ParentProvider from '@/providers/parentProvider';
+import React, { FC, useEffect } from 'react';
+import { ComponentPropertiesPanel } from '../componentPropertiesPanel';
+import { ComponentPropertiesTitle } from '../componentPropertiesTitle';
+import { DebugPanel } from '../debugPanel';
+import { useStyles } from '../styles/styles';
+import Toolbox from '../toolbox';
 
 export interface IDesignerMainAreaProps {
 
@@ -16,13 +16,24 @@ export interface IDesignerMainAreaProps {
 
 export const DesignerMainArea: FC<IDesignerMainAreaProps> = () => {
     const { isDebug, readOnly } = useFormDesignerState();
+    const { setSelectedComponent } = useFormDesignerActions();
     const { form, formMode, formSettings } = useForm();
     const { designerWidth, zoom } = useCanvas();
     const { styles } = useStyles();
 
+    useEffect(() => {
+        if (formMode !== 'designer') {
+            setSelectedComponent(null);
+        }
+    }, [formMode]);
+
     return (
         <div className={styles.mainArea} style={{
             borderTop: '1px solid #d3d3d3',
+            ...(formMode !== 'designer' && {
+                maxHeight: '85vh',
+                overflow: 'auto',
+            })
         }}>
             <ConditionalWrap
                 condition={formMode === 'designer'}
@@ -43,9 +54,7 @@ export const DesignerMainArea: FC<IDesignerMainAreaProps> = () => {
                             placeholder: 'Properties',
                         }}
                     >
-                        <div className={styles.mainArea}>
-                            {children}
-                        </div>
+                        {children}
                     </SidebarContainer>
                 )}
             >


### PR DESCRIPTION
Also show scrollbar if the data in the form overflows in the designer that pops in the modal to allow the configurator to see the preview of the entire form as before

![image](https://github.com/user-attachments/assets/818d1cde-8b0d-4429-aad2-d962ad62aee8)
