### PR TITLE
adding Shesha logo color palette as one of the preset colors that can…

### DIFF
--- a/shesha-reactjs/src/generic-pages/settings/dynamic-theme/parameters.tsx
+++ b/shesha-reactjs/src/generic-pages/settings/dynamic-theme/parameters.tsx
@@ -5,7 +5,7 @@ import { SectionSeparator, Show } from '@/components';
 import { ColorPicker } from '@/components/colorPicker';
 import { IConfigurableTheme } from '@/providers/theme/contexts';
 import { humanizeString } from '@/utils/string';
-import { BACKGROUND_PRESET_COLORS, PRESET_COLORS, TEXT_PRESET_COLORS } from './presetColors';
+import { BACKGROUND_PRESET_COLORS, PRESET_COLORS, SHESHA_COLORS, TEXT_PRESET_COLORS } from './presetColors';
 import { formItemLayout } from './form';
 
 interface IThemeConfig {
@@ -57,7 +57,7 @@ const ThemeParameters: FC<ThemeParametersProps> = ({ value: theme, onChange, rea
         <Space>
           <ColorPicker
             title={humanizeString(colorName)}
-            presets={[{ label: 'Presets', defaultOpen: true, colors: presetColors ?? PRESET_COLORS }]}
+            presets={[{ label: 'Presets', defaultOpen: true, colors: presetColors ?? PRESET_COLORS }, { label: 'Shesha', defaultOpen: false, colors: SHESHA_COLORS }]}
             value={initialColor}
             onChange={onChange}
             readOnly={readonly}

--- a/shesha-reactjs/src/generic-pages/settings/dynamic-theme/presetColors.tsx
+++ b/shesha-reactjs/src/generic-pages/settings/dynamic-theme/presetColors.tsx
@@ -1,5 +1,17 @@
 export const PRESET_COLORS = ['#1890ff', '#25b864', '#ff6f00', '#ff4d4f', '#faad14', '#52c41a'];
 
+export const SHESHA_COLORS = [
+  '#19B411ff',
+  '#007E00ff',
+  '#7BC42Cff',
+  '#D60805ff',
+  '#FF6201ff',
+  '#F8BD00ff',
+  '#00068Dff',
+  '#0038B1ff',
+  '#000000ff',
+];
+
 export const TEXT_PRESET_COLORS = [
   '#8c8c8c',
   '#595959',


### PR DESCRIPTION
… be used on the theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Shesha" color preset group in the theme settings, allowing users to choose from a set of custom Shesha colors in the color picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->