### PR TITLE
Updates to the markdown files + Update dead link to GPL 3 license on the repo

### DIFF
--- a/shesha-core/README.md
+++ b/shesha-core/README.md
@@ -6,7 +6,7 @@ shesha-core
 
 ## License
 
-Shesha and the various shesha community components and services are available under the [GPL-3.0 license](https://opensource.org/licenses/GPL-3.0). Shesha also includes external libraries that are available under a variety of licenses. See [LICENSE](https://github.com/boxfusion/shesha-core/blob/HEAD/LICENSE) for the full license text
+Shesha and the various shesha community components and services are available under the [GPL-3.0 license](https://opensource.org/licenses/GPL-3.0). Shesha also includes external libraries that are available under a variety of licenses. See [LICENSE](https://github.com/teboho/shesha-framework/blob/main/shesha-reactjs/LICENCE.md) for the full license text
 
 ## Running locally from CLI:
 

--- a/shesha-core/README.md
+++ b/shesha-core/README.md
@@ -1,10 +1,31 @@
 shesha-core
 ========================
 
-[![docs](https://readthedocs.org/projects/shesha-core/badge/?version=latest)](https://shesha-core.readthedocs.io/en/latest/?badge=latest)
+
+[![docs](https://badgen.net/badge/docs/Shesha/latest?version=latest)](https://docs.shesha.io/docs/get-started/Introduction)
 
 ## License
 
 Shesha and the various shesha community components and services are available under the [GPL-3.0 license](https://opensource.org/licenses/GPL-3.0). Shesha also includes external libraries that are available under a variety of licenses. See [LICENSE](https://github.com/boxfusion/shesha-core/blob/HEAD/LICENSE) for the full license text
 
-Commit Build
+## Running locally from CLI:
+
+*The working directory is shesha-core*  
+shesha-core  
+ |-- src  
+ |-- nupkg  
+ |-- .nuget  
+ |-- test  
+ |-- ...
+
+### Build
+
+> dotnet build 
+
+### Run
+
+> dotnet run --project src/Shesha.Web.Host --urls "http://localhost:21021;https://localhost:44362"
+
+> [!NOTE]
+> If you have do not have local certificate for SSL you will need to install the default development certificate and trust via:
+>> dotnet dev-certs https --trust

--- a/shesha-core/src/Shesha.Application/README.md
+++ b/shesha-core/src/Shesha.Application/README.md
@@ -1,3 +1,6 @@
 ﻿## Shesha.Application  
 
 Shesha.Application packaged as a NuGet package  
+
+
+[![NuGet version (Shesha.Application)](https://img.shields.io/nuget/v/Shesha.Application?style=flat-square)](https://www.nuget.org/packages/Shesha.Application/)

--- a/shesha-core/src/Shesha.Common/README.md
+++ b/shesha-core/src/Shesha.Common/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Common  
 
 Shesha.Common packaged as a NuGet package
+
+[![NuGet version (Shesha.Common)](https://img.shields.io/nuget/v/Shesha.Common?style=flat-square)](https://www.nuget.org/packages/Shesha.Common/)

--- a/shesha-core/src/Shesha.Core/README.md
+++ b/shesha-core/src/Shesha.Core/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Core  
 
 Shesha.Core packaged as a NuGet package
+
+[![NuGet version (Shesha.Core)](https://img.shields.io/nuget/v/Shesha.Core?style=flat-square)](https://www.nuget.org/packages/Shesha.Core/)

--- a/shesha-core/src/Shesha.Elmah/README.md
+++ b/shesha-core/src/Shesha.Elmah/README.md
@@ -1,3 +1,5 @@
 ﻿# Shesha.Elmah as a NuGet package  
 
 Shesha.Elmah packaged as a NuGet package
+
+[![NuGet version (Shesha.Elmah)](https://img.shields.io/nuget/v/Shesha.Elmah?style=flat-square)](https://www.nuget.org/packages/Shesha.Elmah/)

--- a/shesha-core/src/Shesha.FluentMigrator/README.md
+++ b/shesha-core/src/Shesha.FluentMigrator/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.FluentMigrator  
 
 Shesha.FluentMigrator packaged as a NuGet package
+
+[![NuGet version (Shesha.FluentMigrator)](https://img.shields.io/nuget/v/Shesha.FluentMigrator?style=flat-square)](https://www.nuget.org/packages/Shesha.FluentMigrator/)

--- a/shesha-core/src/Shesha.Framework/README.md
+++ b/shesha-core/src/Shesha.Framework/README.md
@@ -1,3 +1,5 @@
 ﻿# Shesha.Framework packaged as a NuGet package  
 
 Shesha.Framework packaged as a NuGet package
+
+[![NuGet version (Shesha.Framework)](https://img.shields.io/nuget/v/Shesha.Framework?style=flat-square)](https://www.nuget.org/packages/Shesha.Framework/)

--- a/shesha-core/src/Shesha.GraphQL/README.md
+++ b/shesha-core/src/Shesha.GraphQL/README.md
@@ -1,3 +1,5 @@
 ﻿# Shesha.GraphQL packaged as a NuGet package  
 
 Shesha.GraphQL packaged as a NuGet package
+
+[![NuGet version (Shesha.GraphQL)](https://img.shields.io/nuget/v/Shesha.GraphQL?style=flat-square)](https://www.nuget.org/packages/Shesha.GraphQL/)

--- a/shesha-core/src/Shesha.Import/README.md
+++ b/shesha-core/src/Shesha.Import/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Import  
 
 Shesha.Import packaged as a NuGet package
+
+[![NuGet version (Shesha.Import)](https://img.shields.io/nuget/v/Shesha.Import?style=flat-square)](https://www.nuget.org/packages/Shesha.Import/)

--- a/shesha-core/src/Shesha.MongoRepository/README.md
+++ b/shesha-core/src/Shesha.MongoRepository/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.MongoRepository  
 
 Shesha.MongoRepository packaged as a NuGet package
+
+[![NuGet version (Shesha.MongoRepository)](https://img.shields.io/nuget/v/Shesha.MongoRepository?style=flat-square)](https://www.nuget.org/packages/Shesha.MongoRepository/)

--- a/shesha-core/src/Shesha.NHibernate/README.md
+++ b/shesha-core/src/Shesha.NHibernate/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Core  
 
 Shesha.NHibernate packaged as a NuGet package
+
+[![NuGet version (Shesha.NHibernate)](https://img.shields.io/nuget/v/Shesha.NHibernate?style=flat-square)](https://www.nuget.org/packages/Shesha.NHibernate/)

--- a/shesha-core/src/Shesha.RestSharp/README.md
+++ b/shesha-core/src/Shesha.RestSharp/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.RestSharp  
 
 Shesha.RestSharp packaged as a NuGet package
+
+[![NuGet version (Shesha.RestSharp)](https://img.shields.io/nuget/v/Shesha.RestSharp?style=flat-square)](https://www.nuget.org/packages/Shesha.RestSharp/)

--- a/shesha-core/src/Shesha.Scheduler/README.md
+++ b/shesha-core/src/Shesha.Scheduler/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Scheduler  
 
 Shesha.Scheduler packaged as a NuGet package
+
+[![NuGet version (Shesha.Scheduler)](https://img.shields.io/nuget/v/Shesha.Scheduler?style=flat-square)](https://www.nuget.org/packages/Shesha.Scheduler/)

--- a/shesha-core/src/Shesha.Sms.Clickatell/README.md
+++ b/shesha-core/src/Shesha.Sms.Clickatell/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Sms.Clickatell  
 
 Shesha.Sms.Clickatell packaged as a NuGet package
+
+[![NuGet version (Shesha.Sms.Clickatell)](https://img.shields.io/nuget/v/Shesha.Sms.Clickatell?style=flat-square)](https://www.nuget.org/packages/Shesha.Sms.Clickatell)

--- a/shesha-core/src/Shesha.Web.Core/README.md
+++ b/shesha-core/src/Shesha.Web.Core/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Web.Core  
 
 Shesha.Web.Core packaged as a NuGet package
+
+[![NuGet version (Shesha.Application)](https://img.shields.io/nuget/v/Shesha.Web.Core?style=flat-square)](https://www.nuget.org/packages/Shesha.Web.Core)

--- a/shesha-core/src/Shesha.Web.FormsDesigner/README.md
+++ b/shesha-core/src/Shesha.Web.FormsDesigner/README.md
@@ -1,3 +1,5 @@
 ﻿## Shesha.Web.FormsDesigner  
 
 Shesha.Web.FormsDesigner packaged as a NuGet package
+
+[![NuGet version (Shesha.Web.FormsDesigner)](https://img.shields.io/nuget/v/Shesha.Web.FormsDesigner?style=flat-square)](https://www.nuget.org/packages/Shesha.Web.FormsDesigner/)


### PR DESCRIPTION
- Updates to the README files to have nuget versions for each class library   
- Added "how to run locally" for shesha-core solution on the shesha-core root README
- Updated the dead link to LICENSE on the shesha-core root README to point to the license on shesha-reactjs 