### PR TITLE
Cherry pick columns fix from main into 44

### DIFF
--- a/shesha-reactjs/src/designer-components/columns/columns.tsx
+++ b/shesha-reactjs/src/designer-components/columns/columns.tsx
@@ -125,7 +125,7 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
 
     const hasBorder = border && !border.hideBorder && (
       [border.border?.all, border.border?.top, border.border?.right, border.border?.bottom,
-    border.border?.left]
+      border.border?.left]
         .some(side => isValidBorderWidth(side?.width))
     );
 

--- a/shesha-reactjs/src/designer-components/columns/columns.tsx
+++ b/shesha-reactjs/src/designer-components/columns/columns.tsx
@@ -119,12 +119,16 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
     const finalStyle = removeUndefinedProps({ ...additionalStyles, fontWeight: Number(model?.font?.weight?.split(' - ')[0]) || 400 });
 
     // Add padding when border is configured to prevent border from touching components
+    const isValidBorderWidth = (width: string | number | undefined): boolean => {
+      return Boolean(width && width !== '0px' && width !== 0 && width !== '0');
+    };
+
     const hasBorder = border && !border.hideBorder && (
-      (border.border?.all?.width && border.border.all.width !== '0px' && border.border.all.width !== 0 && border.border.all.width !== '0') ||
-      (border.border?.top?.width && border.border.top.width !== '0px' && border.border.top.width !== 0 && border.border.top.width !== '0') ||
-      (border.border?.right?.width && border.border.right.width !== '0px' && border.border.right.width !== 0 && border.border.right.width !== '0') ||
-      (border.border?.bottom?.width && border.border.bottom.width !== '0px' && border.border.bottom.width !== 0 && border.border.bottom.width !== '0') ||
-      (border.border?.left?.width && border.border.left.width !== '0px' && border.border.left.width !== 0 && border.border.left.width !== '0')
+      isValidBorderWidth(border.border?.all?.width) ||
+      isValidBorderWidth(border.border?.top?.width) ||
+      isValidBorderWidth(border.border?.right?.width) ||
+      isValidBorderWidth(border.border?.bottom?.width) ||
+      isValidBorderWidth(border.border?.left?.width)
     );
 
 

--- a/shesha-reactjs/src/designer-components/columns/columns.tsx
+++ b/shesha-reactjs/src/designer-components/columns/columns.tsx
@@ -120,21 +120,19 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
 
     // Add padding when border is configured to prevent border from touching components
     const isValidBorderWidth = (width: string | number | undefined): boolean => {
-      return Boolean(width && width !== '0px' && width !== 0 && width !== '0');
+      return !!(width && width !== '0px' && width != 0);
     };
 
     const hasBorder = border && !border.hideBorder && (
-      isValidBorderWidth(border.border?.all?.width) ||
-      isValidBorderWidth(border.border?.top?.width) ||
-      isValidBorderWidth(border.border?.right?.width) ||
-      isValidBorderWidth(border.border?.bottom?.width) ||
-      isValidBorderWidth(border.border?.left?.width)
+      [border.border?.all, border.border?.top, border.border?.right, border.border?.bottom,
+    border.border?.left]
+        .some(side => isValidBorderWidth(side?.width))
     );
 
 
-    const hPad = `${((gutterX || 0) / 2) + 8}px`;
-    const vPadTop = `${((gutterY || 0) / 2) + 8}px`;
-    const vPadBottom = `${((gutterY || 0) / 2) + 3}px`; // keep the reduced bottom margin intent
+    const hPad = `${((gutterX || 0) / 2) + 2}px`;
+    const vPadTop = `${((gutterY || 0) / 2) + 2}px`;
+    const vPadBottom = `${((gutterY || 0) / 2)}px`; // keep the reduced bottom margin intent
     const containerPadding = hasBorder
       ? { paddingTop: vPadTop, paddingLeft: hPad, paddingRight: hPad, paddingBottom: vPadBottom }
       : {};

--- a/shesha-reactjs/src/designer-components/columns/columns.tsx
+++ b/shesha-reactjs/src/designer-components/columns/columns.tsx
@@ -10,7 +10,7 @@ import ParentProvider from '@/providers/parentProvider/index';
 import { jsonSafeParse, removeUndefinedProps } from '@/utils/object';
 import { SplitCellsOutlined } from '@ant-design/icons';
 import { Col, Row } from 'antd';
-import React, { CSSProperties, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { migratePrevStyles } from '../_common-migrations/migrateStyles';
 import { removeComponents } from '../_common-migrations/removeComponents';
 import { getBackgroundStyle } from '../_settings/utils/background/utils';
@@ -108,7 +108,7 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
     }
     const styling = jsonSafeParse(model.stylingBox || '{}');
     const stylingBoxAsCSS = pickStyleFromModel(styling);
-    const additionalStyles: CSSProperties = removeUndefinedProps({
+    const additionalStyles = removeUndefinedProps({
       ...stylingBoxAsCSS,
       ...dimensionsStyles,
       ...borderStyles,
@@ -118,12 +118,30 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
 
     const finalStyle = removeUndefinedProps({ ...additionalStyles, fontWeight: Number(model?.font?.weight?.split(' - ')[0]) || 400 });
 
+    // Add padding when border is configured to prevent border from touching components
+    const hasBorder = border && !border.hideBorder && (
+      (border.border?.all?.width && border.border.all.width !== '0px' && border.border.all.width !== 0 && border.border.all.width !== '0') ||
+      (border.border?.top?.width && border.border.top.width !== '0px' && border.border.top.width !== 0 && border.border.top.width !== '0') ||
+      (border.border?.right?.width && border.border.right.width !== '0px' && border.border.right.width !== 0 && border.border.right.width !== '0') ||
+      (border.border?.bottom?.width && border.border.bottom.width !== '0px' && border.border.bottom.width !== 0 && border.border.bottom.width !== '0') ||
+      (border.border?.left?.width && border.border.left.width !== '0px' && border.border.left.width !== 0 && border.border.left.width !== '0')
+    );
+
+
+    const containerPadding = hasBorder ? { 
+      paddingTop: '8px', 
+      paddingLeft: '8px', 
+      paddingRight: '8px', 
+      paddingBottom: '3px' // Reduced to account for form item bottom margin
+    } : {};
+    const boxSizing = hasBorder ? { boxSizing: 'border-box' } : {};
+
     // Validate and normalize columns to prevent overflow
     const validatedColumns = validateColumns(columns);
 
     return (
-      <div style={{ ...getLayoutStyle(model, { data, globalState }), ...finalStyle }}>
-        <Row gutter={[gutterX || 0, gutterY || 0]} style={{ margin: 0, height: 'auto' }}>
+      <div style={{ ...getLayoutStyle(model, { data, globalState }), ...containerPadding, ...boxSizing, ...finalStyle }}>
+        <Row gutter={[gutterX || 0, gutterY || 0]}>
           <ParentProvider model={model}>
             {validatedColumns &&
               validatedColumns.map((col, index) => (
@@ -133,8 +151,6 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
                   offset={col.offset}
                   pull={col.pull}
                   push={col.push}
-                  className="sha-designer-column"
-                  style={{ height: 'auto', minHeight: 'auto' }}
                 >
                   <ComponentsContainer
                     containerId={col.id}

--- a/shesha-reactjs/src/designer-components/columns/columns.tsx
+++ b/shesha-reactjs/src/designer-components/columns/columns.tsx
@@ -128,14 +128,13 @@ const ColumnsComponent: IToolboxComponent<IColumnsComponentProps> = {
     );
 
 
-    const containerPadding = hasBorder ? { 
-      paddingTop: '8px', 
-      paddingLeft: '8px', 
-      paddingRight: '8px', 
-      paddingBottom: '3px' // Reduced to account for form item bottom margin
-    } : {};
+    const hPad = `${((gutterX || 0) / 2) + 8}px`;
+    const vPadTop = `${((gutterY || 0) / 2) + 8}px`;
+    const vPadBottom = `${((gutterY || 0) / 2) + 3}px`; // keep the reduced bottom margin intent
+    const containerPadding = hasBorder
+      ? { paddingTop: vPadTop, paddingLeft: hPad, paddingRight: hPad, paddingBottom: vPadBottom }
+      : {};
     const boxSizing = hasBorder ? { boxSizing: 'border-box' } : {};
-
     // Validate and normalize columns to prevent overflow
     const validatedColumns = validateColumns(columns);
 


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/2946#issuecomment-3298964410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved columns layout with border-aware padding and box-sizing for consistent spacing when borders are enabled.
  * Applied calculated container padding and box-sizing to the outer wrapper for more predictable spacing.
  * Rows and columns now size naturally by removing forced margins/heights and inline constraints.

* **Refactor**
  * Simplified style handling and typing for additional styles.
  * Removed legacy column class usage and streamlined Row/Col rendering to rely on container-driven sizing.
  * Added support for border, dimension, and shadow styling helpers for more flexible visual composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->