### PR TITLE
remove default values from textarea and slider

### DIFF
--- a/shesha-reactjs/src/designer-components/slider/settings.ts
+++ b/shesha-reactjs/src/designer-components/slider/settings.ts
@@ -60,11 +60,6 @@ export const settingsFormMarkup = new DesignerToolbarSettings()
         ...new DesignerToolbarSettings()
           .addNumberField({
             id: nanoid(),
-            propertyName: 'defaultValue',
-            label: 'Default Value',
-          })
-          .addNumberField({
-            id: nanoid(),
             propertyName: 'min',
             label: 'Minimum',
           })

--- a/shesha-reactjs/src/designer-components/textArea/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/textArea/settingsForm.ts
@@ -82,15 +82,6 @@ export const getSettings = (data: any) => {
                 parentId: commonTabId,
                 inputs: [
                   {
-                    type: 'textField',
-                    id: nanoid(),
-                    propertyName: "initialValue",
-                    parentId: commonTabId,
-                    label: "Default Value",
-                    jsSetting: true,
-                    size: "small",
-                  },
-                  {
                     type: 'switch',
                     id: nanoid(),
                     propertyName: 'passEmptyStringByDefault',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Slider settings: Removed the “Default Value” field from the Data panel. Existing fields (e.g., Min, Max) remain available.
  * Text Area settings: Removed the “Default Value” field from the Common tab. Other inputs (e.g., placeholder, tooltip, pass empty string) remain unchanged.
  * Overall: Streamlines configuration by reducing redundant fields while preserving existing behavior and layout of the settings panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->