### PR TITLE
Normalize file extension to lowercase in file upload to prevent case …

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -207,7 +207,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       // It used to be RcCustomRequestOptions, but it doesn't seem to be found anymore
       // Normalize file extension to lowercase to avoid case sensitivity issues on Linux
       const lastDotIndex = options?.file?.name.lastIndexOf(".");
-      const fileName = options?.file?.name.substring(0, lastDotIndex) + options?.file?.name.substring(lastDotIndex).toLowerCase();
+      const fileName = lastDotIndex === -1 ? options?.file?.name : options?.file?.name.substring(0, lastDotIndex) + options?.file?.name.substring(lastDotIndex).toLowerCase();
 
       const normalizedFile = new File([options.file], fileName, { type: options.file.type });
 


### PR DESCRIPTION
File with uppercase extension not downloadable #4049 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized uploaded file extensions to lowercase during upload to ensure consistent, case-insensitive handling across platforms while preserving file content and MIME type.
  * Kept existing error handling and upload flow unchanged so behavior and failure modes remain as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->