### PR TITLE
remove enableStyleOnReadonly for button group

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
@@ -245,19 +245,6 @@ export const getItemSettings = () => {
                                         },
                                         {
                                             id: nanoid(),
-                                            type: 'switch',
-                                            propertyName: 'enableStyleOnReadonly',
-                                            label: 'Enable Style On Readonly',
-                                            tooltip: 'Removes all visual styling except typography when the component becomes read-only',
-                                            jsSetting: true,
-                                            hidden: {
-                                                _code: 'return  getSettingValue(data?.itemSubType) === "separator";',
-                                                _mode: 'code',
-                                                _value: false
-                                            } as any,
-                                        },
-                                        {
-                                            id: nanoid(),
                                             type: 'textField',
                                             propertyName: 'dividerWidth',
                                             label: "Thickness",

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -286,12 +286,16 @@ export const getSettings = () => {
                   ...new DesignerToolbarSettings()
                     .addSettingsInput({
                       id: nanoid(),
-                      parentId: styleRouterId,
-                      propertyName: 'enableStyleOnReadonly',
-                      label: 'Style Readonly',
-                      tooltip: 'Removes all visual styling except typography when the component becomes read-only',
                       inputType: 'switch',
-                      jsSetting: true
+                      propertyName: 'enableStyleOnReadonly',
+                      label: 'Enable Style On Readonly',
+                      tooltip: 'Removes all visual styling except typography when the component becomes read-only',
+                      jsSetting: true,
+                      hidden: {
+                        _code: 'return  getSettingValue(data?.itemSubType) === "separator";',
+                        _mode: 'code',
+                        _value: false
+                      } as any,
                     })
                     .addCollapsiblePanel({
                       id: nanoid(),


### PR DESCRIPTION
#3540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the label and visibility logic for the "Enable Style On Readonly" option in appearance settings.
  * Removed the "Enable Style On Readonly" setting from the button group configurator to streamline options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->