### PR TITLE
fix: PostgreSql support

### DIFF
--- a/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/DbCommandExtensions.cs
+++ b/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/DbCommandExtensions.cs
@@ -8,14 +8,67 @@ namespace Shesha.FluentMigrator
     /// </summary>
     public static class DbCommandExtensions
     {
-        public static void AddParameter(this IDbCommand command, string name, object? value)
+        public static void AddParameter<TValue>(this IDbCommand command, string name, TValue? value)
         {
             var parameter = command.CreateParameter();
             parameter.ParameterName = name;
             parameter.Value = value != null
                 ? value
                 : DBNull.Value;
+            if (value == null)
+                parameter.DbType = typeof(TValue).ToDbType();
             command.Parameters.Add(parameter);
+        }
+
+        private static readonly Dictionary<Type, DbType> TypeMap = new Dictionary<Type, DbType>
+        {
+            { typeof(byte), DbType.Byte },
+            { typeof(sbyte), DbType.SByte },
+            { typeof(short), DbType.Int16 },
+            { typeof(ushort), DbType.UInt16 },
+            { typeof(int), DbType.Int32 },
+            { typeof(uint), DbType.UInt32 },
+            { typeof(long), DbType.Int64 },
+            { typeof(ulong), DbType.UInt64 },
+            { typeof(float), DbType.Single },
+            { typeof(double), DbType.Double },
+            { typeof(decimal), DbType.Decimal },
+            { typeof(bool), DbType.Boolean },
+            { typeof(string), DbType.String },
+            { typeof(char), DbType.StringFixedLength },
+            { typeof(Guid), DbType.Guid },
+            { typeof(DateTime), DbType.DateTime },
+            { typeof(DateTimeOffset), DbType.DateTimeOffset },
+            { typeof(TimeSpan), DbType.Time },
+            { typeof(byte[]), DbType.Binary },            
+        };
+
+        /// <summary>
+        /// Converts a .NET Type to System.Data.DbType
+        /// </summary>
+        /// <param name="type">The .NET type to convert</param>
+        /// <returns>The corresponding DbType, or DbType.Object if no mapping found</returns>
+        private static DbType ToDbType(this Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            // Handle nullable types by getting the underlying type
+            Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+
+            if (TypeMap.TryGetValue(underlyingType, out DbType dbType))
+            {
+                return dbType;
+            }
+
+            // Handle enums as their underlying type
+            if (underlyingType.IsEnum)
+            {
+                return ToDbType(Enum.GetUnderlyingType(underlyingType));
+            }
+
+            // Return Object for unmapped types
+            return DbType.Object;
         }
     }
 }

--- a/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/ReferenceLists/ReferenceListDbHelper.cs
+++ b/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/ReferenceLists/ReferenceListDbHelper.cs
@@ -48,7 +48,7 @@ namespace Shesha.FluentMigrator.ReferenceLists
                 ExecuteNonQuery(sql, command =>
                 {
                     command.AddParameter("@id", id);
-                    command.AddParameter("@tenantId", null);
+                    command.AddParameter<int?>("@tenantId", null);
                     command.AddParameter("@description", description);
                     command.AddParameter("@name", name);
                     command.AddParameter("@namespace", @namespace);
@@ -278,13 +278,13 @@ where
 
             ExecuteNonQuery(sql, command => {
                 command.AddParameter("@Id", id);
-                command.AddParameter("@TenantId", null);
+                command.AddParameter<int?>("@TenantId", null);
                 command.AddParameter("@Description", item.Description);
                 command.AddParameter("@HardLinkToApplication", false);
                 command.AddParameter("@Item", item.Item);
                 command.AddParameter("@ItemValue", item.ItemValue);
                 command.AddParameter("@OrderIndex", item.OrderIndex ?? item.ItemValue);
-                command.AddParameter("@ParentId", null);
+                command.AddParameter<Guid?>("@ParentId", null);
                 command.AddParameter("@ReferenceListId", refListId);
             });
 

--- a/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/Settings/SettingsDbHelper.cs
+++ b/shesha-core/src/Shesha.FluentMigrator/FluentMigrator/Settings/SettingsDbHelper.cs
@@ -224,7 +224,7 @@ where
                         where 
 	                        ""SettingConfigurationId"" = @settingId
                             and ((@appId is null and ""ApplicationId"" is null or (""ApplicationId"" = @appId)))
-                            {(userIdExists ? "and ((@userId is null and \"UserId\" is null or (\"ApplicationId\" = @userId)))" : "")}
+                            {(userIdExists ? "and ((@userId is null and \"UserId\" is null or (\"UserId\" = @userId)))" : "")}
             ";
 
             return ExecuteScalar<Guid?>(sql, command =>

--- a/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/M20250623120299.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/M20250623120299.cs
@@ -79,6 +79,9 @@ namespace Shesha.Migrations.ConfigurationStudio
 
             IfDatabase("SqlServer").Execute.Sql(@"IF (OBJECT_ID('dbo.FK_SheshaFunctionalTests_TestAccounts_CaptureFormId_Frwk_FormConfigurations_Id', 'F') IS NOT NULL)
 	ALTER TABLE SheshaFunctionalTests_TestAccounts DROP CONSTRAINT FK_SheshaFunctionalTests_TestAccounts_CaptureFormId_Frwk_FormConfigurations_Id;");
+
+            if (Schema.Table("SheshaFunctionalTests_TestAccounts").Exists())
+                IfDatabase("PostgreSql").Execute.Sql(@"ALTER TABLE ""SheshaFunctionalTests_TestAccounts"" DROP CONSTRAINT IF EXISTS ""FK_SheshaFunctionalTests_TestAccounts_CaptureFormId_Frwk_FormCo""");
             Delete.Table("Frwk_FormConfigurations");
             Delete.Table("Frwk_PermissionDefinitions");
             Delete.Table("Frwk_ConfigurableComponents");

--- a/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/M20251016115699.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/M20251016115699.cs
@@ -104,8 +104,8 @@ select
 from 
 	cte
 	left join frwk.module_relations rel on rel.module_id = frwk.get_module_id() and rel.base_module_id = cte.override_module_id
-	inner join frwk.modules m on m.id = cte.module_id and m.is_deleted = fasle
-	inner join frwk.modules om on om.id = cte.override_module_id and om.is_deleted = fasle");
+	inner join frwk.modules m on m.id = cte.module_id and m.is_deleted = false
+	inner join frwk.modules om on om.id = cte.override_module_id and om.is_deleted = false");
         }
     }
 }

--- a/shesha-core/test/Shesha.Tests/ModuleHierarchy/ModuleHierarchy_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/ModuleHierarchy/ModuleHierarchy_Tests.cs
@@ -200,7 +200,7 @@ namespace Shesha.Tests.ModuleHierarchy
         }
 
         [Fact]
-        public async Task When_ExposedOnTopLevel_SHould_ReturnTopLevel()
+        public async Task When_ExposedOnTopLevel_Should_ReturnTopLevel()
         {
             /*
              * case: 

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Domain/Account.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Domain/Account.cs
@@ -15,6 +15,5 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Domain
         public virtual RefListAccType? AccountType { get; set; }
 
         public virtual Bank Bank { get; set; }
-        //public virtual FormConfiguration CaptureForm { get; set; }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230227113900.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230227113900.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230227113900), MsSqlOnly]
-    public class M20230227113900 : Migration
+    [Migration(20230227113900)]
+    public class M20230227113900 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             if (!Schema.Table("SheshaFunctionalTests_TestClasses").Exists())
@@ -19,7 +13,7 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
                 Create.Table("SheshaFunctionalTests_TestClasses")
                     .WithIdAsGuid()
                     .WithColumn("TestProp").AsString().Nullable()
-                    .WithColumn("JsonProp").AsCustom("nvarchar(max)").Nullable()
+                    .WithColumn("JsonProp").AsStringMax().Nullable()
                     .WithColumn("ReflistPropLkp").AsInt64().Nullable();
             }
         }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230228082800.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230228082800.cs
@@ -1,21 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230228082800), MsSqlOnly]
-    public class M20230228082800 : Migration
+    [Migration(20230228082800)]
+    public class M20230228082800 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             if (!Schema.Table("SheshaFunctionalTests_Brands").Exists())

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230228151500.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230228151500.cs
@@ -1,27 +1,18 @@
 ﻿using FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230228151500), MsSqlOnly]
-    public class M20230228151500 : Migration
+    [Migration(20230228151500)]
+    public class M20230228151500 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             Alter.Table("SheshaFunctionalTests_TestClasses")
-                .AddColumn("SomeGenericPropId").AsCustom("nvarchar(100)").Nullable()
-                .AddColumn("SomeGenericPropDisplayName").AsCustom("nvarchar(1000)").Nullable()
-                .AddColumn("SomeGenericPropClassName").AsCustom("nvarchar(1000)").Nullable()
-                .AddColumn("SomeJsonAddressProp").AsCustom("nvarchar(max)").Nullable();
+                .AddColumn("SomeGenericPropId").AsString(100).Nullable()
+                .AddColumn("SomeGenericPropDisplayName").AsString(1000).Nullable()
+                .AddColumn("SomeGenericPropClassName").AsString(1000).Nullable()
+                .AddColumn("SomeJsonAddressProp").AsStringMax().Nullable();
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230301104400.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230301104400.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230301104400), MsSqlOnly]
-    public class M20230301104400 : Migration
+    [Migration(20230301104400)]
+    public class M20230301104400 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             if (!Schema.Table("SheshaFunctionalTests_Banks").Exists())

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230308102000.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230308102000.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230308102000), MsSqlOnly]
-    public class M202303081020000 : Migration
+    [Migration(20230308102000)]
+    public class M202303081020000 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             if (!Schema.Table("SheshaFunctionalTests_TestClasses").Column("TestListOfJsonEntitiesProp").Exists())

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230313163700.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230313163700.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230313163700), MsSqlOnly]
-    public class M20230313163700 : Migration
+    [Migration(20230313163700)]
+    public class M20230313163700 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             Alter.Table("Core_Persons")

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230313164300.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230313164300.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230313164300), MsSqlOnly]
-    public class M20230313164300 : Migration
+    [Migration(20230313164300)]
+    public class M20230313164300 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             Alter.Table("Core_Persons")

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230313164500.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230313164500.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230313164500), MsSqlOnly]
-    public class M20230313164500 : Migration
+    [Migration(20230313164500)]
+    public class M20230313164500 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             Create.Table("SheshaFunctionalTests_MembershipPayments")

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230316114400.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230316114400.cs
@@ -1,14 +1,9 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230316114400), MsSqlOnly]
+    [Migration(20230316114400)]
     public class M20230316114400 : AutoReversingMigration
     {
         public override void Up()

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230316114500.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230316114500.cs
@@ -1,14 +1,9 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230316114500), MsSqlOnly]
+    [Migration(20230316114500)]
     public class M20230316114500 : AutoReversingMigration
     {
         public override void Up()

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230316144800.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230316144800.cs
@@ -1,17 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230316144800), MsSqlOnly]
-    public class M20230316144800 : Migration
+    [Migration(20230316144800)]
+    public class M20230316144800 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             if (!Schema.Table("SheshaFunctionalTests_TestClasses").Column("TestListOfJsonHouses").Exists())

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230320114500.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230320114500.cs
@@ -1,14 +1,9 @@
 ﻿using FluentMigrator;
-using System;
 using Shesha.FluentMigrator;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230320114500), MsSqlOnly]
+    [Migration(20230320114500)]
     public class M20230320114500 : AutoReversingMigration
     {
         public override void Up()

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230322150500.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230322150500.cs
@@ -1,14 +1,8 @@
 ﻿using FluentMigrator;
-using System;
-using Shesha.FluentMigrator;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230322150500), MsSqlOnly]
+    [Migration(20230322150500)]
     public class M20230322150500 : AutoReversingMigration
     {
         public override void Up()

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230327173100.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230327173100.cs
@@ -1,14 +1,9 @@
 ﻿using FluentMigrator;
-using System;
 using Shesha.FluentMigrator;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230327173100), MsSqlOnly]
+    [Migration(20230327173100)]
     public class M20230327173100 : AutoReversingMigration
     {
         public override void Up()

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230404150400.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230404150400.cs
@@ -1,14 +1,9 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230404150400), MsSqlOnly]
+    [Migration(20230404150400)]
     public class M20230404150400 : AutoReversingMigration
     {
         public override void Up()
@@ -20,11 +15,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
             this.Shesha()
                 .SettingDelete("IsAllowedTo")
                 .FromModule("Shesha");
-            /* Not working */
-            //this.Shesha()
-            //    .SettingUpdate("IsAllowedTo")
-            //    .OnModule("Boxfusion.SheshaFunctionalTests.Common")
-            //    .SetValue(false.ToString());
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230404151800.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230404151800.cs
@@ -1,14 +1,9 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230404151800), MsSqlOnly]
+    [Migration(20230404151800)]
     public class M20230404151800 : AutoReversingMigration
     {
         public override void Up()

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230411130200.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230411130200.cs
@@ -1,21 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230411130200), MsSqlOnly]
-    public class M20230411130200 : Migration
+    [Migration(20230411130200)]
+    public class M20230411130200 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             Rename.Table("SheshaFunctionalTests_Accounts").To("SheshaFunctionalTests_TestAccounts");

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230418112000.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230418112000.cs
@@ -1,21 +1,11 @@
 ﻿using FluentMigrator;
 using Shesha.FluentMigrator;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230418112000), MsSqlOnly]
-    public class M20230418112000 : Migration
+    [Migration(20230418112000)]
+    public class M20230418112000 : OneWayMigration
     {
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
-
         public override void Up()
         {
             Alter.Table("Core_Persons")

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230516104216.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20230516104216.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using FluentMigrator;
+﻿using FluentMigrator;
 using Shesha.Domain;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20230516104216), MsSqlOnly]
-    public class M20230516104216 : Migration
+    [Migration(20230516104216)]
+    public class M20230516104216 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -50,14 +49,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 
             Alter.Table("SheshaFunctionalTests_Subjects").AddForeignKeyColumn("SchoolId", "SheshaFunctionalTests_Schools").Nullable();
 
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20231031120400.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20231031120400.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using FluentMigrator;
-using Shesha.Domain;
+﻿using FluentMigrator;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20231031120400), MsSqlOnly]
-    public class M20231031120400 : Migration
+    [Migration(20231031120400)]
+    public class M20231031120400 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -15,14 +13,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
         {
             Alter.Table("Core_Persons").AddColumn("SheshaFunctionalTests_OrderIndex").AsInt32().Nullable();
             Alter.Table("SheshaFunctionalTests_Employees").AddColumn("OrderIndex").AsInt32().Nullable();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20231116153800.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20231116153800.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using FluentMigrator;
-using Shesha.Domain;
+﻿using FluentMigrator;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20231116153800), MsSqlOnly]
-    public class M20231116153800 : Migration
+    [Migration(20231116153800)]
+    public class M20231116153800 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -15,14 +13,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
         {
             Alter.Table("SheshaFunctionalTests_Books").AddColumn("TimeTicks").AsInt64().Nullable();
             Alter.Table("SheshaFunctionalTests_Schools").AddColumn("TimeTicks").AsInt64().Nullable();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20231212122500.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20231212122500.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using FluentMigrator;
-using Shesha.Domain;
+﻿using FluentMigrator;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20231212122500), MsSqlOnly]
-    public class M20231212122500 : Migration
+    [Migration(20231212122500)]
+    public class M20231212122500 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -17,14 +15,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
                 .WithIdAsGuid()
                 .WithColumn("MainCar").AsStringMax().Nullable()
                 .WithColumn("OtherCars").AsStringMax().Nullable();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20240219144300.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20240219144300.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using FluentMigrator;
-using Shesha.Domain;
+﻿using FluentMigrator;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20240219144300), MsSqlOnly]
-    public class M20240219144300 : Migration
+    [Migration(20240219144300)]
+    public class M20240219144300 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -14,14 +12,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
         public override void Up()
         {
             Alter.Table("SheshaFunctionalTests_MembershipPayments").AddColumn("PaymentTypeLkp").AsInt64().Nullable();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20240326212600.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20240326212600.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using FluentMigrator;
-using Shesha.Domain;
+﻿using FluentMigrator;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20240326212600), MsSqlOnly]
-    public class M20240326212600 : Migration
+    [Migration(20240326212600)]
+    public class M20240326212600 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -14,14 +12,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
         public override void Up()
         {
             Alter.Table("SheshaFunctionalTests_TestAccounts").AddForeignKeyColumn("CaptureFormId", "Frwk_FormConfigurations").Nullable();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
-        }
+        }        
     }
 }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20240604203200.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20240604203200.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using FluentMigrator;
-using Shesha.Domain;
+﻿using FluentMigrator;
 using Shesha.FluentMigrator;
 
 namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
 {
-    [Migration(20240604203200), MsSqlOnly]
-    public class M20240604203200 : Migration
+    [Migration(20240604203200)]
+    public class M20240604203200 : OneWayMigration
     {
         /// <summary>
         /// 
@@ -14,14 +12,6 @@ namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
         public override void Up()
         {
             Alter.Table("Core_Persons").AddColumn("SheshaFunctionalTests_Base64String").AsStringMax().Nullable();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Down()
-        {
-            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- fixed old FunctionTests migrations which were marked as MsSqlOnly
- fixed legacy DB helpers to support PostgreSql
- converted Swagger dependencies in DynamicEntityUpdateEvent to dynamic to fix unit tests