### PR TITLE
Number Component Does Not Allow Saving null Value #3765

### DIFF
--- a/shesha-core/src/Shesha.Framework/Validations/EntityPropertyValidator.cs
+++ b/shesha-core/src/Shesha.Framework/Validations/EntityPropertyValidator.cs
@@ -4,6 +4,7 @@ using Shesha.DynamicEntities.Cache;
 using Shesha.DynamicEntities.Dtos;
 using Shesha.Extensions;
 using Shesha.Metadata;
+using Shesha.Reflection;
 using Shesha.Utilities;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -158,8 +159,11 @@ namespace Shesha.Validations
                     }
                     break;
                 case DataTypes.Number:
-                    var b = double.TryParse(value?.ToString(), out double val);
+                    var stringValue = value?.ToString();
+                    if (string.IsNullOrWhiteSpace(stringValue) && propInfo != null && propInfo.IsNullable())
+                        return true;
 
+                    var b = double.TryParse(stringValue, out double val);
                     if (!b)
                     {
                         validationResult.Add(new ValidationResult($"Property '{friendlyName}' should be in a number format"));

--- a/shesha-reactjs/src/designer-components/numberField/numberField.tsx
+++ b/shesha-reactjs/src/designer-components/numberField/numberField.tsx
@@ -90,7 +90,9 @@ const NumberFieldComponent: IToolboxComponent<INumberFieldComponentProps, INumbe
         {(value, onChange) => {
           const customEvents = calculatedModel.eventHandlers;
           const onChangeInternal = (val: number | string | null) => {
-            const newValue = val === undefined || val === null ? undefined : model.highPrecision ? val : parseInt(val + '', 10);
+            const newValue = val !== undefined && val !== null && model.highPrecision
+              ? parseInt(val + '', 10)
+              : val;
             customEvents.onChange(newValue);
             onChange(newValue);
           };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optional number fields now accept blank inputs without triggering validation errors.
  * High-precision number inputs are parsed only when appropriate, avoiding unintended integer coercion.
  * Preserves null values on change, preventing unexpected conversion to undefined and improving form state consistency.
  * Overall, numeric field handling is more predictable across forms, reducing false validation failures and improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->