### PR TITLE
Tshepo/f/entity reference

### DIFF
--- a/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
@@ -505,6 +505,7 @@ export const getSettings = (data: IEntityReferenceControlProps) => {
                         labelAlign: 'left',
                         parentId: dataTabId,
                         collapsible: 'header',
+                        ghost: true,
                         hidden: {
                           _code: 'return getSettingValue(data?.handleSuccess) !== true;',
                           _mode: 'code',
@@ -547,6 +548,7 @@ export const getSettings = (data: IEntityReferenceControlProps) => {
                         labelAlign: 'left',
                         parentId: dataTabId,
                         collapsible: 'header',
+                        ghost: true,
                         hidden: {
                           _code: 'return getSettingValue(data?.handleFail) !== true;',
                           _mode: 'code',
@@ -611,36 +613,6 @@ export const getSettings = (data: IEntityReferenceControlProps) => {
             id: appearanceTabId,
             components: [
               ...new DesignerToolbarSettings()
-                .addCollapsiblePanel({
-                  id: nanoid(),
-                  propertyName: 'customStyle',
-                  label: 'Custom Styles',
-                  labelAlign: 'right',
-                  ghost: true,
-                  parentId: styleRouterId,
-                  collapsible: 'header',
-                  content: {
-                    id: nanoid(),
-                    components: [
-                      ...new DesignerToolbarSettings()
-                        .addSettingsInput({
-                          readOnly: {
-                            _code: 'return  getSettingValue(data?.readOnly);',
-                            _mode: 'code',
-                            _value: false,
-                          } as any,
-                          id: nanoid(),
-                          inputType: 'codeEditor',
-                          propertyName: 'style',
-                          parentId: styleRouterId,
-                          label: 'Style',
-                          description:
-                            'A script that returns the style of the element as an object. This should conform to CSSProperties',
-                        })
-                        .toJson(),
-                    ],
-                  },
-                })
                 .addPropertyRouter({
                   id: styleRouterId,
                   propertyName: 'propertyRouter1',
@@ -1147,6 +1119,36 @@ export const getSettings = (data: IEntityReferenceControlProps) => {
                                     defaultValue: 16,
                                   },
                                 ],
+                              })
+                              .toJson(),
+                          ],
+                        },
+                      })
+                      .addCollapsiblePanel({
+                        id: nanoid(),
+                        propertyName: 'customStyle',
+                        label: 'Custom Styles',
+                        labelAlign: 'right',
+                        ghost: true,
+                        parentId: styleRouterId,
+                        collapsible: 'header',
+                        content: {
+                          id: nanoid(),
+                          components: [
+                            ...new DesignerToolbarSettings()
+                              .addSettingsInput({
+                                readOnly: {
+                                  _code: 'return  getSettingValue(data?.readOnly);',
+                                  _mode: 'code',
+                                  _value: false,
+                                } as any,
+                                id: nanoid(),
+                                inputType: 'codeEditor',
+                                propertyName: 'style',
+                                parentId: styleRouterId,
+                                label: 'Style',
+                                description:
+                                  'A script that returns the style of the element as an object. This should conform to CSSProperties',
                               })
                               .toJson(),
                           ],

--- a/shesha-reactjs/src/designer-components/entityReference/utils.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/utils.ts
@@ -3,7 +3,7 @@ import { IStyleType } from "@/index";
 export const defaultStyles = (): IStyleType => {
     return {
         background: { type: 'color', color: '#fff' },
-        font: { weight: '400', size: 14, color: '#000', type: 'Segoe UI' },
+        font: { weight: '400', size: 14, type: 'Segoe UI' },
         border: {
             border: {
                 all: { width: '1px', style: 'none', color: '#d9d9d9' },

--- a/shesha-reactjs/src/designer-components/entityReference/utils.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/utils.ts
@@ -6,7 +6,7 @@ export const defaultStyles = (): IStyleType => {
         font: { weight: '400', size: 14, color: '#000', type: 'Segoe UI' },
         border: {
             border: {
-                all: { width: '1px', style: 'solid', color: '#d9d9d9' },
+                all: { width: '1px', style: 'none', color: '#d9d9d9' },
                 top: { width: '1px', style: 'solid', color: '#d9d9d9' },
                 bottom: { width: '1px', style: 'solid', color: '#d9d9d9' },
                 left: { width: '1px', style: 'solid', color: '#d9d9d9' },


### PR DESCRIPTION
#3211 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Custom Styles" panel under the "Appearance" tab has been moved to a nested position within the property router for improved organization.

- **Style**
  - Updated default styles by removing the explicit font color and disabling the overall border style, while keeping individual border sides unchanged.
  - Applied a visual update to make certain collapsible panels ("On Success Handler" and "On Fail Handler") appear with a ghost style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->