### PR TITLE
update default text size to 14 from 16

### DIFF
--- a/shesha-reactjs/src/designer-components/text/utils.ts
+++ b/shesha-reactjs/src/designer-components/text/utils.ts
@@ -117,7 +117,7 @@ export const defaultStyles = (textType: string): IStyleType => {
   };
 };
 
-export const remToPx = (remValue: string | number, rootFontSize = 16): number | null => {
+export const remToPx = (remValue: string | number, rootFontSize = 14): number | null => {
   if (typeof remValue !== 'string') return rootFontSize;
   const match = remValue.trim().match(/^([0-9.]+)rem$/);
   if (!match) return rootFontSize;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the default root font size used for rem-to-pixel conversions from 16 to 14, which may affect sizing calculations throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->