### PR TITLE
fix the side menu hiding some items on login

### DIFF
--- a/shesha-reactjs/src/providers/mainMenu/index.tsx
+++ b/shesha-reactjs/src/providers/mainMenu/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, PropsWithChildren, useContext, useEffect, useReducer, useRef
 import { setItemsAction, setLoadedMenuAction } from './actions';
 import { IConfigurableMainMenu, MAIN_MENU_CONTEXT_INITIAL_STATE, MainMenuActionsContext, MainMenuStateContext } from './contexts';
 import { uiReducer } from './reducer';
-import { FormFullName, isNavigationActionConfiguration, useSettingValue, useSheshaApplication } from '..';
+import { FormFullName, isNavigationActionConfiguration, useSettingValue, useSheshaApplication, useAuth } from '..';
 import { IHasVersion, Migrator } from '@/utils/fluentMigrator/migrator';
 import { mainMenuMigration } from './migrations/migration';
 import { getActualModel, useAvailableConstantsData } from '../form/utils';
@@ -20,6 +20,7 @@ const MainMenuProvider: FC<PropsWithChildren<MainMenuProviderProps>> = ({childre
   const [state, dispatch] = useReducer(uiReducer, {...MAIN_MENU_CONTEXT_INITIAL_STATE});
 
   const { loadingState, value: fetchedMainMenu } = useSettingValue({module: 'Shesha', name: 'Shesha.MainMenuSettings'});
+  const auth = useAuth(false);
 
   const { applicationKey, anyOfPermissionsGranted, backendUrl, httpHeaders } = useSheshaApplication();
   const allData = useAvailableConstantsData();
@@ -121,12 +122,11 @@ const MainMenuProvider: FC<PropsWithChildren<MainMenuProviderProps>> = ({childre
     dispatch(setItemsAction(getActualItemsModel(formPermissionedItems.current)));
   }, [allData]);
 
-
   useEffect(() => {
     if (loadingState === 'ready') {
       updateMainMenu(fetchedMainMenu);
     }
-  }, [loadingState]);
+  }, [loadingState, auth?.isLoggedIn]);
 
   const changeMainMenu = (value: IConfigurableMainMenu) => {
     updateMainMenu(value);


### PR DESCRIPTION
Related issue: https://github.com/shesha-io/shesha-framework/issues/3196

`updateMenu` must be called when the user logs in (auth state changes) to decide on what must be on the menu

this forces the menu to be validated when the user los because `updateMenu` will call `getActualItemsModel` which will call `anyOfPermissionsGranted` to ensure only the items relevant to the user are shown on the menu