### PR TITLE
Adding migration to increase string length for reciepientId column

### DIFF
--- a/shesha-core/src/Shesha.NHibernate/Migrations/M20250220151500.cs
+++ b/shesha-core/src/Shesha.NHibernate/Migrations/M20250220151500.cs
@@ -1,0 +1,15 @@
+﻿using FluentMigrator;
+using Shesha.FluentMigrator;
+using System;
+
+namespace Shesha.Migrations
+{
+    [Migration(20250220151500)]
+    public class M20250220151500 : OneWayMigration
+    {
+        public override void Up()
+        {
+            Alter.Column("RecipientId").OnTable("Frwk_OtpAuditItems").AsString(100).Nullable();
+        }
+    }
+}


### PR DESCRIPTION
Adding migration to increase string length for reciepientId column on  OtpAuditItems entity to account for longer recipientTexts.

Related issue: https://github.com/shesha-io/shesha-framework/issues/2537