### PR TITLE
chore: padding-bottom 50px on side panels of the form designer

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/componentPropertiesPanel/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/componentPropertiesPanel/index.tsx
@@ -17,8 +17,7 @@ const ComponentPropertiesPanelInner: FC<IProps> = () => {
           }
         />
       )}
-      <div ref={settingsPanelRef}>
-      </div>
+      <div style={{paddingBottom: '50px'}} ref={settingsPanelRef}></div>
     </>
   );
 };

--- a/shesha-reactjs/src/components/formDesigner/toolbox.tsx
+++ b/shesha-reactjs/src/components/formDesigner/toolbox.tsx
@@ -35,7 +35,7 @@ const Toolbox: FC<IProps> = () => {
 
   return (
     <div className={styles.shaDesignerToolbox}>
-      <Tabs defaultActiveKey="1" type="card" items={[...builderItems]} />
+      <Tabs style={{paddingBottom: '50px'}} defaultActiveKey="1" type="card" items={[...builderItems]} />
     </div>
   );
 };


### PR DESCRIPTION
When opening the form designer on the fly into the dialog, the dialog / modal imposes the height on its children. This is good. But now the overflowing content does not show properly.

> This PR adds 50px bottomPadding to each on the side panel contents so that they are rendered correctly without hiding other things

Before:
![image](https://github.com/user-attachments/assets/4bcd5516-70eb-4252-a63f-b9bdef0b2cc7)

After:
![image](https://github.com/user-attachments/assets/eb5d7f03-4a32-49fa-be05-64cb1398e326)

