### PR TITLE
add defaultvalue to editmodeselector

### DIFF
--- a/shesha-reactjs/src/components/editModeSelector/index.tsx
+++ b/shesha-reactjs/src/components/editModeSelector/index.tsx
@@ -8,21 +8,43 @@ export interface IReadOnlyModeSelectorProps {
   readOnly?: boolean;
   onChange?: (value: EditMode) => void;
   size?: 'small' | 'middle' | 'large';
+  defaultValue?: EditMode;
 }
 
 const EditModeSelector: FC<IReadOnlyModeSelectorProps> = (props) => {
+  const { value, defaultValue, onChange, size, readOnly } = props;
 
-  const val: EditMode = props.value === false
-    ? 'readOnly'
-    : !props.value || props.value === true
-      ? 'inherited'
-      : props.value;
+  const finalValue = defaultValue !== undefined ? defaultValue : value;
+
+  const getEditModeValue = (val: boolean | EditMode | undefined): EditMode => {
+    if (val === false) {
+      return 'readOnly';
+    }
+    if (val === true || val === undefined) {
+      return 'inherited';
+    }
+    return val;
+  };
+
+  const editModeValue = getEditModeValue(finalValue);
 
   return (
-    <Radio.Group buttonStyle='solid' value={val} onChange={(e) => props.onChange(e.target.value)} size={props.size} disabled={props.readOnly}>
-      <Radio.Button key='editable' value="editable"><Icon icon='editIcon' hint='Editable' /></Radio.Button>
-      <Radio.Button key='readOnly' value="readOnly"><Icon icon='readonlyIcon' hint='Read only' /></Radio.Button>
-      <Radio.Button key='inherited' value="inherited"><Icon icon='inheritIcon' hint='Inherited' /></Radio.Button>
+    <Radio.Group
+      buttonStyle='solid'
+      value={editModeValue}
+      onChange={(e) => onChange?.(e.target.value)}
+      size={size}
+      disabled={readOnly}
+    >
+      <Radio.Button key='editable' value='editable'>
+        <Icon icon='editIcon' hint='Editable' />
+      </Radio.Button>
+      <Radio.Button key='readOnly' value='readOnly'>
+        <Icon icon='readonlyIcon' hint='Read only' />
+      </Radio.Button>
+      <Radio.Button key='inherited' value='inherited'>
+        <Icon icon='inheritIcon' hint='Inherited' />
+      </Radio.Button>
     </Radio.Group>
   );
 };

--- a/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/settingsForm.ts
@@ -93,6 +93,7 @@ export const getSettings = (data: any) => {
                       label: 'Edit Mode',
                       labelAlign: 'right',
                       jsSetting: true,
+                      defaultValue: 'editable',
                     },
                   ],
                 })

--- a/shesha-reactjs/src/designer-components/inputComponent/index.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/index.tsx
@@ -183,7 +183,7 @@ export const InputComponent: FC<Omit<ISettingsInputProps, 'hidden'>> = (props) =
         case 'buttonGroupConfigurator':
             return <ButtonGroupConfigurator readOnly={readOnly} size={size} value={value} onChange={onChange} />;
         case 'editModeSelector':
-            return <EditModeSelector readOnly={readOnly} value={value} onChange={onChange} size={size} />;
+            return <EditModeSelector readOnly={readOnly} value={value} defaultValue={defaultValue} onChange={onChange} size={size} />;
         case 'dynamicItemsConfigurator':
             return <DynamicActionsConfigurator editorConfig={{ ...props } as IDynamicActionsConfiguratorComponentProps} readOnly={readOnly} value={value} onChange={onChange} size={size} />;
         case 'autocomplete':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Edit Mode Selector now supports a default value, allowing forms and components to start with a preselected mode.
  - Advanced Filter Button settings now default the Edit Mode to “Editable” for faster setup.
  - Improved handling of read-only and inherited states for more predictable selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->