### PR TITLE
Context Values Not Persistent on Page Reload #3708

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
@@ -68,11 +68,12 @@ export const DesignerMainArea: FC = () => {
         >
           <ParentProvider model={null} formMode="designer">
             {/* pageContext has added only to customize the designed form. It is not used as a data context.*/}
-            <DataContextProvider id="pageContext" name="pageContext" type="page">
+            <DataContextProvider id="pageContext" name="pageContext" type="page" webStorageType="sessionStorage">
               <DataContextProvider
-                id={SheshaCommonContexts.FormContext}
+                id="designerFormContext"
                 name={SheshaCommonContexts.FormContext}
                 type="form"
+                webStorageType="sessionStorage"
                 description="Form designer"
               >
                 <ConfigurableFormRenderer form={form} className={formMode === 'designer' ? styles.designerWorkArea : undefined}>

--- a/shesha-reactjs/src/generic-pages/dynamic/index.tsx
+++ b/shesha-reactjs/src/generic-pages/dynamic/index.tsx
@@ -46,7 +46,12 @@ const DynamicPageInternal: PageWithLayout<IDynamicPageProps> = (props) => {
 
 export const DynamicPage: PageWithLayout<IDynamicPageProps> = (props) => {
   return (
-    <DataContextProvider id={SheshaCommonContexts.PageContext} name={SheshaCommonContexts.PageContext} type="page">
+    <DataContextProvider
+      id={SheshaCommonContexts.PageContext}
+      name={SheshaCommonContexts.PageContext}
+      type="page"
+      webStorageType="sessionStorage"
+    >
       <DynamicPageInternal {...props} />
     </DataContextProvider>
   );

--- a/shesha-reactjs/src/providers/dataContextProvider/index.tsx
+++ b/shesha-reactjs/src/providers/dataContextProvider/index.tsx
@@ -8,15 +8,16 @@ import { setValueByPropertyName } from "@/utils/object";
 import { IApplicationContext, useAvailableConstantsDataNoRefresh } from "../form/utils";
 import { IShaDataWrapper } from "./contexts/shaDataAccessProxy";
 import { IAnyObject } from "@/interfaces";
-import { isDefined } from "@/utils/nullables";
 import { Path } from "@/utils/dotnotation";
 import { GetShaDataContextAccessor, useShaDataContextAccessor } from "./contexts/contextDataAccessor";
+import { WebStorageType } from "./contexts/webStorageProxy";
 
 export interface IDataContextProviderProps<TData extends object> {
   id: string;
   name: string;
   description?: string | undefined;
   type: DataContextType;
+  webStorageType?: WebStorageType;
   initialData?: Promise<TData> | undefined;
   metadata?: Promise<IModelMetadata> | undefined;
   onChangeData?: ContextOnChangeData | undefined;
@@ -32,6 +33,7 @@ export const DataContextProvider = <TData extends object = object>(props: PropsW
     name,
     description,
     type,
+    webStorageType,
     initialData,
     metadata,
     getShaDataContextAccessor,
@@ -42,7 +44,27 @@ export const DataContextProvider = <TData extends object = object>(props: PropsW
   const allData = useRef<IApplicationContext>(undefined);
   allData.current = useAvailableConstantsDataNoRefresh({ topContextId: id });
 
-  const storage = useShaDataContextAccessor<TData>(onChangeContextData, type, getShaDataContextAccessor);
+  const setDataInternal = (changedData: TData): void => {
+    storage.setData(changedData);
+
+    if (onChangeData.current)
+      onChangeData.current(changedData, changedData);
+  };
+
+  const setFieldValue: ContextSetFieldValue<TData> = (name, value): void => {
+    const partial = setValueByPropertyName({} as TData, name.toString(), value, false) as Partial<TData>;
+    onChangeAction(partial);
+    onChangeContextData();
+  };
+
+  const setData = (changedData: TData): void => {
+    if (onChangeData.current)
+      onChangeData.current(storage.getData(), changedData);
+    onChangeAction(changedData);
+    onChangeContextData();
+  };
+
+  const storage = useShaDataContextAccessor<TData>(id, setFieldValue, setData, webStorageType, getShaDataContextAccessor);
 
   const initialDataRef = useRef<IAnyObject>(undefined);
 
@@ -61,35 +83,11 @@ export const DataContextProvider = <TData extends object = object>(props: PropsW
 
   const onChangeAction = (changedData: Partial<TData>): void => {
     if (props.onChangeAction?.actionName) {
-      const data = { ...allData.current };
-      // TODO: Alex, please check this assignment
-      // update self
-      const { contexts } = data;
-      if (isDefined(contexts))
-        contexts[name] = getData();
       executeAction({
         actionConfiguration: props.onChangeAction,
         argumentsEvaluationContext: { ...allData.current, changedData },
       });
     }
-  };
-
-  const setFieldValue: ContextSetFieldValue<TData> = (name, value): void => {
-    storage.setFieldValue(name, value);
-    const partial = setValueByPropertyName({} as TData, name.toString(), value, false) as Partial<TData>;
-    onChangeAction(partial);
-  };
-
-  const setDataInternal = (changedData: TData): void => {
-    storage.setData(changedData);
-
-    if (onChangeData.current)
-      onChangeData.current(changedData, changedData);
-  };
-
-  const setData = (changedData: TData): void => {
-    setDataInternal(changedData);
-    onChangeAction(changedData);
   };
 
   if (initialData && initialDataRef.current === undefined) {

--- a/shesha-reactjs/src/providers/parentProvider/index.tsx
+++ b/shesha-reactjs/src/providers/parentProvider/index.tsx
@@ -133,9 +133,10 @@ const ParentProvider: FC<PropsWithChildren<IParentProviderProps>> = (props) => {
             <DataContextManager id={id}>
               <ConfigurableActionDispatcherProvider>
                 <DataContextProvider
-                  id={SheshaCommonContexts.FormContext}
+                  id={id}
                   name={SheshaCommonContexts.FormContext}
                   type="form"
+                  webStorageType="sessionStorage"
                   description={`${props.name || id}`}
                 >
                   {children}

--- a/shesha-reactjs/src/providers/sheshaApplication/index.tsx
+++ b/shesha-reactjs/src/providers/sheshaApplication/index.tsx
@@ -125,6 +125,7 @@ const ShaApplicationProvider: FC<PropsWithChildren<IShaApplicationProviderProps>
                                           name={SheshaCommonContexts.AppContext}
                                           description="Application data store context"
                                           type="app"
+                                          webStorageType="localStorage"
                                         >
                                           <FormDataLoadersProvider>
                                             <FormDataSubmittersProvider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced configurable data persistence via a new storage option on app contexts, pages, and forms. You can now choose session-based or local persistence for context data.
  - Dynamic pages, the form designer, and parent-provided forms now default to session-based persistence for safer, per-tab state.
  - The application-level context uses local persistence to retain state across sessions.
  - Improves reliability of data retention and cleanup, reducing unexpected state loss when navigating or reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->