### PR TITLE
File upload prevents record saving when using script in Wizard component 

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -214,6 +214,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     multiple,
     fileList,
     disabled,
+    pastable: false,
     onChange(info: UploadChangeParam) {
       const { status } = info.file;
       if (status === 'done') {

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -20,6 +20,7 @@ import { migrateVisibility } from '@/designer-components/_common-migrations/migr
 import { getFormApi } from '@/providers/form/formApi';
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { containerDefaultStyles, defaultStyles } from './utils';
+import { GHOST_PAYLOAD_KEY } from '@/utils/form';
 
 export type layoutType = 'vertical' | 'horizontal' | 'grid';
 export type listType = 'text' | 'thumbnail';
@@ -45,6 +46,7 @@ export interface IAttachmentsEditorProps extends IConfigurableFormComponent, IIn
   hideFileName?: boolean;
   container?: IStyleType;
   primaryColor?: string;
+  removeFieldFromPayload?: boolean;
 }
 
 const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
@@ -85,8 +87,9 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
     return (
       // Add GHOST_PAYLOAD_KEY to remove field from the payload
       // File list uses propertyName only for support Required feature
-      <ConfigurableFormItem model={{ ...model }}>
+      <ConfigurableFormItem model={{ ...model, propertyName: !model.removeFieldFromPayload && model.propertyName ? model.propertyName : `${GHOST_PAYLOAD_KEY}_${model.propertyName}` }}>
         {(value, onChange) => {
+
           return (
             <StoredFilesProvider
               ownerId={Boolean(ownerId) ? ownerId : Boolean(data?.id) ? data?.id : ''}

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -157,7 +157,8 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
       onFileChanged: migrateFormApi.withoutFormData(prev?.onFileChanged),
     }))
     .add<IAttachmentsEditorProps>(6, (prev) => ({ ...prev, listType: !prev.listType ? 'text' : prev.listType, filesLayout: prev.filesLayout ?? 'horizontal' }))
-    .add<IAttachmentsEditorProps>(7, (prev) => ({ ...prev, desktop: { ...defaultStyles(), container: containerDefaultStyles() }, mobile: { ...defaultStyles() }, tablet: { ...defaultStyles() } })),
+    .add<IAttachmentsEditorProps>(7, (prev) => ({ ...prev, desktop: { ...defaultStyles(), container: containerDefaultStyles() }, mobile: { ...defaultStyles() }, tablet: { ...defaultStyles() } }))
+    .add<IAttachmentsEditorProps>(8, (prev) => ({ ...prev, removeFieldFromPayload: true })),
 };
 
 export default AttachmentsEditor;

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -49,17 +49,28 @@ export const getSettings = () => {
                   tooltip: 'If checked, the field will not be included in the submitted payload',
                   jsSetting: true,
                 })
-                .addContextPropertyAutocomplete({
+                .addContainer({
                   id: nanoid(),
-                  propertyName: 'propertyName',
-                  label: 'Property Name',
+                  propertyName: 'container',
+                  label: 'Container',
                   parentId: commonTabId,
-                  size: 'small',
-                  styledLabel: true,
-                  validate: {
-                    required: true,
-                  },
-                  jsSetting: true,
+                  hidden: { _code: 'return getSettingValue(data?.removeFieldFromPayload);', _mode: 'code', _value: false } as any,
+                  components: [
+                    ...new DesignerToolbarSettings()
+                    .addContextPropertyAutocomplete({
+                      id: nanoid(),
+                      propertyName: 'propertyName',
+                      label: 'Property Name',
+                      parentId: commonTabId,
+                      size: 'small',
+                      styledLabel: true,
+                      validate: {
+                        required: true,
+                      },
+                      jsSetting: true,
+                    })
+                    .toJson()
+                  ]
                 })
                 .addSettingsInput({
                   id: nanoid(),

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -41,6 +41,14 @@ export const getSettings = () => {
             id: commonTabId,
             components: [
               ...new DesignerToolbarSettings()
+                .addSettingsInput({
+                  id: nanoid(),
+                  propertyName: 'removeFieldFromPayload',
+                  label: 'Exclude From Form Data',
+                  inputType: 'switch',
+                  tooltip: 'If checked, the field will not be included in the submitted payload',
+                  jsSetting: true,
+                })
                 .addContextPropertyAutocomplete({
                   id: nanoid(),
                   propertyName: 'propertyName',

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -23,6 +23,7 @@ export const getSettings = () => {
   const pnlShadowStyleId = nanoid();
   const customStylePnlId = nanoid();
   const pnlFontStyleId = nanoid();
+  const containerId = nanoid();
 
   return {
     components: new DesignerToolbarSettings()
@@ -50,7 +51,7 @@ export const getSettings = () => {
                   jsSetting: true,
                 })
                 .addContainer({
-                  id: nanoid(),
+                  id: containerId,
                   propertyName: 'container',
                   label: 'Container',
                   parentId: commonTabId,
@@ -61,7 +62,7 @@ export const getSettings = () => {
                       id: nanoid(),
                       propertyName: 'propertyName',
                       label: 'Property Name',
-                      parentId: commonTabId,
+                      parentId: containerId,
                       size: 'small',
                       styledLabel: true,
                       validate: {

--- a/shesha-reactjs/src/providers/storedFiles/index.tsx
+++ b/shesha-reactjs/src/providers/storedFiles/index.tsx
@@ -108,8 +108,8 @@ const StoredFilesProvider: FC<PropsWithChildren<IStoredFilesProviderProps>> = ({
   }, [value]);
 
   useEffect(() => {
-    const val = state?.fileList?.length > 0 ? state.fileList : value || [];
-      if (typeof onChange === 'function' && value !== val) {
+    const val = state.fileList?.length > 0 ? state.fileList : [];
+        if (typeof onChange === 'function' && value !== val) {
         onChange(val);
       };
   }, [state.fileList]);
@@ -145,6 +145,7 @@ const StoredFilesProvider: FC<PropsWithChildren<IStoredFilesProviderProps>> = ({
       const patient = typeof eventData === 'object' ? eventData : (JSON.parse(eventData) as IStoredFile);
 
       dispatch(onFileDeletedAction(patient?.id));
+      onChange?.(state.fileList?.filter(file => file.id !== patient?.id) || []);
     });
   }, []);
   //#endregion


### PR DESCRIPTION
#3705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exposed a downloadFile action in stored files for easier file retrieval.
  - Attachments Editor: added an “Exclude From Form Data” switch; shows property selector only when not excluded.
  - Migration enables “Exclude From Form Data” by default for existing configs.

- Bug Fixes
  - Improved syncing of file lists and propagation of deletions to parent components.
  - Disabled paste-to-upload in the drag-and-drop uploader to avoid unintended uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->