### PR TITLE
added disable style on readonly

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/buttonGroupItem.tsx
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/buttonGroupItem.tsx
@@ -39,7 +39,7 @@ export const ButtonGroupItem: FC<IButtonGroupItemProps> = ({ item, actionConfigu
 
   const { icon, label, tooltip, iconPosition, size, buttonType, borderColor, borderRadius,
     height, width, backgroundColor, fontSize, fontWeight, color, borderStyle, borderWidth,
-    readOnly, block, danger } = actualItem;
+    readOnly, block, danger, disabledStyleOnReadonly } = actualItem;
 
   const model = {
     ...actualItem,
@@ -59,14 +59,15 @@ export const ButtonGroupItem: FC<IButtonGroupItemProps> = ({ item, actionConfigu
   const prevStyles = migratePrevStyles(model, initialValues());
 
   const buttonStyles = useFormComponentStyles(prevStyles);
+  const disableReadonlyStyles = disabledStyleOnReadonly && readOnly;
 
   const newStyles = {
     ...buttonStyles.dimensionsStyles,
-    ...(['primary', 'default'].includes(item.buttonType) && buttonStyles.borderStyles),
+    ...(['primary', 'default', 'ghost'].includes(item.buttonType) && !disableReadonlyStyles && buttonStyles.borderStyles),
     ...buttonStyles.fontStyles,
-    ...(['dashed', 'default'].includes(item.buttonType) && buttonStyles.backgroundStyles),
-    ...(['primary', 'default', 'dashed'].includes(item.buttonType) && buttonStyles.shadowStyles),
-    ...buttonStyles.jsStyle,
+    ...(['dashed', 'default', 'ghost'].includes(item.buttonType) && !disableReadonlyStyles && buttonStyles.backgroundStyles),
+    ...(['primary', 'default', 'dashed', 'ghost'].includes(item.buttonType) && !disableReadonlyStyles && buttonStyles.shadowStyles),
+    ...(!disableReadonlyStyles && buttonStyles.jsStyle),
     ...buttonStyles.stylingBoxAsCSS,
     justifyContent: buttonStyles.fontStyles.textAlign,
   };

--- a/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
@@ -245,6 +245,19 @@ export const getItemSettings = () => {
                                         },
                                         {
                                             id: nanoid(),
+                                            type: 'switch',
+                                            propertyName: 'disabledStyleOnReadonly',
+                                            label: 'Disable Style On Readonly',
+                                            tooltip: 'Removes all visual styling except typography when the component becomes read-only',
+                                            jsSetting: true,
+                                            hidden: {
+                                                _code: 'return  getSettingValue(data?.itemSubType) === "separator";',
+                                                _mode: 'code',
+                                                _value: false
+                                            } as any,
+                                        },
+                                        {
+                                            id: nanoid(),
                                             type: 'textField',
                                             propertyName: 'dividerWidth',
                                             label: "Thickness",
@@ -431,7 +444,7 @@ export const getItemSettings = () => {
                                     label: 'Border',
                                     labelAlign: 'right',
                                     ghost: true,
-                                    hidden: { _code: `return  ["dashed","text", "link"].includes(getSettingValue(data?.buttonType)) || getSettingValue(data?.itemSubType) === "separator" || ${entityOrUrl};`, _mode: 'code', _value: false } as any,
+                                    hidden: { _code: `return  ["dashed","text", "link", "ghost"].includes(getSettingValue(data?.buttonType)) || getSettingValue(data?.itemSubType) === "separator" || ${entityOrUrl};`, _mode: 'code', _value: false } as any,
                                     parentId: appearanceTabId,
                                     collapsible: 'header',
                                     content: {
@@ -459,7 +472,7 @@ export const getItemSettings = () => {
                                     ghost: true,
                                     parentId: appearanceTabId,
                                     collapsible: 'header',
-                                    hidden: { _code: `return  ["text", "link", "primary"].includes(getSettingValue(data?.buttonType)) || getSettingValue(data?.itemSubType) === "separator" || ${entityOrUrl};`, _mode: 'code', _value: false } as any,
+                                    hidden: { _code: `return  ["text", "link", "primary", "ghost"].includes(getSettingValue(data?.buttonType)) || getSettingValue(data?.itemSubType) === "separator" || ${entityOrUrl};`, _mode: 'code', _value: false } as any,
                                     content: {
                                         id: backgroundStylePnlId,
                                         components: [
@@ -590,7 +603,7 @@ export const getItemSettings = () => {
                                     label: 'Shadow',
                                     labelAlign: 'right',
                                     ghost: true,
-                                    hidden: { _code: `return  ["text", "link"].includes(getSettingValue(data?.buttonType)) || getSettingValue(data?.itemSubType) === "separator" || ${entityOrUrl};`, _mode: 'code', _value: false } as any,
+                                    hidden: { _code: `return  ["text", "link", "ghost"].includes(getSettingValue(data?.buttonType)) || getSettingValue(data?.itemSubType) === "separator" || ${entityOrUrl};`, _mode: 'code', _value: false } as any,
                                     parentId: appearanceTabId,
                                     collapsible: 'header',
                                     content: {

--- a/shesha-reactjs/src/designer-components/button/button.tsx
+++ b/shesha-reactjs/src/designer-components/button/button.tsx
@@ -27,9 +27,9 @@ const ButtonComponent: IToolboxComponent<IButtonComponentProps> = {
 
     const finalStyle = {
       ...model.allStyles.dimensionsStyles,
-      ...(['primary', 'default'].includes(model.buttonType) && model.allStyles.borderStyles),
+      ...(['primary', 'default'].includes(model.buttonType) && !model.readOnly && model.allStyles.borderStyles),
       ...model.allStyles.fontStyles,
-      ...(['dashed', 'default'].includes(model.buttonType) && model.allStyles.backgroundStyles),
+      ...(['dashed', 'default'].includes(model.buttonType) && !model.readOnly && model.allStyles.backgroundStyles),
       ...(['primary', 'default'].includes(model.buttonType) && model.allStyles.shadowStyles),
       ...model.allStyles.stylingBoxAsCSS,
       ...model.allStyles.jsStyle,

--- a/shesha-reactjs/src/designer-components/button/buttonGroup/buttonGroup.tsx
+++ b/shesha-reactjs/src/designer-components/button/buttonGroup/buttonGroup.tsx
@@ -52,16 +52,17 @@ const RenderButton: FC<{ props: ButtonGroupItemProps; uuid: string; form?: FormI
     const { backgroundStyles, fontStyles, borderStyles, shadowStyles, dimensionsStyles, stylingBoxAsCSS, jsStyle } = useFormComponentStyles(model);
 
     const isPrimaryOrDefault = ['primary', 'default'].includes(buttonType);
+    const disableReadonlyStyles = model.disabledStyleOnReadonly && model.readOnly;
 
     const additionalStyles: CSSProperties = removeUndefinedProps({
-        ...fontStyles,
         ...dimensionsStyles,
+        ...(isPrimaryOrDefault && !disableReadonlyStyles && borderStyles),
+        ...fontStyles,
+        ...(['dashed', 'default'].includes(model.buttonType) && !disableReadonlyStyles && backgroundStyles),
+        ...(isPrimaryOrDefault && !disableReadonlyStyles && shadowStyles),
         ...stylingBoxAsCSS,
-        ...(isPrimaryOrDefault && borderStyles),
-        ...((isPrimaryOrDefault || buttonType === 'dashed') && shadowStyles),
-        ...((buttonType === 'default' || buttonType === 'dashed') && backgroundStyles),
-        ...jsStyle,
-        justifyContent: model?.font?.align,
+        ...(!disableReadonlyStyles && jsStyle),
+        justifyContent: model.font?.align
     });
 
 

--- a/shesha-reactjs/src/designer-components/button/buttonGroup/styles/styles.ts
+++ b/shesha-reactjs/src/designer-components/button/buttonGroup/styles/styles.ts
@@ -7,7 +7,6 @@ export const useStyles = createStyles(({ css, cx, prefixCls, token }) => {
   const a = css`
 
         .${shaButtonMenu} {
-            background: red !important;
             .${prefixCls}-menu-submenu.${prefixCls}-menu-submenu-popup & {
                 padding: unset !important;
                 button {
@@ -65,7 +64,6 @@ export const useStyles = createStyles(({ css, cx, prefixCls, token }) => {
             .${prefixCls}-menu-overflow-item,
             .${prefixCls}-menu-overflow-item.${prefixCls}-menu-item.${prefixCls}-menu-item-only-child.${shaButtonMenu} {
               padding-left: 6px !important;
-              background: orange !important;
       
               &:first-child,
               &:last-child {
@@ -90,7 +88,6 @@ export const useStyles = createStyles(({ css, cx, prefixCls, token }) => {
             .${prefixCls}-menu-overflow-item,
             .${prefixCls}-menu-overflow-item.${prefixCls}-menu-item.${prefixCls}-menu-item-only-child.${shaButtonMenu} {
               padding-left: 12px !important;
-              background: green !important;
       
               &:first-child,
               &:last-child {

--- a/shesha-reactjs/src/designer-components/button/configurableButton/style.ts
+++ b/shesha-reactjs/src/designer-components/button/configurableButton/style.ts
@@ -17,7 +17,6 @@ export const useStyles = createStyles(({ css, cx }) => {
     `);
 
     const disabled = css`
-        opacity: 0.6;
         cursor: not-allowed;
     `;
     return {

--- a/shesha-reactjs/src/providers/buttonGroupConfigurator/models.ts
+++ b/shesha-reactjs/src/providers/buttonGroupConfigurator/models.ts
@@ -55,6 +55,7 @@ export interface IButtonGroupItemBase extends IStyleType {
   borderStyle?: 'dotted' | 'solid' | 'dashed';
   borderRadius?: number;
   styles?: React.CSSProperties;
+  disabledStyleOnReadonly?: boolean;
 }
 
 export interface IButtonGroupItem extends IButtonGroupItemBase, ListItemWithId {


### PR DESCRIPTION
#2740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control whether visual styles (except typography) are disabled for buttons in read-only mode.
  * Introduced a switch in the appearance settings to enable or disable this behavior for individual buttons.

* **Improvements**
  * Expanded the range of button types affected by appearance settings and style logic.
  * Updated style logic so that certain visual styles are conditionally excluded when buttons are read-only and the new setting is enabled.

* **Style**
  * Removed specific background color and opacity styles to improve visual consistency for button components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->