### PR TITLE
pass template settings to code editor

### DIFF
--- a/shesha-reactjs/src/designer-components/inputComponent/index.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/index.tsx
@@ -75,7 +75,7 @@ export const InputComponent: FC<Omit<ISettingsInputProps, 'hidden'>> = (props) =
         wrapInTemplate: props.wrapInTemplate ?? true,
         value: value,
         onChange: onChange,
-        templateSettings: { functionName: functionName },
+        templateSettings: props.templateSettings ?? { functionName: functionName  },
         exposedVariables: defaultExposedVariables
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now customize the code editor’s template settings when configuring the input component. If no custom settings are provided, the previous default is used. This adds flexibility without breaking existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->