### PR TITLE
align permissions js settings with .43

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
@@ -703,6 +703,7 @@ export const getItemSettings = (data) => {
                                 propertyName: 'permissions',
                                 label: 'Permissions',
                                 size: 'small',
+                                jsSetting: true,
                                 parentId: securityTabId
                             })
                             .toJson()

--- a/shesha-reactjs/src/designer-components/alert/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/alert/settingsForm.ts
@@ -207,6 +207,7 @@ export const getSettings = (data: IAlertComponentProps) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityTabId
               })

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -903,6 +903,7 @@ export const getSettings = () => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId
                 })

--- a/shesha-reactjs/src/designer-components/autocomplete/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/autocomplete/settingsForm.ts
@@ -1147,6 +1147,7 @@ export const getSettings = (data: IAutocompleteComponentProps) => {
                                 inputType: 'permissions',
                                 propertyName: 'permissions',
                                 label: 'Permissions',
+                                jsSetting: true,
                                 size: 'small',
                                 parentId: securityTabId
                             })

--- a/shesha-reactjs/src/designer-components/button/buttonGroup/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/button/buttonGroup/settingsForm.ts
@@ -501,6 +501,7 @@ export const getSettings = (data: IButtonGroupComponentProps) => {
                                 inputType: 'permissions',
                                 propertyName: 'permissions',
                                 label: 'Permissions',
+                                jsSetting: true,
                                 size: 'small',
                                 parentId: securityTabId
                             })

--- a/shesha-reactjs/src/designer-components/button/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/button/settingsForm.ts
@@ -587,6 +587,7 @@ export const getSettings = (data) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityTabId
               })

--- a/shesha-reactjs/src/designer-components/card/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/card/settingsForm.ts
@@ -390,6 +390,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/checkbox/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/checkbox/settingsForm.ts
@@ -205,6 +205,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/checkboxGroup/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/checkboxGroup/settingsForm.ts
@@ -346,6 +346,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/chevron/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/chevron/settingsForm.ts
@@ -336,6 +336,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                   tooltip: 'Enter a list of permissions that should be associated with this component',

--- a/shesha-reactjs/src/designer-components/collapsiblePanel/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/collapsiblePanel/settingsForm.ts
@@ -1003,6 +1003,7 @@ export const getSettings = () => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityTabId
               })

--- a/shesha-reactjs/src/designer-components/colorPicker/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/colorPicker/settingsForm.ts
@@ -269,6 +269,7 @@ export const getSettings = (data: any) => {
                                 inputType: 'permissions',
                                 propertyName: 'permissions',
                                 label: 'Permissions',
+                                jsSetting: true,
                                 size: 'small',
                                 parentId: securityTabId,
                                 tooltip: 'Enter a list of permissions that should be associated with this component'

--- a/shesha-reactjs/src/designer-components/columns/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/columns/settingsForm.ts
@@ -516,6 +516,7 @@ export const getSettings = (data: any) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityId,
                 permissions: data.permissions,

--- a/shesha-reactjs/src/designer-components/container/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/container/settingsForm.ts
@@ -911,6 +911,7 @@ export const getSettings = (data) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityTabId,
               })

--- a/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/settingsForm.ts
@@ -634,6 +634,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: '6Vw9iiDw9d0MD_Rh5cbIn',
                 })

--- a/shesha-reactjs/src/designer-components/dataTable/pager/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/pager/settingsForm.ts
@@ -220,6 +220,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: '6Vw9iiDw9d0MD_Rh5cbIn',
                 })

--- a/shesha-reactjs/src/designer-components/dataTable/quickSearch/tabbedSettingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/quickSearch/tabbedSettingsForm.ts
@@ -125,6 +125,7 @@ export const getSettings = (data: any) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityId
               })

--- a/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/columnSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/columnSettings.ts
@@ -415,7 +415,8 @@ export const getColumnSettings = (data?: any) => ({
                             "type": "settingsInput",
                             "inputType": "permissions",
                             "propertyName": "permissions",
-                            "label": "Permissions"
+                            "label": "Permissions",
+                            "jsSetting": true,
                         }
                     ]
                 }

--- a/shesha-reactjs/src/designer-components/dataTable/tableContext/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/tableContext/settingsForm.ts
@@ -533,10 +533,11 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
-                  jsSetting: true,
                 })
+      
                 .toJson(),
             ],
           },

--- a/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/filters/filterItemSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/filters/filterItemSettings.ts
@@ -20,6 +20,7 @@ export const filtersSettingsForm = new DesignerToolbarSettings()
     inputType: 'permissions',
     propertyName: 'permissions',
     label: 'Permissions',
+    jsSetting: true,
     size: 'small',
   })
   .toJson();

--- a/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/settingsForm.ts
@@ -65,6 +65,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: '6Vw9iiDw9d0MD_Rh5cbIn',
                 })

--- a/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
@@ -872,6 +872,7 @@ export const getSettings = (data: IDateFieldProps) => {
                                 inputType: 'permissions',
                                 propertyName: 'permissions',
                                 label: 'Permissions',
+                                jsSetting: true,
                                 size: 'small',
                                 parentId: securityTabId
                             })

--- a/shesha-reactjs/src/designer-components/dropdown/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dropdown/settingsForm.ts
@@ -1311,6 +1311,7 @@ export const getSettings = (data: IDropdownComponentProps) => {
                                 inputType: 'permissions',
                                 propertyName: 'permissions',
                                 label: 'Permissions',
+                                jsSetting: true,
                                 size: 'small',
                                 parentId: securityTabId
                             })

--- a/shesha-reactjs/src/designer-components/dynamicView/settings.ts
+++ b/shesha-reactjs/src/designer-components/dynamicView/settings.ts
@@ -59,8 +59,8 @@ export const getSettings = (data: DynamicViewComponentProps) => {
                                 inputType: 'permissions',
                                 propertyName: 'permissions',
                                 label: 'Permissions',
-                                size: 'small',
                                 jsSetting: true,
+                                size: 'small',
                                 parentId: '6Vw9iiDw9d0MD_Rh5cbIn'
                             })
                             .toJson()

--- a/shesha-reactjs/src/designer-components/editModeToggler/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/editModeToggler/settingsForm.ts
@@ -59,6 +59,7 @@ export const getSettings = (data: any) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityId
               })

--- a/shesha-reactjs/src/designer-components/entityPicker/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityPicker/settingsForm.ts
@@ -861,6 +861,7 @@ export const getSettings = (data) => {
                 inputType: 'permissions',
                 propertyName: 'permissions',
                 label: 'Permissions',
+                jsSetting: true,
                 size: 'small',
                 parentId: securityTabId
               })

--- a/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
@@ -1155,6 +1155,7 @@ export const getSettings = (data: IEntityReferenceControlProps) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityId,
                 })

--- a/shesha-reactjs/src/designer-components/fileUpload/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/fileUpload/settingsForm.ts
@@ -790,6 +790,7 @@ export const getSettings = () => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/htmlRender/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/htmlRender/settingsForm.ts
@@ -137,6 +137,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/kanban/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/kanban/settingsForm.ts
@@ -1114,6 +1114,7 @@ export const getSettings = (data: IKanbanProps) => {
                   propertyName: 'permissions',
                   label: 'Permissions',
                   size: 'small',
+                  jsSetting: true,
                   parentId: securityTabId,
                   tooltip: 'Enter a list of permissions that should be associated with this component',
                 })

--- a/shesha-reactjs/src/designer-components/link/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/link/settingsForm.ts
@@ -517,6 +517,7 @@ export const getSettings = (data: any) => {
                   label: 'Permissions',
                   size: 'small',
                   parentId: securityTabId,
+                  jsSetting: true,
                 })
                 .toJson(),
             ],

--- a/shesha-reactjs/src/designer-components/markdown/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/markdown/settingsForm.ts
@@ -634,6 +634,7 @@ export const getSettings = (data: any) => {
                   label: 'Permissions',
                   size: 'small',
                   parentId: securityTabId,
+                  jsSetting: true,
                 })
                 .toJson(),
             ],

--- a/shesha-reactjs/src/designer-components/numberField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/numberField/settingsForm.ts
@@ -780,6 +780,7 @@ export const getSettings = (data: INumberFieldComponentProps) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/passwordCombo/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/passwordCombo/settingsForm.ts
@@ -629,6 +629,7 @@ export const getSettings = (data: IPasswordComponentProps) => {
                                 propertyName: 'permissions',
                                 label: 'Permissions',
                                 size: 'small',
+                                jsSetting: true,
                                 parentId: nanoid()
                             })
                             .toJson()

--- a/shesha-reactjs/src/designer-components/radio/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/radio/settingsForm.ts
@@ -328,6 +328,7 @@ export const getSettings = (data: any) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/rate/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/rate/settingsForm.ts
@@ -212,6 +212,7 @@ export const getSettings = (data: IRateProps) => {
                   propertyName: 'permissions',
                   label: 'Permissions',
                   size: 'small',
+                  jsSetting: true,
                   parentId: securityTabId,
                 })
                 .toJson()

--- a/shesha-reactjs/src/designer-components/richTextEditor/formSettings.ts
+++ b/shesha-reactjs/src/designer-components/richTextEditor/formSettings.ts
@@ -651,6 +651,7 @@ export const getSettings = (data: any) => {
                   label: 'Permissions',
                   size: 'small',
                   parentId: securityTabId,
+                  jsSetting: true,
                 })
                 .toJson(),
             ],

--- a/shesha-reactjs/src/designer-components/sectionSeprator/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/sectionSeprator/settingsForm.ts
@@ -438,6 +438,7 @@ export const getSettings = (data: any) => {
                   propertyName: 'permissions',
                   label: 'Permissions',
                   size: 'small',
+                  jsSetting: true,
                   parentId: securityTabId,
                 })
                 .toJson(),

--- a/shesha-reactjs/src/designer-components/sizableColumns/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/sizableColumns/settingsForm.ts
@@ -494,6 +494,7 @@ export const getSettings = (data: any) => {
                 label: 'Permissions',
                 size: 'small',
                 parentId: securityId,
+                jsSetting: true,
                 permissions: data.permissions,
                 tooltip: "Enter a list of permissions that should be associated with this component"
               })

--- a/shesha-reactjs/src/designer-components/statistic/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/statistic/settingsForm.ts
@@ -719,6 +719,7 @@ export const getSettings = (data: any) => {
                 propertyName: 'permissions',
                 label: 'Permissions',
                 size: 'small',
+                jsSetting: true,
                 parentId: securityId
               })
               .toJson()

--- a/shesha-reactjs/src/designer-components/switch/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/switch/settingsForm.ts
@@ -197,6 +197,7 @@ export const getSettings = (data: ISwitchComponentProps) => {
                   inputType: 'permissions',
                   propertyName: 'permissions',
                   label: 'Permissions',
+                  jsSetting: true,
                   size: 'small',
                   parentId: securityTabId,
                 })

--- a/shesha-reactjs/src/designer-components/tabs/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/tabs/settingsForm.ts
@@ -933,6 +933,7 @@ export const getSettings = () => {
                                 propertyName: 'permissions',
                                 label: 'Permissions',
                                 size: 'small',
+                                jsSetting: true,
                                 parentId: securityTabId
                             })
                             .toJson()

--- a/shesha-reactjs/src/designer-components/text/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/text/settingsForm.ts
@@ -957,6 +957,7 @@ export const getSettings = (data: any) => {
                   label: 'Permissions',
                   size: 'small',
                   parentId: securityTabId,
+                  jsSetting: true,
                 })
                 .toJson(),
             ],

--- a/shesha-reactjs/src/designer-components/textArea/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/textArea/settingsForm.ts
@@ -764,7 +764,8 @@ export const getSettings = (data: any) => {
                 propertyName: 'permissions',
                 label: 'Permissions',
                 size: 'small',
-                parentId: securityId
+                parentId: securityId,
+                jsSetting: true,
               })
               .toJson()
             ]

--- a/shesha-reactjs/src/designer-components/textField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/textField/settingsForm.ts
@@ -717,6 +717,7 @@ export const getSettings = (data: ITextFieldComponentProps) => {
                                 propertyName: 'permissions',
                                 label: 'Permissions',
                                 size: 'small',
+                                jsSetting: true,
                                 parentId: securityTabId
                             })
                             .toJson()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the "Permissions" input in the Security tab across multiple component settings to be explicitly marked as a JavaScript setting for improved consistency in configuration handling. No changes to user-facing functionality or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->