### PR TITLE
Alexs/fix

### DIFF
--- a/shesha-core/src/Shesha.Framework/DynamicEntities/Binder/EntityModelBinder.cs
+++ b/shesha-core/src/Shesha.Framework/DynamicEntities/Binder/EntityModelBinder.cs
@@ -251,7 +251,6 @@ namespace Shesha.DynamicEntities.Binder
                                                         listType = typeof(Collection<>).MakeGenericType(paramType);
 
                                                     var idProp = paramType.GetProperty("Id");
-                                                    var idPropType = idProp.PropertyType;
                                                     var addMethod = listType.GetMethod("Add");
                                                     var addDbMethod = dbValue?.GetType().GetMethod("Add");
                                                     var removeDbMethod = dbValue?.GetType().GetMethod("Remove");

--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -116,7 +116,9 @@ export const DataList: FC<Partial<IDataListProps>> = ({
 
   const allData = useAvailableConstantsData();
   const { configurationItemMode } = useAppConfigurator();
-  const { executeAction } = useConfigurableActionDispatcher();
+  const { executeAction, useActionDynamicContext } = useConfigurableActionDispatcher();
+
+  const dynamicContext = useActionDynamicContext(props.dblClickActionConfiguration);
 
   const computedGroupStyle = getStyle(groupStyle, allData.data) ?? {};
 
@@ -327,6 +329,7 @@ export const DataList: FC<Partial<IDataListProps>> = ({
         const evaluationContext = {
           ...allData,
           selectedRow: item,
+          ...dynamicContext
         };
         executeAction({
           actionConfiguration: props.dblClickActionConfiguration,

--- a/shesha-reactjs/src/components/dataTable/cell/actionCell.tsx
+++ b/shesha-reactjs/src/components/dataTable/cell/actionCell.tsx
@@ -44,6 +44,7 @@ export const ActionCell = <D extends object = {}, V = any>(props: IActionCellPro
     http: httpClient,
     message: message,
     globalState: globalState,
+    ...dynamicContext
   };
 
 
@@ -55,7 +56,7 @@ export const ActionCell = <D extends object = {}, V = any>(props: IActionCellPro
       changeActionedRow(data.row.original);
       executeAction({
         actionConfiguration: actionConfiguration,
-        argumentsEvaluationContext: { ...evaluationContext, ...dynamicContext },
+        argumentsEvaluationContext: evaluationContext,
       });
 
     } else console.error('Action is not configured');


### PR DESCRIPTION
If a JSON property or list supports sub-selection, the endpoint fails due to recognizing the value as invalid #2657
DataTable and DataList Action Config: Error thrown when refreshing dataTableContext using refresh method from custom buttons #2614