### PR TITLE
Standardise on 'Component' terminology instead of 'Widget' when refer…

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
@@ -30,7 +30,7 @@ export const DesignerMainArea: FC<IDesignerMainAreaProps> = () => {
     const { styles } = useStyles();
 
     const leftSidebarProps = useMemo(() => 
-      readOnly ? null : { title: 'Builder Widgets', content: () => <Toolbox />, placeholder: 'Builder Widgets' }
+      readOnly ? null : { title: 'Builder Components', content: () => <Toolbox />, placeholder: 'Builder Components' }
     , [readOnly]);
 
     return (

--- a/shesha-reactjs/src/components/formDesigner/toolbox.tsx
+++ b/shesha-reactjs/src/components/formDesigner/toolbox.tsx
@@ -17,7 +17,7 @@ const Toolbox: FC<IProps> = () => {
   const builderItems = useMemo(() => {
     const dataSources = [...formDs];
 
-    const defaultItems = [{ key: '1', label: 'Widgets', children: <ToolboxComponents /> }];
+    const defaultItems = [{ key: '1', label: 'Components', children: <ToolboxComponents /> }];
 
     if (isEntityMetadata(currentMeta?.metadata))
       dataSources.push({


### PR DESCRIPTION
…ring to form compontents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated UI terminology in the Form Designer from “Widgets” to “Components” for clearer, consistent labeling.
  - In editable mode, the left sidebar title and placeholder now display “Builder Components” instead of “Builder Widgets”; read-only behavior remains unchanged.
  - Renamed the first Toolbox category to “Components” to align with the new terminology.
  - These changes are cosmetic only and do not alter functionality or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->