### PR TITLE
throw error when user uploads wrong file type

### DIFF
--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -15,6 +15,7 @@ import React, { FC, useEffect, useRef, useState } from 'react';
 import { listType } from '@/designer-components/attachmentsEditor/attachmentsEditor';
 import { getFileIcon, isImageType } from '@/icons/fileIcons';
 import { useSheshaApplication, useStoredFile, useTheme } from '@/providers';
+import { isFileTypeAllowed } from '@/utils/fileValidation';
 import FileVersionsPopup from './fileVersionsPopup';
 import { DraggerStub } from './stubs';
 import { useStyles } from './styles/styles';
@@ -225,13 +226,9 @@ export const FileUpload: FC<IFileUploadProps> = ({
     style: !isDragger && stylesProp,
     customRequest: onCustomRequest,
     beforeUpload: (file) => {
-      if (allowedFileTypes && allowedFileTypes.length > 0) {
-        const fileExt = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
-        const isAllowed = allowedFileTypes.some((type) => fileExt === type.toLowerCase());
-        if (!isAllowed) {
-          message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
-          return false;
-        }
+      if (!isFileTypeAllowed(file.name, allowedFileTypes)) {
+        message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
+        return false;
       }
       return true;
     },
@@ -337,14 +334,10 @@ export const FileUpload: FC<IFileUploadProps> = ({
         onChange={(e) => {
           const file = e.target.files?.[0];
           if (file) {
-            if (allowedFileTypes && allowedFileTypes.length > 0) {
-              const fileExt = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
-              const isAllowed = allowedFileTypes.some((type) => fileExt === type.toLowerCase());
-              if (!isAllowed) {
-                message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
-                e.target.value = '';
-                return;
-              }
+            if (!isFileTypeAllowed(file.name, allowedFileTypes)) {
+              message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
+              e.target.value = '';
+              return;
             }
             uploadFile({ file }, callback);
           }

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -6,6 +6,7 @@ import { IInputStyles, IStyleType, useSheshaApplication, ValidationErrors } from
 import { IFormComponentStyles } from '@/providers/form/models';
 import { IDownloadFilePayload, IStoredFile, IUploadFilePayload } from '@/providers/storedFiles/contexts';
 import { addPx } from '@/utils/style';
+import { isFileTypeAllowed } from '@/utils/fileValidation';
 import { DownloadOutlined, FileZipOutlined, UploadOutlined } from '@ant-design/icons';
 import {
   Alert,
@@ -228,13 +229,9 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     beforeUpload(file: RcFile) {
       const { type, size, name } = file;
 
-      if (allowedFileTypes && allowedFileTypes.length > 0) {
-        const fileExt = name.substring(name.lastIndexOf('.')).toLowerCase();
-        const isAllowed = allowedFileTypes.some((t) => fileExt === t.toLowerCase());
-        if (!isAllowed) {
-          message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
-          return false;
-        }
+      if (!isFileTypeAllowed(name, allowedFileTypes)) {
+        message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
+        return false;
       }
 
       const isValidFileType =

--- a/shesha-reactjs/src/designer-components/image/image.tsx
+++ b/shesha-reactjs/src/designer-components/image/image.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { App, Button, Image, Tooltip, Upload, UploadProps } from 'antd';
 import { toBase64, useSheshaApplication, useStoredFile } from '@/index';
+import { isFileTypeAllowed } from '@/utils/fileValidation';
 import { DeleteOutlined, UploadOutlined } from '@ant-design/icons';
 
 export type ImageSourceType = 'url' | 'storedFile' | 'base64';
@@ -75,13 +76,9 @@ export const ImageField: FC<IImageFieldProps> = (props) => {
     accept: props.allowedFileTypes?.join(','),
     showUploadList: false,
     beforeUpload: async (file) => {
-      if (allowedFileTypes && allowedFileTypes.length > 0) {
-        const fileExt = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
-        const isAllowed = allowedFileTypes.some((type) => fileExt === type.toLowerCase());
-        if (!isAllowed) {
-          message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
-          return Upload.LIST_IGNORE;
-        }
+      if (!isFileTypeAllowed(file.name, allowedFileTypes)) {
+        message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
+        return Upload.LIST_IGNORE;
       }
 
       if (imageSource === 'base64') {

--- a/shesha-reactjs/src/designer-components/imagePicker/index.tsx
+++ b/shesha-reactjs/src/designer-components/imagePicker/index.tsx
@@ -6,6 +6,7 @@ import { useStyles } from './style';
 import { IToolboxComponent } from '@/interfaces';
 import ConfigurableFormItem from '@/components/formDesigner/components/formItem';
 import { toBase64, validateConfigurableComponentSettings } from '@/providers/form/utils';
+import { isFileTypeAllowed } from '@/utils/fileValidation';
 import { IFileUploadProps } from '../fileUpload';
 import { getSettings } from './settings';
 
@@ -70,13 +71,9 @@ export const ImagePicker = ({ onChange, value, readOnly, allowedFileTypes }: IIm
         onRemove={handleRemove}
         onChange={handleChange}
         beforeUpload={(file) => {
-          if (allowedFileTypes && allowedFileTypes.length > 0) {
-            const fileExt = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
-            const isAllowed = allowedFileTypes.some((type) => fileExt === type.toLowerCase());
-            if (!isAllowed) {
-              message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
-              return Upload.LIST_IGNORE;
-            }
+          if (!isFileTypeAllowed(file.name, allowedFileTypes)) {
+            message.error(`File type not allowed. Only ${allowedFileTypes.join(', ')} files are accepted.`);
+            return Upload.LIST_IGNORE;
           }
           return false;
         }}

--- a/shesha-reactjs/src/utils/fileValidation.ts
+++ b/shesha-reactjs/src/utils/fileValidation.ts
@@ -1,0 +1,14 @@
+/**
+ * Validates if a file is allowed based on configured file types
+ * @param fileName The name of the file to validate
+ * @param allowedFileTypes Array of allowed file extensions (e.g., ['.png', '.jpg'])
+ * @returns true if file is allowed, false otherwise
+ */
+export const isFileTypeAllowed = (fileName: string, allowedFileTypes?: string[]): boolean => {
+  if (!allowedFileTypes || allowedFileTypes.length === 0) {
+    return true;
+  }
+
+  const fileExt = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
+  return allowedFileTypes.some((type) => fileExt === type.toLowerCase());
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable allowed file types for uploads across file, image, and image-picker controls.
  * File chooser filters now reflect configured allowed types.

* **Bug Fixes**
  * Client-side validation now blocks disallowed file types and displays a clear error message.
  * File inputs are reset after processing to prevent unintended re-uploads and ensure consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->