### PR TITLE
added editor adapter to the form designer components (is used for cel…

### DIFF
--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Domain/OrganisationTest.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Domain/OrganisationTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Domain
 {
+    /*
     public class OrganisationTest : Organisation
     {
         [CascadeUpdateRules(true, true)]
@@ -15,6 +16,7 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Domain
         [AuditedAsManyToMany]
         public virtual IList<Person> DirectPersons { get; set; } = new List<Person>();
     }
+    */
 
     /* AS: Experiments for using one table for linking two entities with several list properties with the same entity types
     [Table("ShaAutoGen_OrganisationTest_DirectPersons_Reference")]

--- a/shesha-reactjs/src/components/dataTable/cell/dataCell.tsx
+++ b/shesha-reactjs/src/components/dataTable/cell/dataCell.tsx
@@ -18,7 +18,8 @@ import { ReferenceListCell } from './default/referenceListCell';
 import { useCrud } from '@/providers/crudContext';
 import { useDeepCompareMemo } from '@/hooks';
 import { useFormDesignerComponents } from '@/providers/form/hooks';
-import { editorAdapters, updateModelExcludeFiltered } from '@/components/formComponentSelector/adapters';
+import { updateModelExcludeFiltered } from '@/components/formComponentSelector/adapters';
+import { getEditorAdapter } from '@/components/formComponentSelector';
 
 export const DefaultDataDisplayCell = <D extends object = {}, V = number>(props: IDataCellProps<D, V>) => {
   const { columnConfig } = props;
@@ -94,7 +95,7 @@ const ComponentWrapper: FC<IComponentWrapperProps> = (props) => {
       readOnly: actualModel.readOnly === undefined ? props.readOnly : actualModel.readOnly,
     };
 
-    const adapter = editorAdapters[customComponent.type];
+    const adapter = getEditorAdapter(component);
 
     if (component.linkToModelMetadata && propertyMeta && adapter?.propertiesFilter) {
       editorModel = updateModelExcludeFiltered(editorModel, component.linkToModelMetadata({

--- a/shesha-reactjs/src/components/formComponentSelector/adapters.ts
+++ b/shesha-reactjs/src/components/formComponentSelector/adapters.ts
@@ -9,9 +9,7 @@ import NumberComponent from '@/designer-components/numberField/numberField';
 import RefListStatusComponent from '@/designer-components/refListStatus/index';
 import TextFieldComponent from '@/designer-components/textField/textField';
 import { TimeFieldComponent } from '@/designer-components/timeField';
-import { IDictionary } from '@/interfaces';
-
-type PropertyInclusionPredicate = (name: string) => boolean;
+import { IDictionary, IEditorAdapter, PropertyInclusionPredicate } from '@/interfaces';
 
 export const updateModelExcludeFiltered = (model: any, updatedModel: any, filter: PropertyInclusionPredicate) => {
   Object.keys(updatedModel).forEach((key) => {
@@ -21,10 +19,6 @@ export const updateModelExcludeFiltered = (model: any, updatedModel: any, filter
   });
   return model;
 };
-
-export interface IEditorAdapter {
-  propertiesFilter: PropertyInclusionPredicate;
-}
 
 export const getAllExceptPredicate = (names: string[]): PropertyInclusionPredicate => {
   return (name: string) => {

--- a/shesha-reactjs/src/components/formComponentSelector/index.tsx
+++ b/shesha-reactjs/src/components/formComponentSelector/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Space, Select } from 'antd';
 import { DefaultOptionType } from 'antd/lib/select';
-import { DEFAULT_FORM_SETTINGS, IConfigurableFormComponent, IToolboxComponent } from '@/interfaces';
+import { DEFAULT_FORM_SETTINGS, IConfigurableFormComponent, IEditorAdapter, IToolboxComponent, IToolboxComponents } from '@/interfaces';
 import { IPropertyMetadata } from '@/interfaces/metadata';
 import { nanoid } from '@/utils/uuid';
 import { useFormDesignerComponents } from '@/providers/form/hooks';
@@ -25,6 +25,20 @@ export interface IFormComponentSelectorProps {
   propertyMeta?: IPropertyMetadata;
 }
 
+export const getEditorAdapter = (component: IToolboxComponent): IEditorAdapter | undefined => {
+  return component.editorAdapter ?? editorAdapters[component.type];
+};
+
+const getEditorAdapterByType = (components: IToolboxComponents, type: string): IEditorAdapter | undefined => {
+  const component = components[type];
+  return component ? getEditorAdapter(component) : undefined;
+};
+
+const canBeUsedAsEditor = (component: IToolboxComponent): boolean => {
+  const adapter = getEditorAdapter(component);
+  return Boolean(adapter);
+};
+
 export const FormComponentSelector: FC<IFormComponentSelectorProps> = (props) => {
   const { componentType, noSelectionItem, value, onChange, readOnly = false, propertyMeta } = props;
 
@@ -34,8 +48,8 @@ export const FormComponentSelector: FC<IFormComponentSelectorProps> = (props) =>
     const result: IToolboxComponent[] = [];
     for (const key in allComponents) {
       if (allComponents.hasOwnProperty(key)) {
-        if (!editorAdapters[key]) continue; // skip components without adapters
         const component = allComponents[key];
+        if (!canBeUsedAsEditor(component)) continue; // skip components without adapters
 
         if (
           component.isHidden !== true &&
@@ -118,7 +132,9 @@ export const FormComponentSelector: FC<IFormComponentSelectorProps> = (props) =>
   };
 
   const propertyFilter = (name: string): boolean => {
-    const adapter = value?.type ? editorAdapters[value.type] : null;
+    const adapter = value?.type 
+      ? getEditorAdapterByType(allComponents, value.type)
+      : null;
     if (!adapter) return false;
 
     return !adapter.propertiesFilter || adapter.propertiesFilter(name);

--- a/shesha-reactjs/src/designer-components/notes/notesComponent.tsx
+++ b/shesha-reactjs/src/designer-components/notes/notesComponent.tsx
@@ -23,8 +23,6 @@ import { INote } from '@/providers/notes/contexts';
 export interface INotesProps extends IConfigurableFormComponent {
   ownerId: string;
   ownerType: string;
-  ownerIdExpression: string;
-  ownerTypeExpression: string;
   savePlacement?: 'left' | 'right';
   autoSize?: boolean;
   allowDelete?: boolean;

--- a/shesha-reactjs/src/designer-components/notes/settingsForm.json
+++ b/shesha-reactjs/src/designer-components/notes/settingsForm.json
@@ -158,7 +158,7 @@
         "components": [
           {
             "id": "417ee22e-a49d-44f2-a1c7-fef32ec87503",
-            "type": "propertyAutocomplete",
+            "type": "textField",
             "propertyName": "ownerId",
             "parentId": "2y9SNudmMM0Wd1Sc_YI1ng",
             "label": "Owner Id",

--- a/shesha-reactjs/src/interfaces/formDesigner.ts
+++ b/shesha-reactjs/src/interfaces/formDesigner.ts
@@ -52,6 +52,12 @@ export interface ComponentFactoryArguments<TModel extends IConfigurableFormCompo
 
 export type FormFactory<TModel extends IConfigurableFormComponent = IConfigurableFormComponent> = FC<ComponentFactoryArguments<TModel>>;
 
+export type PropertyInclusionPredicate = (name: string) => boolean;
+
+export interface IEditorAdapter {
+  propertiesFilter: PropertyInclusionPredicate;
+}
+
 export interface IToolboxComponent<TModel extends IConfigurableFormComponent = IConfigurableFormComponent /*, TSettingsContext = any*/> {
   /**
    * Type of the component. Must be unique in the project.
@@ -146,6 +152,8 @@ export interface IToolboxComponent<TModel extends IConfigurableFormComponent = I
    * Returns true if the property should be calculated for the actual model (calculated from JS code)
    */
   actualModelPropertyFilter?: (name: string) => boolean;
+  
+  editorAdapter?: IEditorAdapter;
 }
 
 export interface SettingsMigrationContext {


### PR DESCRIPTION
…l editors in tables only)

temporary commented out test entity OrganisationTest to prevent issues on PostgreSql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form designer with new adapter logic for editor components, improving flexibility and modularity.
  * Extended toolbox components to support custom editor adapters.

* **Improvements**
  * Updated the Notes component settings to use a simple text field for the "Owner Id" instead of an autocomplete selector.
  * Streamlined how editor adapters are retrieved and validated across form components for better maintainability.

* **Breaking Changes**
  * Removed the properties "ownerIdExpression" and "ownerTypeExpression" from the Notes component’s public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->