### PR TITLE
Coerce/numberField null/undefined values to zero

### DIFF
--- a/shesha-reactjs/src/designer-components/numberField/control.tsx
+++ b/shesha-reactjs/src/designer-components/numberField/control.tsx
@@ -8,13 +8,24 @@ interface IProps {
   disabled: boolean;
   model: INumberFieldComponentProps;
   onChange?: Function;
-  value?: number;
+  value?: number | null;
 }
 
 const NumberFieldControl: FC<IProps> = ({ disabled, model, onChange, value }) => {
   const allData = useAvailableConstantsData();
 
   const style = model.style;
+
+  // Coerce null/undefined values to 0
+  const coercedValue = value ?? 0;
+
+  // Create a wrapped onChange that coerces null/undefined to 0
+  const wrappedOnChange = (value: number | string | null) => {
+    const coercedChangeValue = value ?? 0;
+    if (onChange) {
+      onChange(coercedChangeValue);
+    }
+  };
 
   const inputProps: InputNumberProps = {
     className: 'sha-number-field',
@@ -26,12 +37,12 @@ const NumberFieldControl: FC<IProps> = ({ disabled, model, onChange, value }) =>
     size: model?.size,
     style: style ? getStyle(style, allData.data, allData.globalState) : { width: '100%' },
     step: model?.highPrecision ? model?.stepNumeric : model?.stepNumeric,
-    ...customOnChangeValueEventHandler(model, allData, onChange),
-    defaultValue: model?.defaultValue,
+    ...customOnChangeValueEventHandler(model, allData, wrappedOnChange),
+    defaultValue: model?.defaultValue ?? 0,
     changeOnWheel: false,
   };
 
-  return <InputNumber value={value} {...inputProps} stringMode={model?.highPrecision} />;
+  return <InputNumber value={coercedValue} {...inputProps} stringMode={model?.highPrecision} />;
 };
 
 export default NumberFieldControl;

--- a/shesha-reactjs/src/designer-components/numberField/numberField.tsx
+++ b/shesha-reactjs/src/designer-components/numberField/numberField.tsx
@@ -37,16 +37,19 @@ const NumberFieldComponent: IToolboxComponent<INumberFieldComponentProps> = {
     return (
       <ConfigurableFormItem
         model={model}
-        initialValue={model?.defaultValue ? evaluateString(model?.defaultValue, { formData, formMode, globalState }) : undefined}
+        initialValue={model?.defaultValue ? evaluateString(model?.defaultValue, { formData, formMode, globalState }) : 0}
       >
         {(value, onChange) => {
+          // Coerce null/undefined values to 0
+          const coercedValue = value ?? 0;
+          
           return model.readOnly ? (
             <ReadOnlyDisplayFormItem
               type="number"
-              value={getNumberFormat(value, getDataProperty(properties, model.propertyName))}
+              value={getNumberFormat(coercedValue, getDataProperty(properties, model.propertyName))}
             />
           ) : (
-            <NumberFieldControl disabled={model.readOnly} model={model} value={value} onChange={onChange} />
+            <NumberFieldControl disabled={model.readOnly} model={model} value={coercedValue} onChange={onChange} />
           );
         }}
       </ConfigurableFormItem>


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/3765#issue-3359284844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Number inputs now coerce null/undefined to a numeric fallback (uses field min when >0, otherwise 0) and emit that initial value on mount to avoid blank/NaN states.
  * Read-only views consistently format and display coerced numeric values.
  * Controlled/uncontrolled number fields normalize input (strings → numbers, NaN handled) so onChange receives a stable numeric value.

* **UX Improvements**
  * More predictable, consistent behavior for number fields across edit and read-only modes, including high-precision inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->