### PR TITLE
use default enity type

### DIFF
--- a/shesha-reactjs/src/designer-components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/designer-components/entityPicker/index.tsx
@@ -199,6 +199,8 @@ const EntityPickerComponent: IToolboxComponent<IEntityPickerComponentProps> = {
     .add<IEntityPickerComponentProps>(10, (prev) => ({ ...prev, desktop: { ...defaultStyles(prev) }, mobile: { ...defaultStyles(prev) }, tablet: { ...defaultStyles(prev) } }))
     .add<IEntityPickerComponentProps>(11, (prev, context) => ({
       ...prev,
+      // Default to Person for backward compatibility with legacy forms
+      // should explicitly set entityType for other entity types
       entityType: context.isNew && !prev.entityType ? 'Shesha.Core.Person' : prev.entityType,
     })),
   settingsFormMarkup: (data) => getSettings(data),


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/3520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the entity picker configuration by removing an unused visual property, reducing clutter.

* **Bug Fixes**
  * New entities created without an explicit type now receive a sensible default entity type during migration; existing records keep their prior type.
  * Default desktop/mobile/tablet styling behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->