### PR TITLE
Alexs/fix

### DIFF
--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -57,13 +57,13 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
 
   // update local store of values details
   useEffect(() => {
-    if (!props.value && props.readOnly)
+    if (!keys.length && props.readOnly)
       return;
     if (props.dataSourceType === 'entitiesList' && props.entityType
       || props.dataSourceType === 'url' && props.dataSourceUrl
     ) {
       // use _displayName from value if dataSourceType === 'entitiesList' and displayPropName is empty
-      if (props.value) {
+      if (keys.length) {
         const hasDisplayName = (Array.isArray(props.value) ? props.value[0] : props.value).hasOwnProperty('_displayName');
         if (props.dataSourceType === 'entitiesList' && !props.displayPropName && hasDisplayName) {
           setLoadingValues(false);
@@ -121,7 +121,9 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
         : outcomeValueFunc((option as ISelectOption).data, allData)
       : undefined;
 
-    const selectedFilter = selectedValue ? filterNotKeysFunc(selectedValue) : null;
+    const selectedFilter = selectedValue && (!Array.isArray(selectedValue) || selectedValue.length) 
+      ? filterNotKeysFunc(selectedValue) 
+      : null;
     source?.setPredefinedFilters([{id: 'selectedFilter', name: 'selectedFilter', expression: selectedFilter}]);
     debouncedSearch('');
     

--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -378,12 +378,12 @@ export const RawAutocomplete = (props: IAutocompleteProps) => {
 type InternalAutocompleteType = typeof Autocomplete;
 interface IInternalAutocompleteInterface extends InternalAutocompleteType {
   /** 
-  * @deprecated The method should not be used, please use Autocomplete
-  */
+   * @deprecated The method should not be used, please use Autocomplete
+   */
   Raw: typeof RawAutocomplete;
   /** 
-  * @deprecated The method should not be used, please use Autocomplete
-  */
+   * @deprecated The method should not be used, please use Autocomplete
+   */
   EntityDto: typeof EntityDtoAutocomplete;
 }
 

--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -364,13 +364,24 @@ export const EntityDtoAutocomplete = (props: IAutocompleteProps) => {
  */
 export const RawAutocomplete = (props: IAutocompleteProps) => {
   return (
-    <Autocomplete {...props} displayPropName={props.displayPropName || 'displayText'} keyPropName={props.keyPropName || 'value'} mode='single'/>
+    <Autocomplete 
+      {...props}
+      displayPropName={props.displayPropName || (props.dataSourceType === 'url' ? 'displayText' : '_displayName')}
+      keyPropName={props.keyPropName || (props.dataSourceType === 'url' ? 'value' : 'id')}
+      mode='single'
+    />
   );
 };
 
 type InternalAutocompleteType = typeof Autocomplete;
 interface IInternalAutocompleteInterface extends InternalAutocompleteType {
+  /** 
+  * @deprecated The method should not be used, please use Autocomplete
+  */
   Raw: typeof RawAutocomplete;
+  /** 
+  * @deprecated The method should not be used, please use Autocomplete
+  */
   EntityDto: typeof EntityDtoAutocomplete;
 }
 

--- a/shesha-reactjs/src/components/modelConfigurator/permissionSettings.json
+++ b/shesha-reactjs/src/components/modelConfigurator/permissionSettings.json
@@ -273,8 +273,6 @@
       "props": {}
     },
     "formKeysToPersist": [],
-    "access": 4,
-    "permissions": [ "testPermission" ],
     "version": 6,
     "dataLoaderType": "gql",
     "dataSubmitterType": "gql",

--- a/shesha-reactjs/src/components/reactTable/newTableRowEditor.tsx
+++ b/shesha-reactjs/src/components/reactTable/newTableRowEditor.tsx
@@ -16,7 +16,7 @@ export interface INewRowEditorProps {
 export const NewTableRowEditor: FC<INewRowEditorProps> = (props) => {
   const { creater, columns, headerGroups, onInitData, components } = props;
 
-  const headerGroupProps = headerGroups.length > 0 ? headerGroups[0].getHeaderGroupProps() : {};
+  const {key, ...headerGroupProps} = headerGroups.length > 0 ? headerGroups[0].getHeaderGroupProps() : {key: ''};
 
   return (
     <div className="tbody" style={{ overflowX: 'unset' }}>

--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
@@ -41,7 +41,7 @@ export const ReadOnlyDisplayFormItem: FC<IReadOnlyDisplayFormItemProps> = (props
       return '';
     }
 
-    const entityId = value?.id ?? value?.data?.id ?? value?.data ?? value;
+    const entityId = typeof value === 'object' ? value?.id ?? value?.data?.id ?? value?.data : value;
     const className = value?._className ?? value?.data?._className;
     const displayName = value?.label || value?._displayName || value?.data?._displayName;
 

--- a/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
+++ b/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
@@ -206,9 +206,9 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
         displayPropName: prev.dataSourceType === 'entitiesList' 
           ? prev['entityDisplayProperty'] 
           : prev['useRawValues']
-            ? 'displayText'
+            ? prev['valuePropName'] || 'displayText'
             : prev['valuePropName'],
-        keyPropName: prev.dataSourceType === 'url' && prev['useRawValues'] ? 'value' : undefined,
+        keyPropName: prev.dataSourceType === 'url' && prev['useRawValues'] ? prev.keyPropName || 'value' : prev.keyPropName,
       };
     })
   ,


### PR DESCRIPTION
Autocomplete component breaks when all selected entities are removed in multiple selection mode #2851
Selecting an entity property in the query builder causes the getAll endpoint of that entity to return an error #2821
Autocomplete: Configured display property is not rendered on the component #2789
Unauthorized access message displayed when accessing CRUD APIs on Entity Configurations #2848
Autocomplete Component: No pop-over displayed onHover for long selected texts #2748
Autocomplete query builder does not serialize applied dynamic filters #2749
Display name for Entity Reference shows loader when empty #2162
