### PR TITLE
comfirm before delete

### DIFF
--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -54,7 +54,7 @@ export const FileUpload: FC<IFileUploadProps> = ({
   const { styles } = useStyles();
   const uploadButtonRef = useRef(null);
   const uploadDraggerSpanRef = useRef(null);
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
 
   const onCustomRequest = ({ file /*, onError, onSuccess*/ }: RcCustomRequestOptions) => {
     // call action from context
@@ -78,9 +78,23 @@ export const FileUpload: FC<IFileUploadProps> = ({
     }
   };
 
+
+  const showDeleteConfirmation = () => {
+    modal.confirm({
+      title: 'Delete Attachment',
+      content: 'Are you sure you want to delete this attachment?',
+      okText: 'Yes',
+      cancelText: 'Cancel',
+      okType: 'danger',
+      onOk: () => {
+        deleteFile();
+      }
+    });
+  };
+
   const onDeleteClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     e.preventDefault();
-    deleteFile();
+    showDeleteConfirmation();
   };
 
   const fileControls = () => {

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -106,7 +106,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     hideFileName: hideFileName && listType === 'thumbnail', isDragger, gap: addPx(gap), styles: jsSstyles
   });
 
-  const { message, notification } = App.useApp();
+  const { message, notification, modal } = App.useApp();
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewImage, setPreviewImage] = useState({ url: '', uid: '', name: '' });
   const [imageUrls, setImageUrls] = useState<{ [key: string]: string }>(fileList.reduce((acc, { uid, url }) => ({ ...acc, [uid]: url }), {}));
@@ -190,7 +190,8 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       }
     },
     onRemove(file) {
-      deleteFile(file.uid);
+      showDeleteConfirmation(file);
+      return false; // Prevent default removal behavior
     },
     customRequest(options: any) {
       // It used to be RcCustomRequestOptions, but it doesn't seem to be found anymore
@@ -232,6 +233,19 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     iconRender,
   };
 
+
+  const showDeleteConfirmation = (file: UploadFile) => {
+    modal.confirm({
+      title: 'Delete Attachment',
+      content: 'Are you sure you want to delete this attachment?',
+      okText: 'Yes',
+      cancelText: 'Cancel',
+      okType: 'danger',
+      onOk: () => {
+        deleteFile(file.uid);
+      }
+    });
+  };
 
   const renderUploadContent = () => {
     return (


### PR DESCRIPTION
Implement Delete Confirmation Dialog for Attachments on File and Filelist #3716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a confirmation dialog when deleting attachments/files to prevent accidental removals.
  - Users now see a modal with clear Yes/Cancel options before deletion proceeds.
  - Confirmation applies across file upload and stored file lists, including drag-and-drop and standard removal flows.
  - Deletion only occurs after explicit confirmation; canceling leaves files untouched.
  - No changes to public interfaces; behavior is an in-app UX safeguard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->