### PR TITLE
decode the URL if the query string is part of a link in a SMS message

### DIFF
--- a/shesha-core/src/Shesha.Sms.Clickatell/Clickatell/ClickatellSmsGateway.cs
+++ b/shesha-core/src/Shesha.Sms.Clickatell/Clickatell/ClickatellSmsGateway.cs
@@ -58,8 +58,8 @@ namespace Shesha.Sms.Clickatell
             {
                 query["concat"] = messagePartsCount.ToString();
             }
-
-            var url = $"https://api.clickatell.com/http/sendmsg?{query}";
+            var decodedQuery = HttpUtility.UrlDecode(query.ToString());
+            var url = $"https://api.clickatell.com/http/sendmsg?{decodedQuery}";
             try
             {
                 // Send the GET request


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/3324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SMS sending via Clickatell by correcting the formatting of the URL query string, which may enhance message delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->