### PR TITLE
omit the use of cacheKey because it causes form state to be shared ac…

### DIFF
--- a/shesha-reactjs/src/designer-components/configurableActionsConfigurator/actionArgumensEditor.tsx
+++ b/shesha-reactjs/src/designer-components/configurableActionsConfigurator/actionArgumensEditor.tsx
@@ -31,9 +31,8 @@ const getDefaultFactory = (
     const markupFactory = typeof markup === 'function'
       ? (markup as FormMarkupFactory)
       : () => markup as FormMarkup;
-    const cacheKey = typeof markup !== 'function'
-      ? `${action.ownerUid}-${action.name}-args`
-      : undefined;
+    // omit the use of cacheKey because it causes form state to be shared across different instances of the same action type
+    const cacheKey = undefined;
 
     const formMarkup = markupFactory({ exposedVariables, availableConstants });
     return (


### PR DESCRIPTION
…ross different instances of the same action type
https://dev.azure.com/boxfusion/Shesha%20Web%20v3.0/_workitems/edit/69481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where argument editor forms could share state across instances, causing values to carry over unexpectedly between components or tabs.
  * Each instance now maintains isolated form state, preventing edits in one configurator from affecting others.
  * Improves reliability when configuring actions in the designer and avoids stale or prefilled inputs after switching between items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->