### PR TITLE
en: delete confirm

### DIFF
--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -76,7 +76,7 @@ export const FileUpload: FC<IFileUploadProps> = ({
   const { theme } = useTheme();
   const uploadDraggerSpanRef = useRef(null);
   const hiddenUploadInputRef = useRef<HTMLInputElement>(null);
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
   const [imageUrl, setImageUrl] = useState('');
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewImage, setPreviewImage] = useState({ url: '', uid: '', name: '' });
@@ -109,9 +109,22 @@ export const FileUpload: FC<IFileUploadProps> = ({
     }
   };
 
+  const showDeleteConfirmation = () => {
+    modal.confirm({
+      title: 'Delete Attachment',
+      content: 'Are you sure you want to delete this attachment?',
+      okText: 'Yes',
+      cancelText: 'Cancel',
+      okType: 'danger',
+      onOk: () => {
+        deleteFile();
+      }
+    });
+  };
+
   const onDeleteClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     e.preventDefault();
-    deleteFile();
+    showDeleteConfirmation();
   };
 
   const onPreview = () => {

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -97,7 +97,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
   enableStyleOnReadonly = true,
   ...rest
 }) => {
-  const { message, notification } = App.useApp();
+  const { message, notification, modal } = App.useApp();
   const { httpHeaders } = useSheshaApplication();
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewImage, setPreviewImage] = useState({ url: '', uid: '', name: '' });
@@ -194,6 +194,20 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     return <ValidationErrors error="The provided StoredFileId is invalid" />;
   }
 
+
+  const showDeleteConfirmation = (file) => {
+    modal.confirm({
+      title: 'Delete Attachment',
+      content: 'Are you sure you want to delete this attachment?',
+      okText: 'Yes',
+      cancelText: 'Cancel',
+      okType: 'danger',
+      onOk: () => {
+        deleteFile(file.uid);
+      }
+    });
+  };
+
   const props: DraggerProps = {
     name: '',
     accept: allowedFileTypes?.join(','),
@@ -212,7 +226,8 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       }
     },
     onRemove(file) {
-      deleteFile(file.uid);
+      showDeleteConfirmation(file);
+      return false;
     },
     customRequest(options: any) {
       // It used to be RcCustomRequestOptions, but it doesn't seem to be found anymore


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a confirmation dialog before deleting attachments across file upload and stored file list views.
  - Users now see a “Delete Attachment” modal with Yes/Cancel options; deletion proceeds only after confirmation.
  - Prevents accidental removals and ensures a consistent, safer deletion experience.
  - The default remove action is paused until confirmation, with no changes to other upload or listing behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->