### PR TITLE
If 'Allow Sorting' is set to true on an Entity Picker column, togglin…

### DIFF
--- a/shesha-reactjs/src/components/entityPicker/modal.tsx
+++ b/shesha-reactjs/src/components/entityPicker/modal.tsx
@@ -241,6 +241,7 @@ export const EntityPickerModal = (props: IEntityPickerModalProps) => {
       sourceType='Entity'
       entityType={props.entityType}
       dataFetchingMode='paging'
+      sortMode='standard'
     >
       <EntityPickerModalInternal {...props} />
     </DataTableProvider>


### PR DESCRIPTION
…g the column to sort triggers a call to the getAll endpoint, but the sorting parameter is not included in the request #2514