### PR TITLE
add field to payload

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -43,7 +43,7 @@ export interface IAttachmentsEditorProps extends IConfigurableFormComponent, IIn
   thumbnailHeight?: string;
   borderRadius?: number;
   hideFileName?: boolean;
-  removeFieldFromPayload?: boolean;
+  addFieldToPayload?: boolean;
 }
 
 const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
@@ -58,7 +58,7 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
     const { data } = useFormData();
     const { globalState, setState: setGlobalState } = useGlobalState();
     const { message } = App.useApp();
-    const pageContext = useDataContextManagerActions(false)?.getPageContext();
+    const pageContext = useDataContextManagerActions()?.getPageContext();
     const ownerId = evaluateValue(`${model.ownerId}`, { data: data, globalState });
 
     const enabled = !model.readOnly;
@@ -81,7 +81,7 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
     return (
       // Add GHOST_PAYLOAD_KEY to remove field from the payload
       // File list uses propertyName only for support Required feature
-      <ConfigurableFormItem model={{ ...model, propertyName: model.propertyName || `${GHOST_PAYLOAD_KEY}_${model.id}` }}>
+      <ConfigurableFormItem model={{ ...model, propertyName: model.addFieldToPayload ? model.propertyName : `${GHOST_PAYLOAD_KEY}_${model.propertyName}` }}>
         {(value, onChange) => {
 
           const onFileListChanged = (fileList) => {
@@ -157,8 +157,7 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
       ...migrateFormApi.eventsAndProperties(prev),
       onFileChanged: migrateFormApi.withoutFormData(prev?.onFileChanged),
     }))
-    .add<IAttachmentsEditorProps>(6, (prev) => ({ ...prev, listType: !prev.listType ? 'text' : prev.listType }))
-    .add<IAttachmentsEditorProps>(7, (prev) => ({ ...prev, propertyName: prev.propertyName || '' })),
+    .add<IAttachmentsEditorProps>(6, (prev) => ({ ...prev, listType: !prev.listType ? 'text' : prev.listType })),
 };
 
 export default AttachmentsEditor;

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -15,6 +15,12 @@ export const getSettings = () =>
       content: {
         id: 'pnl54bf6-f76d-4139-a850-c99bf06c8b69',
         components: [...new DesignerToolbarSettings()
+          .addCheckbox({
+            id: nanoid(),
+            propertyName: "addFieldToPayload",
+            label: "Add Field To Payload",
+            parentId: "pnl54bf6-f76d-4139-a850-c99bf06c8b69"
+          })
           .addContextPropertyAutocomplete({
             id: nanoid(),
             propertyName: 'propertyName',


### PR DESCRIPTION
Added new property `addFieldToPayload` to AttachmentEditor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Add Field To Payload" configuration option to the Display panel for the attachments editor, enabling control over whether attachment fields are included in the data payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->