### PR TITLE
fix: adding the component Name to settings

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -41,6 +41,14 @@ export const getSettings = () => {
             id: commonTabId,
             components: [
               ...new DesignerToolbarSettings()
+                  .addSettingsInput({
+                    id: nanoid(),
+                    propertyName: 'componentName',
+                    label: 'Component name',
+                    inputType: 'propertyAutocomplete',
+                    validate: { required: true },
+                    jsSetting: false,
+                  })
                 .addLabelConfigurator({
                   id: nanoid(),
                   propertyName: 'hideLabel',


### PR DESCRIPTION
#3648 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Component name" setting to the attachments editor configuration with autocomplete support, enabling users to specify and configure component naming directly from the settings panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->