### PR TITLE
James/fix/datatable

### DIFF
--- a/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/column.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/column.tsx
@@ -21,7 +21,7 @@ export const Column: FC<IProps> = ({ item }) => {
     <>
       {actionProps && actionProps.icon && <ShaIcon iconName={actionProps.icon as IconType} />}
       <span className={styles.listItemName}>{item.caption}</span>
-      {item.description && (
+      {item.description && item.columnType === "data" && (
         <Tooltip title={item.description}>
           <QuestionCircleOutlined className={styles.helpIcon} />
         </Tooltip>

--- a/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/columnSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/columnSettings.ts
@@ -270,6 +270,7 @@ export const getColumnSettings = (data?: any) => ({
                                     "inputType": "switch",
                                     "propertyName": "allowSorting",
                                     "label": "Allow Sorting",
+                                    "jsSetting": true
                                 }
                             ]
                         },

--- a/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/columnSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/columnsEditor/columnSettings.ts
@@ -108,7 +108,12 @@ export const getColumnSettings = (data?: any) => ({
                                     "type": "textArea",
                                     "propertyName": "description",
                                     "label": "Tooltip",
-                                    "labelAlign": "right"
+                                    "labelAlign": "right",
+                                    "hidden": {
+                                        "_code": "return getSettingValue(data?.columnType) !== 'data';",
+                                        "_mode": "code",
+                                        "_value": false
+                                    },
                                 },
                             ]
                         },
@@ -322,7 +327,6 @@ export const getColumnSettings = (data?: any) => ({
                             id: 'dimensionsStyleCollapsiblePanel',
                             propertyName: 'pnlDimensions',
                             label: 'Dimensions',
-                            parentId: 'styleRouter',
                             labelAlign: 'right',
                             ghost: true,
                             collapsible: 'header',
@@ -384,7 +388,6 @@ export const getColumnSettings = (data?: any) => ({
                             label: 'Background',
                             labelAlign: 'right',
                             ghost: true,
-                            parentId: 'styleRouter',
                             collapsible: 'header',
                             hidden: { _code: 'return  ["text", "link", "ghost"].includes(getSettingValue(data[`${contexts.canvasContext?.designerDevice || "desktop"}`]?.buttonType));', _mode: 'code', _value: false } as any,
                             content: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips with descriptions are now only shown for columns of type "data," ensuring other column types do not display unnecessary tooltips.
  * The "Tooltip" input field is now only visible when editing a column of type "data."
  * Adjusted visibility and configuration of appearance settings panels for improved user experience in the column editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->