### PR TITLE
Teboho/fix-dropdown-boarder-3927

### DIFF
--- a/shesha-reactjs/src/components/modelConfigurator/styles/styles.ts
+++ b/shesha-reactjs/src/components/modelConfigurator/styles/styles.ts
@@ -48,6 +48,12 @@ export const useStyles = createStyles(({ css, cx, prefixCls }) => {
                       .sidebar-body {
                         height: calc(100% - 35px);
                         overflow: auto;
+
+                        /* Remove border styles from read-only display form items in properties panel */
+                        .read-only-display-form-item {
+                          border: none !important;
+                          border-radius: 0 !important;
+                        }
                       }
                     }
                   }

--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
@@ -149,7 +149,11 @@ export const ReadOnlyDisplayFormItem: FC<IReadOnlyDisplayFormItemProps> = (props
     quickviewFormPath,
     quickviewDisplayPropertyName,
     quickviewGetEntityUrl,
-    quickviewWidth
+    quickviewWidth,
+    showIcon,
+    showItemName,
+    solidColor,
+    tagStyle
   ]);
 
   return (

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -46,11 +46,11 @@ const DropdownComponent: IToolboxComponent<IDropdownComponentProps, ITextFieldCo
     const initialValue = model?.defaultValue ? { initialValue: model.defaultValue } : {};
     const tagStyle = useFormComponentStyles({ ...model.tag }).fullStyle;
 
-    const finalStyle = model.enableStyleOnReadonly && model.readOnly ? 
-    { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles } :
-     { ...model.allStyles.fullStyle, width: '100%', height: '100%', overflow: 'hidden' 
-
-     };
+    const finalStyle = model.readOnly ?
+      model.enableStyleOnReadonly ?
+        { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles } :
+        { ...model.allStyles.fontStyles, ...model.allStyles.dimensionsStyles, ...model.allStyles.backgroundStyles, width: '100%', height: '100%', overflow: 'hidden' } :
+      { ...model.allStyles.fullStyle, width: '100%', height: '100%', overflow: 'hidden' };
 
     return (
       <ConfigurableFormItem model={model} {...initialValue}>


### PR DESCRIPTION
Targeting 0.44
https://github.com/shesha-io/shesha-framework/issues/3927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Read-only display items now support optional icon, item name, solid-color tags, and custom tag styling for dropdown and multi-select values.
* Style
  * Read-only items in the properties panel render without borders and rounded corners for a cleaner look.
  * Dropdowns in read-only mode now apply styles based on the “Enable style on read-only” setting, improving consistency for background, width, height, and overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->