### PR TITLE
fix:  showDeleteConfirm declaration

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -172,6 +172,20 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     return getFileIcon(type);
   };
 
+
+  const showDeleteConfirmation = (file: UploadFile) => {
+    modal.confirm({
+      title: 'Delete Attachment',
+      content: 'Are you sure you want to delete this attachment?',
+      okText: 'Yes',
+      cancelText: 'Cancel',
+      okType: 'danger',
+      onOk: () => {
+        deleteFile(file.uid);
+      }
+    });
+  };
+
   const props: DraggerProps = {
     name: '',
     accept: allowedFileTypes?.join(','),
@@ -231,20 +245,6 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       showDownloadIcon: true,
     },
     iconRender,
-  };
-
-
-  const showDeleteConfirmation = (file: UploadFile) => {
-    modal.confirm({
-      title: 'Delete Attachment',
-      content: 'Are you sure you want to delete this attachment?',
-      okText: 'Yes',
-      cancelText: 'Cancel',
-      okType: 'danger',
-      onOk: () => {
-        deleteFile(file.uid);
-      }
-    });
   };
 
   const renderUploadContent = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when deleting attachments. Users now see “Delete Attachment” with the message “Are you sure you want to delete this attachment?” and actions “Yes” (danger) and “Cancel.”
  * Deletion only proceeds after confirmation, preventing accidental removals and improving safety without altering existing workflows or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->