### PR TITLE
align progress style with appearance tab

### DIFF
--- a/shesha-reactjs/src/designer-components/progress/index.tsx
+++ b/shesha-reactjs/src/designer-components/progress/index.tsx
@@ -73,12 +73,12 @@ const ProgressComponent: IToolboxComponent<IProgressProps> = {
       let isLineOrCircle = false;
 
       if (progressType === 'line') {
-        color = lineStrokeColor?.toString();
+        color = lineStrokeColor?.toString() ?? strokeColor?.toString();
         isLineOrCircle = true;
       }
 
       if (progressType === 'circle') {
-        color = circleStrokeColor?.toString();
+        color = circleStrokeColor?.toString() ?? strokeColor?.toString();
         isLineOrCircle = true;
       }
 

--- a/shesha-reactjs/src/designer-components/progress/settings.ts
+++ b/shesha-reactjs/src/designer-components/progress/settings.ts
@@ -249,17 +249,53 @@ export const getSettings = (data: any) => {
                                 jsSetting: true,
                                 parentId: styleRouterId,
                               })
+                              // .addSettingsInputRow({
+                              //   id: nanoid(),
+                              //   parentId: styleRouterId,
+                              //   hidden: { _code: 'return getSettingValue(data?.progressType) !== "line";', _mode: 'code', _value: false },
+                              //   inputs: [
+                              //     {
+                              //       type: 'colorPicker',
+                              //       id: nanoid(),
+                              //       propertyName: 'lineStrokeColor',
+                              //       label: 'Line Stroke Color',
+                              //       tooltip: "The color of line progress bar",
+                              //       jsSetting: true,
+                              //     }
+                              //   ]
+                              // })
                               .addSettingsInputRow({
                                 id: nanoid(),
                                 parentId: styleRouterId,
-                                hidden: { _code: 'return getSettingValue(data?.progressType) !== "line";', _mode: 'code', _value: false },
+                                hidden: { _code: 'return getSettingValue(data?.progressType) !== "circle";', _mode: 'code', _value: false },
                                 inputs: [
                                   {
-                                    type: 'colorPicker',
+                                    type: 'numberField',
                                     id: nanoid(),
-                                    propertyName: 'lineStrokeColor',
-                                    label: 'Stroke Color',
-                                    tooltip: "The color of progress bar",
+                                    propertyName: 'gapDegree',
+                                    label: 'Gap Degree',
+                                    tooltip: "The gap degree of half circle, 0 ~ 295",
+                                    jsSetting: true,
+                                  }
+                                ]
+                              })
+                              .addSettingsInputRow({
+                                id: nanoid(),
+                                parentId: styleRouterId,
+                                hidden: { _code: 'return !["circle", "dashboard"].includes(getSettingValue(data?.progressType));', _mode: 'code', _value: false },
+                                inputs: [
+                                  {
+                                    type: 'dropdown',
+                                    id: nanoid(),
+                                    propertyName: 'gapPosition',
+                                    label: 'Gap Position',
+                                    tooltip: "The gap position",
+                                    dropdownOptions: [
+                                      { label: 'Top', value: 'top' },
+                                      { label: 'Bottom', value: 'bottom' },
+                                      { label: 'Left', value: 'left' },
+                                      { label: 'Right', value: 'right' },
+                                    ],
                                     jsSetting: true,
                                   }
                                 ]
@@ -275,20 +311,6 @@ export const getSettings = (data: any) => {
                                     propertyName: 'gapDegree',
                                     label: 'Gap Degree',
                                     tooltip: "The gap degree of half circle, 0 ~ 295",
-                                    jsSetting: true,
-                                  },
-                                  {
-                                    type: 'dropdown',
-                                    id: nanoid(),
-                                    propertyName: 'gapPosition',
-                                    label: 'Gap Position',
-                                    tooltip: "The gap position",
-                                    dropdownOptions: [
-                                      { label: 'Top', value: 'top' },
-                                      { label: 'Bottom', value: 'bottom' },
-                                      { label: 'Left', value: 'left' },
-                                      { label: 'Right', value: 'right' },
-                                    ],
                                     jsSetting: true,
                                   }
                                 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gap Degree setting for circle and dashboard progress types.
  * Expanded Gap Position to both circle and dashboard.
  * Made Width setting specific to circle/dashboard and streamlined settings visibility by progress type.

* **Bug Fixes**
  * Progress color now falls back to the general stroke color when a type-specific color isn’t set for line or circle, ensuring consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->