### PR TITLE
updated chevron default dimensions and dialog collapsible style

### DIFF
--- a/shesha-reactjs/src/designer-components/chevron/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/chevron/settingsForm.ts
@@ -223,7 +223,7 @@ export const getSettings = (data: any) => {
                                     propertyName: 'width',
                                     icon: 'widthIcon',
                                     tooltip: 'You can use any unit (%, px, em, etc). px by default if without unit',
-                                    defaultValue: 'auto',
+                                    defaultValue: '150px',
                                   },
                                   {
                                     type: 'textField',
@@ -233,7 +233,7 @@ export const getSettings = (data: any) => {
                                     propertyName: 'height',
                                     icon: 'heightIcon',
                                     tooltip: 'You can use any unit (%, px, em, etc). px by default if without unit',
-                                    defaultValue: 'auto',
+                                    defaultValue: '35px',
                                   },
                                 ],
                               })

--- a/shesha-reactjs/src/providers/dynamicModal/configurable-actions/show-dialog-arguments.json
+++ b/shesha-reactjs/src/providers/dynamicModal/configurable-actions/show-dialog-arguments.json
@@ -168,7 +168,7 @@
                 ]
             },
             "collapsible": "header",
-            "ghost": false,
+            "ghost": true,
             "isSimpleDesign": false
         }
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated default width and height for the "Dimensions" panel under the "Appearance" tab to 150px and 35px, respectively.
  - Changed the "Footer" panel to use a ghost style for its header, resulting in a subtler visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->