### PR TITLE
loosen autocomplete styling check

### DIFF
--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -247,7 +247,7 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
     );
   }
 
-
+  
   const {width, ...restOfDropdownStyles} = style ?? {};
 
   return (
@@ -273,7 +273,7 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
         style={style}
         size={props.size}
         ref={selectRef}
-        variant={Object.keys(style).length === 0 ? 'outlined' :'borderless'}
+        variant={style.hasOwnProperty("border") || style.hasOwnProperty("borderWidth")  ? 'borderless' : undefined}
         mode={props.value && props.mode === 'multiple' ? props.mode : undefined} // When mode is multiple and value is null, the control shows an empty tag
       >
         {freeTextValuesList /* this is need for showing free text value */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for determining the visual style of the Select component in autocomplete, so that the appearance now depends on the presence of specific border-related style properties rather than whether the style object is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->