### PR TITLE
handle background styles even when a stored file is not specified

### DIFF
--- a/shesha-reactjs/src/hooks/formComponentHooks.ts
+++ b/shesha-reactjs/src/hooks/formComponentHooks.ts
@@ -194,7 +194,7 @@ export const useFormComponentStyles = <TModel,>(
   const stylingBoxAsCSS = useMemo(() => pickStyleFromModel(styligBox), [stylingBox]);
 
   useDeepCompareEffect(() => {
-    if (background?.storedFile?.id && background?.type === 'storedFile')
+    if (background?.storedFile?.id && background?.type === 'storedFile'){
       fetch(`${app.backendUrl}/api/StoredFile/Download?id=${background?.storedFile?.id}`,
         { headers: { ...app.httpHeaders, "Content-Type": "application/octet-stream" } })
         .then((response) => {
@@ -205,6 +205,9 @@ export const useFormComponentStyles = <TModel,>(
           const style = getBackgroundStyle(background, jsStyle, url);
           setBackgroundStyles(style);
         });
+      }else{
+        setBackgroundStyles(getBackgroundStyle(background, jsStyle));
+      }
   }, [background, jsStyle, app.backendUrl, app.httpHeaders]);
 
   const appearanceStyle = useMemo(()=> removeUndefinedProps(


### PR DESCRIPTION

Background Type configurations do not take effect immediately (except for StoredFile)—changes only apply after refreshing the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved background style updates to ensure consistent appearance when changing background types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->