### PR TITLE
Thulasizwe/en/drag wrapper

### DIFF
--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -231,6 +231,7 @@ export const FileUpload: FC<IFileUploadProps> = ({
       icon={!fileInfo ? <UploadOutlined /> : <PictureOutlined />}
       type="link"
       disabled={!showUploadButton}
+      style={{width: '100%', height: '100%'}}
     >
       {listType === 'text' ? `(press to upload)` : null}
     </Button>

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -217,6 +217,8 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style, m
           font-family: ${fontFamily} !important;
         }
         ${listType === 'thumbnail' && style}
+        width: 100%;
+        height: 100%;
       }
 
       .ant-upload-list-item-container {

--- a/shesha-reactjs/src/components/formDesigner/configurableFormComponent/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/configurableFormComponent/index.tsx
@@ -160,7 +160,7 @@ const ConfigurableFormComponentDesignerInner: FC<IConfigurableFormComponentDesig
   };
 
   const getFlexBasis = () => {
-    if (isFileList || isFileUpload) return desktopConfig.container?.dimensions?.minWidth;
+    if (isFileList || isFileUpload) return desktopConfig.container?.dimensions?.width;
     return dimensionsStyles?.maxWidth || dimensionsStyles?.width;
   };
 

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -48,7 +48,7 @@ const FileUploadComponent: IToolboxComponent<IFileUploadProps> = {
 
     const finalStyle = !model.enableStyleOnReadonly && model.readOnly ? {
       ...model.allStyles.fontStyles,
-      ...model.listType === 'thumbnail' ? model.allStyles.dimensionsStyles : {},
+      ...model.allStyles.dimensionsStyles,
     } : {...model.allStyles.fullStyle};
 
     // TODO: refactor and implement a generic way for values evaluation


### PR DESCRIPTION
fixed flex basis for filelist to use % in a container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the file upload button to fully expand and fill its container for better visual consistency.
  * Updated button styles in the file upload component to ensure full width and height coverage.

* **Refactor**
  * Adjusted layout logic for file upload and file list components to use container width for sizing.
  * Unified style merging behavior in the file upload component for read-only states, ensuring consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->