### PR TITLE
James/b/683

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -217,7 +217,7 @@ export const getSettings = () => {
                       type: 'editableTagGroupProps',
                       description: 'File types that can be accepted.',
                       jsSetting: true,
-                      tooltip: "The file typeName should consist a dot before the name .png",
+                      tooltip: "The file typeName should consist a dot before the name, for example .png",
                     }
                   ]
                 })

--- a/shesha-reactjs/src/designer-components/fileUpload/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/fileUpload/settingsForm.ts
@@ -206,7 +206,7 @@ export const getSettings = () => {
                       label: 'Allowed File Types',
                       type: 'editableTagGroupProps',
                       description: 'File types that can be accepted.',
-                      tooltip: "The file typeName should consist a dot before the name .png",
+                      tooltip: "The file typeName should consist a dot before the name, for example: .png",
 
                     },
                   ],


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added clear tooltips to the “Allowed File Types” field in Attachments Editor and File Upload settings, clarifying the required format (e.g., .png).
  - Improved in-app guidance for configuring accepted file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->