### PR TITLE
Thulasizwe/en/read only style

### DIFF
--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -16,8 +16,7 @@ import { useFormEvaluatedFilter } from '@/providers/dataTable/filters/evaluateFi
 
 
 const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseProps) => {
-  const { allowClear = true } = props;
-  const { style = {} } = props;
+  const { allowClear = true, style = {} } = props;
 
   const { styles } = useStyles({ style });
 
@@ -243,13 +242,13 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
         _displayName: displayValueFunc(selected.current[0], allData),
         _className: selected.current[0]?._className
       };
+
     return (
       <ReadOnlyDisplayFormItem
         value={readonlyValue}
         type={props.mode === 'multiple' ? 'dropdownMultiple' : 'dropdown'}
         disabled={props.readOnly}
         style={style}
-        disabledStyleOnReadonly={props.disabledStyleOnReadonly}
         quickviewEnabled={props.quickviewEnabled}
         quickviewFormPath={props.quickviewFormPath}
         quickviewDisplayPropertyName={props.quickviewDisplayPropertyName || props.displayPropName}

--- a/shesha-reactjs/src/components/autocomplete/style.ts
+++ b/shesha-reactjs/src/components/autocomplete/style.ts
@@ -25,7 +25,7 @@ export const useStyles = createStyles(({ css, cx, token }, { style }: { style: C
     border-radius: ${token.borderRadius}px;
     padding: 4px 11px;
     background-color: ${token.colorBgContainer};
-    font-size: ${style?.fontSize || token.fontSize}px;
+    font-size: ${style?.fontSize || token.fontSize};
     font-family: ${style?.fontFamily || token.fontFamily};
     color: ${style?.color || token.colorText};
     

--- a/shesha-reactjs/src/components/autocomplete/style.ts
+++ b/shesha-reactjs/src/components/autocomplete/style.ts
@@ -23,7 +23,6 @@ export const useStyles = createStyles(({ css, cx, token }, { style }: { style: C
     min-height: 32px;
     border-radius: ${token.borderRadius}px;
     padding: 4px 11px;
-    background-color: ${token.colorBgContainer};
     font-size: ${style?.fontSize || token.fontSize};
     font-family: ${style?.fontFamily || token.fontFamily};
     color: ${style?.color || token.colorText};

--- a/shesha-reactjs/src/components/customFile/index.tsx
+++ b/shesha-reactjs/src/components/customFile/index.tsx
@@ -28,6 +28,7 @@ export interface ICustomFileProps extends IInputStyles {
   hideFileName?: boolean;
   container?: IStyleType;
   primaryColor?: string;
+  disabledStyleOnReadonly?: boolean;
 }
 
 export const CustomFile: FC<ICustomFileProps> = (props) => {

--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
@@ -38,7 +38,6 @@ export const ReadOnlyDisplayFormItem: FC<IReadOnlyDisplayFormItemProps> = (props
     showIcon,
     solidColor,
     showItemName,
-    disabledStyleOnReadonly = true
   } = props;
 
   const { styles } = useStyles({ textAlign: style?.textAlign || 'left' });
@@ -127,25 +126,25 @@ export const ReadOnlyDisplayFormItem: FC<IReadOnlyDisplayFormItemProps> = (props
         );
       }
       case 'time': {
-        return <InputField disabledStyleOnReadonly={disabledStyleOnReadonly} style={style} value={<ValueRenderer value={value} meta={{ dataType: 'time', dataFormat: timeFormat }} />} />;
+        return <InputField style={style} value={<ValueRenderer value={value} meta={{ dataType: 'time', dataFormat: timeFormat }} />} />;
       }
       case 'datetime': {
-        return <InputField disabledStyleOnReadonly={disabledStyleOnReadonly} style={style} value={getMoment(value, dateFormat)?.format(dateFormat) || ''} />;
+        return <InputField style={style} value={getMoment(value, dateFormat)?.format(dateFormat) || ''} />;
       }
       case 'checkbox': {
-        return <Checkbox checked={checked} defaultChecked={defaultChecked} disabled style={disabledStyleOnReadonly ? {} : style} />;
+        return <Checkbox checked={checked} defaultChecked={defaultChecked} disabled style={style} />;
       }
       case 'switch': {
-        return <Switch checked={checked} defaultChecked={defaultChecked} style={{ pointerEvents: 'none', ...(disabledStyleOnReadonly ? {} : style) }} />;
+        return <Switch checked={checked} defaultChecked={defaultChecked} style={{ pointerEvents: 'none', ...style }} />;
       }
       case 'textArea': {
-        return <div style={{ ...(disabledStyleOnReadonly ? {} : style), whiteSpace: 'pre-wrap' }}>{value}</div>;
+        return <div style={{ ...style, whiteSpace: 'pre-wrap' }}>{value}</div>;
       }
 
       default:
         break;
     }
-    return <InputField disabledStyleOnReadonly={disabledStyleOnReadonly} style={style} value={Boolean(value) && typeof value === 'object' ? JSON.stringify(value, null, 2) : value
+    return <InputField style={style} value={Boolean(value) && typeof value === 'object' ? JSON.stringify(value, null, 2) : value
     } />;
   }, [value,
     type,

--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/inputField.tsx
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/inputField.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { useStyles } from './styles/styles';
 
-function InputField({ value, style, disabledStyleOnReadonly = true, children }: { value: string | number | React.ReactNode; style?: React.CSSProperties; disabledStyleOnReadonly?: boolean; children?: React.ReactNode }) {
+function InputField({ value, style, children }: { value: string | number | React.ReactNode; style?: React.CSSProperties; enableStyleOnReadonly?: boolean; children?: React.ReactNode }) {
 
     const { styles } = useStyles();
 
-    const { fontSize, fontWeight, color, fontFamily, textAlign, width, height = '32px', minWidth, maxWidth, minHeight, maxHeight } = style || {};
+    const { fontSize, fontWeight, color, fontFamily, textAlign, height, } = style || {};
 
-    return (
-        <div style={disabledStyleOnReadonly ? { width, height, minWidth, maxWidth, minHeight, maxHeight, display: 'flex', alignItems: 'center', justifyContent: textAlign } :
-            { ...style, display: 'flex', alignItems: 'center', justifyContent: textAlign }} >
+    return value || children ? (
+        <div style={{ ...style, height: height === 'auto' ? '32px' : height, display: 'flex', alignItems: 'center', justifyContent: textAlign }} >
             <div className={styles.inputField} style={{ fontSize, fontWeight, color, fontFamily }}>{value || children}</div>
         </div>
-    );
+    ) : null;
 }
 
 export default InputField;

--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/inputField.tsx
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/inputField.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { useStyles } from './styles/styles';
 
-function InputField({ value, style, children }: { value: string | number | React.ReactNode; style?: React.CSSProperties; enableStyleOnReadonly?: boolean; children?: React.ReactNode }) {
+interface IInputFieldProps {
+    value: string | number | React.ReactNode;
+    style?: React.CSSProperties;
+    children?: React.ReactNode;
+}
+
+function InputField({ value, style, children }: IInputFieldProps) {
 
     const { styles } = useStyles();
 

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -63,6 +63,7 @@ export interface IStoredFilesRendererBaseProps extends IInputStyles {
   container?: IStyleType;
   primaryColor?: string;
   allStyles?: IFormComponentStyles;
+  disabledStyleOnReadonly?: boolean;
 }
 
 export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
@@ -92,6 +93,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
   layout,
   listType,
   gap,
+  disabledStyleOnReadonly = true,
   ...rest
 }) => {
   const { message, notification } = App.useApp();
@@ -111,7 +113,8 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       width: layout === 'vertical' ? '' : addPx(containerDimensionsStyles.width), height: layout === 'horizontal' ? '' : addPx(containerDimensionsStyles.height),
       ...containerJsStyle, ...stylingBoxAsCSS,
     },
-    style: model?.allStyles?.fullStyle, model: { gap: addPx(gap), layout: listType === 'thumbnail' && !isDragger, hideFileName: rest.hideFileName && listType === 'thumbnail', isDragger, isStub },
+    style: disabledStyleOnReadonly && disabled ?
+      { ...model.allStyles.dimensionsStyles, ...model.allStyles.fontStyles } : { ...model?.allStyles?.fullStyle }, model: { gap: addPx(gap), layout: listType === 'thumbnail' && !isDragger, hideFileName: rest.hideFileName && listType === 'thumbnail', isDragger, isStub },
     primaryColor
   });
 

--- a/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
@@ -93,7 +93,7 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style, m
     }
 
     .ant-upload-list-item-thumbnail {
-      background: ${backgroundImage ?? (backgroundColor ?? '#fff')} !important;
+      background: ${backgroundImage ?? (backgroundColor ?? 'transparent')} !important;
       border: ${borderWidth} ${borderStyle} ${borderColor};
       border-top: ${borderTopWidth ?? borderWidth} ${borderTopStyle ?? borderStyle} ${borderTopColor ?? borderColor};
       border-right: ${borderRightWidth ?? borderWidth} ${borderRightStyle ?? borderStyle} ${borderRightColor ?? borderColor};

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -284,6 +284,16 @@ export const getSettings = () => {
                 },
                 components: [
                   ...new DesignerToolbarSettings()
+                    .addSettingsInput({
+                      id: nanoid(),
+                      parentId: styleRouterId,
+                      propertyName: 'disabledStyleOnReadonly',
+                      label: 'Disable Style On Readonly',
+                      tooltip: 'Removes all visual styling except typography when the component becomes read-only',
+                      inputType: 'switch',
+                      jsSetting: true,
+                      defaultValue: true,
+                    })
                     .addCollapsiblePanel({
                       id: nanoid(),
                       propertyName: 'pnlFontStyle',

--- a/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
+++ b/shesha-reactjs/src/designer-components/autocomplete/autocomplete.tsx
@@ -1,5 +1,5 @@
 import { FileSearchOutlined } from '@ant-design/icons';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { migrateDynamicExpression } from '@/designer-components/_common-migrations/migrateUseExpression';
 import { IToolboxComponent } from '@/interfaces';
 import { DataTypes } from '@/interfaces/dataTypes';
@@ -33,6 +33,15 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
   dataTypeSupported: ({ dataType }) => dataType === DataTypes.entityReference,
   Factory: ({ model }) => {
     const allData = useAvailableConstantsData();
+    const [style, setStyle] = useState<React.CSSProperties>({});
+
+    useEffect(() => {
+      setStyle(model.disabledStyleOnReadonly !== true && model.readOnly ? {
+        ...model.allStyles.fontStyles,
+        ...model.allStyles.dimensionsStyles,
+      } : model?.allStyles?.fullStyle);
+
+    }, [model.disabledStyleOnReadonly, model.readOnly, model.allStyles]);
 
     const keyPropName = model.keyPropName || (model.dataSourceType === 'entitiesList' ? 'id' : 'value');
     const displayPropName = model.displayPropName || (model.dataSourceType === 'entitiesList' ? '_displayName' : 'displayText');
@@ -86,10 +95,7 @@ const AutocompleteComponent: IToolboxComponent<IAutocompleteComponentProps> = {
             outcomeValueFunc={outcomeValueFunc}
             displayValueFunc={displayValueFunc}
             filterKeysFunc={model.filterKeysFunc ? filterKeysFunc : undefined}
-            style={model.disabledStyleOnReadonly !== false && model.readOnly ? {
-              ...model.allStyles.fontStyles,
-              ...model.allStyles.dimensionsStyles,
-            } : model?.allStyles?.fullStyle}
+            style={style}
             size={model?.size ?? 'middle'}
             value={value}
             onChange={onChangeInternal}

--- a/shesha-reactjs/src/designer-components/button/buttonGroup/buttonGroup.tsx
+++ b/shesha-reactjs/src/designer-components/button/buttonGroup/buttonGroup.tsx
@@ -59,7 +59,7 @@ const RenderButton: FC<{ props: ButtonGroupItemProps; uuid: string; form?: FormI
         ...(isPrimaryOrDefault && !disableReadonlyStyles && borderStyles),
         ...fontStyles,
         ...(['dashed', 'default'].includes(model.buttonType) && !disableReadonlyStyles && backgroundStyles),
-        ...(isPrimaryOrDefault && !disableReadonlyStyles && shadowStyles),
+        ...((isPrimaryOrDefault || model.buttonType === 'dashed') && !disableReadonlyStyles && shadowStyles),
         ...stylingBoxAsCSS,
         ...(!disableReadonlyStyles && jsStyle),
         justifyContent: model.font?.align

--- a/shesha-reactjs/src/designer-components/button/configurableButton/index.tsx
+++ b/shesha-reactjs/src/designer-components/button/configurableButton/index.tsx
@@ -80,7 +80,8 @@ export const ConfigurableButton: FC<IConfigurableButtonProps> = props => {
       danger={props.danger}
       icon={props.icon ? <ShaIcon iconName={props.icon as IconType} /> : undefined}
       iconPosition={props.iconPosition}
-      className={classNames('sha-toolbar-btn sha-toolbar-btn-configurable', styles.configurableButton, buttonDisabled && styles.disabled)}
+      disabled={buttonDisabled}
+      className={classNames('sha-toolbar-btn sha-toolbar-btn-configurable', styles.configurableButton)}
       size={props?.size}
       style={{
         ...props?.style,

--- a/shesha-reactjs/src/designer-components/button/configurableButton/style.ts
+++ b/shesha-reactjs/src/designer-components/button/configurableButton/style.ts
@@ -16,12 +16,7 @@ export const useStyles = createStyles(({ css, cx }) => {
     }
     `);
 
-    const disabled = css`
-        opacity: 0.6;
-        cursor: not-allowed;
-    `;
     return {
-        configurableButton,
-        disabled
+        configurableButton
     };
 });

--- a/shesha-reactjs/src/designer-components/checkbox/checkbox.tsx
+++ b/shesha-reactjs/src/designer-components/checkbox/checkbox.tsx
@@ -52,9 +52,8 @@ const CheckboxComponent: IToolboxComponent<ICheckboxComponentProps, ICheckboxCom
           };
 
           return model.readOnly
-            ? <ReadOnlyDisplayFormItem checked={value} type="checkbox" disabled={model.readOnly} disabledStyleOnReadonly={model.disabledStyleOnReadonly} style={model.allStyles.fullStyle} />
-            : <Checkbox className="sha-checkbox" disabled={model.readOnly} style={model.allStyles.jsStyle} checked={value} {...events} />
-            ;
+            ? <ReadOnlyDisplayFormItem checked={value} type="checkbox" disabled={model.readOnly} style={model.disabledStyleOnReadonly && model.readOnly ? {} : model.allStyles.fullStyle} />
+            : <Checkbox className="sha-checkbox" disabled={model.readOnly} style={model.allStyles.jsStyle} checked={value} {...events} />;
         }}
       </ConfigurableFormItem>
     );

--- a/shesha-reactjs/src/designer-components/checkboxGroup/checkboxGroup.tsx
+++ b/shesha-reactjs/src/designer-components/checkboxGroup/checkboxGroup.tsx
@@ -55,8 +55,7 @@ const CheckboxGroupComponent: IToolboxComponent<IEnhancedICheckboxGoupProps, ICh
           return (
             <RefListCheckboxGroup
               {...model}
-              disabledStyleOnReadonly={model.disabledStyleOnReadonly}
-              style={model.allStyles.fullStyle}
+              style={model.disabledStyleOnReadonly && model.readOnly ? {} : model.allStyles.fullStyle}
               dataSourceUrl={calculatedModel.dataSourceUrl}
               value={value}
               defaultValue={model.defaultValue}

--- a/shesha-reactjs/src/designer-components/dateField/datePickerWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/dateField/datePickerWrapper.tsx
@@ -218,7 +218,7 @@ export const DatePickerWrapper: FC<IDateFieldProps> = (props) => {
 
   if (readOnly) {
     const format = showTime ? `${dateFormat} ${timeFormat}` : dateFormat;
-    return <ReadOnlyDisplayFormItem disabledStyleOnReadonly={disabledStyleOnReadonly} value={momentValue} type="datetime" dateFormat={format} timeFormat={timeFormat} style={allStyles.fullStyle} />;
+    return <ReadOnlyDisplayFormItem value={momentValue} type="datetime" dateFormat={format} timeFormat={timeFormat} style={allStyles.fullStyle} />;
   }
 
   return (

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -58,7 +58,7 @@ const DropdownComponent: IToolboxComponent<IDropdownComponentProps, ITextFieldCo
 
           return <Dropdown
             {...model}
-            style={!model.disabledStyleOnReadonly && model.readOnly ? { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles } : { ...model.allStyles.fullStyle, overflow: 'hidden' }}
+            style={model.disabledStyleOnReadonly && model.readOnly ? { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles } : { ...model.allStyles.fullStyle, overflow: 'hidden' }}
             {...customEvent}
             defaultValue={calculatedModel.defaultValue}
             value={value}

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -58,7 +58,7 @@ const DropdownComponent: IToolboxComponent<IDropdownComponentProps, ITextFieldCo
 
           return <Dropdown
             {...model}
-            style={model.disabledStyleOnReadonly !== false && model.readOnly ? { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles } : { ...model.allStyles.fullStyle, overflow: 'hidden' }}
+            style={!model.disabledStyleOnReadonly && model.readOnly ? { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles } : { ...model.allStyles.fullStyle, overflow: 'hidden' }}
             {...customEvent}
             defaultValue={calculatedModel.defaultValue}
             value={value}

--- a/shesha-reactjs/src/designer-components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/designer-components/entityPicker/index.tsx
@@ -102,7 +102,7 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
 
     const width = modalWidth === 'custom' && customWidth ? `${customWidth}${widthUnits}` : modalWidth;
 
-    const finalStyle = !model.disabledStyleOnReadonly && model.readOnly ? {
+    const finalStyle = model.disabledStyleOnReadonly && model.readOnly ? {
       ...model.allStyles.fontStyles,
       ...model.allStyles.dimensionsStyles,
     } : model.allStyles.fullStyle;

--- a/shesha-reactjs/src/designer-components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/designer-components/entityPicker/index.tsx
@@ -102,7 +102,7 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
 
     const width = modalWidth === 'custom' && customWidth ? `${customWidth}${widthUnits}` : modalWidth;
 
-    const finalStyle = model.disabledStyleOnReadonly !== false && model.readOnly ? {
+    const finalStyle = !model.disabledStyleOnReadonly && model.readOnly ? {
       ...model.allStyles.fontStyles,
       ...model.allStyles.dimensionsStyles,
     } : model.allStyles.fullStyle;

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -1,5 +1,5 @@
 import { FileAddOutlined } from '@ant-design/icons';
-import React, { CSSProperties, useEffect, useMemo, useState } from 'react';
+import React from 'react';
 import { FileUpload } from '@/components';
 import ConfigurableFormItem from '@/components/formDesigner/components/formItem';
 import { IFormItem, IToolboxComponent } from '@/interfaces';
@@ -8,8 +8,6 @@ import { useForm } from '@/providers/form';
 import { IConfigurableFormComponent } from '@/providers/form/models';
 import {
   evaluateValue,
-  getStyle,
-  pickStyleFromModel,
   validateConfigurableComponentSettings,
 } from '@/providers/form/utils';
 import {
@@ -21,13 +19,7 @@ import { migrateVisibility } from '@/designer-components/_common-migrations/migr
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { getSettings } from './settingsForm';
 import { defaultStyles } from './utils';
-import { jsonSafeParse, removeUndefinedProps } from '@/utils/object';
-import { getBorderStyle } from '../_settings/utils/border/utils';
-import { getFontStyle } from '../_settings/utils/font/utils';
-import { getShadowStyle } from '../_settings/utils/shadow/utils';
-import { getBackgroundStyle } from '../_settings/utils/background/utils';
 import { listType } from '../attachmentsEditor/attachmentsEditor';
-import { getDimensionsStyle } from '../_settings/utils/dimensions/utils';
 
 export interface IFileUploadProps extends IConfigurableFormComponent, Omit<IFormItem, 'name'>, IStyleType {
   ownerId: string;
@@ -52,73 +44,12 @@ const FileUploadComponent: IToolboxComponent<IFileUploadProps> = {
   isInput: true,
   isOutput: true,
   Factory: ({ model }) => {
-    const { backendUrl, httpHeaders } = useSheshaApplication();
+    const { backendUrl } = useSheshaApplication();
 
-    const dimensions = model?.dimensions;
-    const border = model?.border;
-    const font = model?.font;
-    const shadow = model?.shadow;
-    const background = model?.background;
-    const jsStyle = getStyle(model?.style, model);
-
-    const dimensionsStyles = useMemo(() => getDimensionsStyle(dimensions), [dimensions]);
-    const borderStyles = useMemo(() => getBorderStyle(border, jsStyle), [border, jsStyle]);
-    const fontStyles = useMemo(() => getFontStyle(font), [font]);
-    const [backgroundStyles, setBackgroundStyles] = useState({});
-    const shadowStyles = useMemo(() => getShadowStyle(shadow), [shadow]);
-
-    useEffect(() => {
-      let objectUrl = '';
-
-      const fetchStyles = async () => {
-        let storedImageUrl = '';
-
-        try {
-          if (background?.storedFile?.id && background?.type === 'storedFile') {
-            const response = await fetch(`${backendUrl}/api/StoredFile/Download?id=${background?.storedFile?.id}`, {
-              headers: { ...httpHeaders, 'Content-Type': 'application/octet-stream' },
-            });
-
-            if (!response.ok) {
-              throw new Error(`Failed to fetch background: ${response.status} ${response.statusText}`);
-            }
-
-            const blob = await response.blob();
-            objectUrl = URL.createObjectURL(blob);
-            storedImageUrl = objectUrl;
-          }
-        } catch (error) {
-          console.error('Error fetching background image:', error);
-        }
-
-        const style = getBackgroundStyle(background, jsStyle, storedImageUrl);
-        setBackgroundStyles(style);
-      };
-
-      fetchStyles();
-
-      // Cleanup function to revoke the object URL when component unmounts or when dependencies change
-      return () => {
-        if (objectUrl) {
-          URL.revokeObjectURL(objectUrl);
-        }
-      };
-    }, [background, backendUrl, httpHeaders]);
-
-    const styling = jsonSafeParse(model.stylingBox || '{}');
-    const stylingBoxAsCSS = pickStyleFromModel(styling);
-
-    const additionalStyles: CSSProperties = removeUndefinedProps({
-      ...stylingBoxAsCSS,
-      ...dimensionsStyles,
-      ...borderStyles,
-      ...fontStyles,
-      ...backgroundStyles,
-      ...shadowStyles,
-      jsStyle,
-    });
-
-    const finalStyle = removeUndefinedProps(additionalStyles);
+    const finalStyle = !model.disabledStyleOnReadonly && model.readOnly ? {
+      ...model.allStyles.fontStyles,
+      ...model.allStyles.dimensionsStyles,
+    } : model.allStyles.fullStyle;
 
     // TODO: refactor and implement a generic way for values evaluation
     const { formSettings, formMode } = useForm();

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -46,7 +46,7 @@ const FileUploadComponent: IToolboxComponent<IFileUploadProps> = {
   Factory: ({ model }) => {
     const { backendUrl } = useSheshaApplication();
 
-    const finalStyle = !model.disabledStyleOnReadonly && model.readOnly ? {
+    const finalStyle = model.disabledStyleOnReadonly && model.readOnly ? {
       ...model.allStyles.fontStyles,
       ...model.allStyles.dimensionsStyles,
     } : model.allStyles.fullStyle;

--- a/shesha-reactjs/src/designer-components/fileUpload/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/fileUpload/settingsForm.ts
@@ -250,6 +250,16 @@ export const getSettings = () => {
                   },
                   components: [
                     ...new DesignerToolbarSettings()
+                      .addSettingsInput({
+                        id: nanoid(),
+                        parentId: styleRouterId,
+                        propertyName: 'disabledStyleOnReadonly',
+                        label: 'Disable Style On Readonly',
+                        tooltip: 'Removes all visual styling except typography when the component becomes read-only',
+                        inputType: 'switch',
+                        jsSetting: true,
+                        defaultValue: true,
+                      })
                       .addCollapsiblePanel({
                         id: nanoid(),
                         propertyName: 'pnlFontStyle',

--- a/shesha-reactjs/src/designer-components/radio/radio.tsx
+++ b/shesha-reactjs/src/designer-components/radio/radio.tsx
@@ -55,7 +55,7 @@ const Radio: IToolboxComponent<IEnhancedRadioProps, IRadioComopnentCalulatedValu
           return (
             <RadioGroup
               {...restProps}
-              style={model.allStyles.fullStyle}
+              style={model.disabledStyleOnReadonly && model.readOnly ? {} : model.allStyles.fullStyle}
               value={value}
               defaultValue={model.defaultValue}
               dataSourceUrl={calculatedModel.dataSourceUrl}

--- a/shesha-reactjs/src/designer-components/switch/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/switch/settingsForm.ts
@@ -125,6 +125,16 @@ export const getSettings = (data: ISwitchComponentProps) => {
                   },
                   components: [
                     ...new DesignerToolbarSettings()
+                      .addSettingsInput({
+                        id: nanoid(),
+                        parentId: styleRouterId,
+                        propertyName: 'disabledStyleOnReadonly',
+                        label: 'Disable Style On Readonly',
+                        tooltip: 'Removes all visual styling except typography when the component becomes read-only',
+                        inputType: 'switch',
+                        jsSetting: true,
+                        defaultValue: true,
+                      })
                       .addCollapsiblePanel({
                         id: nanoid(),
                         propertyName: 'pnlDimensions',


### PR DESCRIPTION
#2740
#3540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Disable Style On Readonly" setting to several components, allowing users to remove all visual styling except typography when components are read-only.

* **Style**
  * Updated styling logic across multiple components to conditionally apply or remove styles based on the new read-only setting.
  * Adjusted background fallback color and spinner font size for improved visual consistency.

* **Refactor**
  * Simplified and unified style application logic for read-only and disabled states in various components.
  * Removed unused props and streamlined component interfaces related to read-only styling.
  * Changed button disabled state handling to use native attributes instead of CSS classes.
  * Cleaned up style computations and imports in file upload and other components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->