### PR TITLE
James/update/datatable

### DIFF
--- a/shesha-reactjs/src/designer-components/dataTable/table/tableSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableSettings.ts
@@ -349,6 +349,17 @@ export const getSettings = (data: ITableComponentProps) => {
                                 })
                                 .addSettingsInput({
                                     id: nanoid(),
+                                    propertyName: 'onRowSave',
+                                    label: 'On Row Save',
+                                    inputType: 'codeEditor',
+                                    parentId: crudTabId,
+                                    tooltip: 'Custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations). This handler should return an object or a Promise<object>.',
+                                    hidden: { _code: 'return getSettingValue(data?.canAddInline) === "no" && getSettingValue(data?.canEditInline) === "no";', _mode: 'code', _value: false } as any,
+                                    description: 'Allows custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations).',
+                                    exposedVariables: ROW_SAVE_EXPOSED_VARIABLES,
+                                })
+                                .addSettingsInput({
+                                    id: nanoid(),
                                     propertyName: 'canDeleteInline',
                                     label: 'Can Delete Inline',
                                     inputType: 'dropdown',
@@ -421,14 +432,6 @@ export const getSettings = (data: ITableComponentProps) => {
                                     label: 'On Row Delete Success',
                                     description: 'Custom business logic to be executed after successfull deletion of a row.',
                                     hideLabel: true,
-                                })
-                                .addSettingsInput({
-                                    id: nanoid(),
-                                    propertyName: 'onRowSave',
-                                    label: 'On Row Save',
-                                    inputType: 'codeEditor',
-                                    description: 'Custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations). This handler should return an object or a Promise<object>.',
-                                    exposedVariables: ROW_SAVE_EXPOSED_VARIABLES,
                                 })
                                 .toJson()
                         ]

--- a/shesha-reactjs/src/designer-components/dataTable/table/tableSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableSettings.ts
@@ -331,6 +331,7 @@ export const getSettings = (data: ITableComponentProps) => {
                                         }
                                     ]
                                 })
+
                                 .addSettingsInputRow({
                                     id: nanoid(),
                                     hidden: { _code: 'return getSettingValue(data?.canAddInline) === "no";', _mode: 'code', _value: false } as any,
@@ -347,16 +348,21 @@ export const getSettings = (data: ITableComponentProps) => {
                                         }
                                     ]
                                 })
-                                .addSettingsInput({
+                                .addSettingsInputRow({
                                     id: nanoid(),
-                                    propertyName: 'onRowSave',
-                                    label: 'On Row Save',
-                                    inputType: 'codeEditor',
-                                    parentId: crudTabId,
-                                    tooltip: 'Custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations). This handler should return an object or a Promise<object>.',
                                     hidden: { _code: 'return getSettingValue(data?.canAddInline) === "no" && getSettingValue(data?.canEditInline) === "no";', _mode: 'code', _value: false } as any,
-                                    description: 'Allows custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations).',
-                                    exposedVariables: ROW_SAVE_EXPOSED_VARIABLES,
+                                    inputs: [
+                                        {
+                                            id: nanoid(),
+                                            propertyName: 'onNewRowSave',
+                                            label: 'On Row Save',
+                                            type: 'codeEditor',
+                                            parentId: crudTabId,
+                                            tooltip: 'Custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations). This handler should return an object or a Promise<object>.',
+                                            description: 'Allows custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations).',
+                                            exposedVariables: NEW_ROW_EXPOSED_VARIABLES,
+                                        }
+                                    ]
                                 })
                                 .addSettingsInput({
                                     id: nanoid(),

--- a/shesha-reactjs/src/designer-components/dataTable/table/tableSettings.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableSettings.ts
@@ -354,13 +354,12 @@ export const getSettings = (data: ITableComponentProps) => {
                                     inputs: [
                                         {
                                             id: nanoid(),
-                                            propertyName: 'onNewRowSave',
+                                            propertyName: 'onRowSave',
                                             label: 'On Row Save',
                                             type: 'codeEditor',
-                                            parentId: crudTabId,
                                             tooltip: 'Custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations). This handler should return an object or a Promise<object>.',
                                             description: 'Allows custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations).',
-                                            exposedVariables: NEW_ROW_EXPOSED_VARIABLES,
+                                            exposedVariables: ROW_SAVE_EXPOSED_VARIABLES,
                                         }
                                     ]
                                 })

--- a/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
@@ -347,6 +347,7 @@ export const getSettings = (data: IEntityReferenceControlProps) => {
                               type: 'dropdown',
                               allowClear: true,
                               jsSetting: true,
+                              defaultValue: 'default',
                               dropdownOptions: [
                                 { value: 'default', label: 'Default' },
                                 { value: 'custom', label: 'Custom' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The "onRowSave" setting for custom logic execution is now located under the "Data" tab and only appears when inline add and edit are disabled.
  * The "footerButtons" dropdown in dialog settings now defaults to "default" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->