### PR TITLE
Update utils.ts to change default height of menuList to 54px

### DIFF
--- a/shesha-reactjs/src/designer-components/menuList/utils.ts
+++ b/shesha-reactjs/src/designer-components/menuList/utils.ts
@@ -24,7 +24,7 @@ export const defaultStyles = (): IStyleType => {
         },
         dimensions: {
             width: '100%',
-            height: 'auto',
+            height: '54px',
             minHeight: '0px',
             maxHeight: 'auto',
             minWidth: '0px',


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/3459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the default height for menu list components to a fixed value for improved consistency in appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->