### PR TITLE
feat: redirect to configuration studio

### DIFF
--- a/shesha-reactjs/src/components/configurableForm/index.tsx
+++ b/shesha-reactjs/src/components/configurableForm/index.tsx
@@ -111,7 +111,7 @@ export const ConfigurableForm = <Values extends object = object>(props: Configur
   }, [shaForm, onSubmitted]);
   //#endregion shaForm sync
 
-  const canConfigure = Boolean(app.routes.formsDesigner) && Boolean(formId);
+  const canConfigure = Boolean(app.routes.configurationStudio) && Boolean(formId);
   const { router } = useShaRoutingOrUndefined() ?? {};
 
   const formDesignerUrl = useFormDesignerUrl(formId);

--- a/shesha-reactjs/src/components/formDesigner/toolbar/formSettingsButton.tsx
+++ b/shesha-reactjs/src/components/formDesigner/toolbar/formSettingsButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { Button } from 'antd';
 import { FormSettingsEditor } from '../formSettingsEditor';
 import { SettingOutlined } from '@ant-design/icons';
@@ -17,6 +17,9 @@ export const FormSettingsButton: FC<IFormSettingsButtonProps> = ({ buttonText, s
   const onSettingsClick = (): void => {
     setSettingsVisible(true);
   };
+  const onClose = useCallback(() => {
+    setSettingsVisible(false);
+  }, [setSettingsVisible]);
 
   return (
     <>
@@ -26,9 +29,7 @@ export const FormSettingsButton: FC<IFormSettingsButtonProps> = ({ buttonText, s
       <FormSettingsEditor
         readOnly={readOnly}
         isVisible={settingsVisible}
-        close={() => {
-          setSettingsVisible(false);
-        }}
+        close={onClose}
       />
     </>
   );

--- a/shesha-reactjs/src/hooks/useAsyncMemo.ts
+++ b/shesha-reactjs/src/hooks/useAsyncMemo.ts
@@ -13,9 +13,8 @@ export function useAsyncMemo<T>(factory: () => Promise<T> | undefined | null, de
       };
 
     promise.then((newVal) => {
-      if (!cancel) {
-        if (newVal !== val)
-          setVal(newVal);
+      if (!cancel && newVal !== val) {
+        setVal(newVal);
       }
     });
 
@@ -39,9 +38,9 @@ export function useAsyncDeepCompareMemo<T>(factory: () => Promise<T> | undefined
         /* nop*/
       };
 
-    promise.then((val) => {
-      if (!cancel) {
-        setVal(val);
+    promise.then((newVal) => {
+      if (!cancel && newVal !== val) {
+        setVal(newVal);
       }
     });
 

--- a/shesha-reactjs/src/providers/appConfigurator/index.tsx
+++ b/shesha-reactjs/src/providers/appConfigurator/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useContext, useEffect, useMemo, useReducer } from 'react';
+import React, { FC, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useReducer } from 'react';
 import { useLocalStorage } from '@/hooks';
 import { PERM_APP_CONFIGURATOR } from '@/shesha-constants';
 import {
@@ -106,25 +106,37 @@ const AppConfiguratorProvider: FC<PropsWithChildren> = ({ children }) => {
 
   /* NEW_ACTION_DECLARATION_GOES_HERE */
 
-  const toggleShowInfoBlock = (visible: boolean): void => {
+  const toggleShowInfoBlock = useCallback((visible: boolean): void => {
     configuratorSettings.setIsInformerVisible(visible);
-  };
+  }, [configuratorSettings]);
 
-  const switchApplicationMode = (mode: ApplicationMode): void => {
+  const switchApplicationMode = useCallback((mode: ApplicationMode): void => {
     dispatch(switchApplicationModeAction(mode));
-  };
+  }, [dispatch]);
 
-  const toggleEditModeConfirmation = (visible: boolean): void => {
+  const toggleEditModeConfirmation = useCallback((visible: boolean): void => {
     dispatch(toggleEditModeConfirmationAction(visible));
-  };
+  }, [dispatch]);
 
-  const toggleCloseEditModeConfirmation = (visible: boolean): void => {
+  const toggleCloseEditModeConfirmation = useCallback((visible: boolean): void => {
     dispatch(toggleCloseEditModeConfirmationAction(visible));
-  };
+  }, [dispatch]);
 
-  const softToggleInfoBlock = (softInfoBlock: boolean): void => {
+  const softToggleInfoBlock = useCallback((softInfoBlock: boolean): void => {
     dispatch(softToggleInfoBlockAction(softInfoBlock));
-  };
+  }, [dispatch]);
+
+  const actions: IAppActionsContext = useMemo(() => ({
+    switchApplicationMode,
+    toggleEditModeConfirmation,
+    toggleCloseEditModeConfirmation,
+    toggleShowInfoBlock,
+    softToggleInfoBlock,
+  }), [switchApplicationMode,
+    toggleEditModeConfirmation,
+    toggleCloseEditModeConfirmation,
+    toggleShowInfoBlock,
+    softToggleInfoBlock]);
 
   return (
     <AppConfiguratorStateContext.Provider value={{
@@ -133,13 +145,7 @@ const AppConfiguratorProvider: FC<PropsWithChildren> = ({ children }) => {
     }}
     >
       <AppConfiguratorActionsContext.Provider
-        value={{
-          switchApplicationMode,
-          toggleEditModeConfirmation,
-          toggleCloseEditModeConfirmation,
-          toggleShowInfoBlock,
-          softToggleInfoBlock,
-        }}
+        value={actions}
       >
         {children}
       </AppConfiguratorActionsContext.Provider>

--- a/shesha-reactjs/src/providers/form/hooks.ts
+++ b/shesha-reactjs/src/providers/form/hooks.ts
@@ -56,7 +56,7 @@ export const useFormDesignerComponentGetter = (): FormDesignerComponentGetter =>
 
 const getDesignerUrl = (designerUrl: string, fId: FormIdentifier): string | null => {
   return typeof fId === 'string'
-    ? `${designerUrl}?id=${fId}`
+    ? `${designerUrl}?docId=${fId}`
     : Boolean(fId?.name)
       ? `${designerUrl}?module=${fId.module}&name=${fId.name}`
       : null;
@@ -64,5 +64,5 @@ const getDesignerUrl = (designerUrl: string, fId: FormIdentifier): string | null
 
 export const useFormDesignerUrl = (formId: FormIdentifier): string => {
   const app = useSheshaApplication();
-  return getDesignerUrl(app.routes.formsDesigner, formId);
+  return getDesignerUrl(app.routes.configurationStudio, formId);
 };

--- a/shesha-reactjs/src/providers/sheshaApplication/contexts.tsx
+++ b/shesha-reactjs/src/providers/sheshaApplication/contexts.tsx
@@ -4,6 +4,7 @@ import { createNamedContext } from '@/utils/react';
 
 export interface ISheshaRoutes {
   formsDesigner: string;
+  configurationStudio: string;
 }
 
 export interface IHttpHeadersDictionary {
@@ -23,6 +24,7 @@ export interface ISheshaApplicationStateContext {
 
 export const DEFAULT_SHESHA_ROUTES: ISheshaRoutes = {
   formsDesigner: '/shesha/forms-designer',
+  configurationStudio: '/configuration-studio',
 };
 
 export const SHESHA_APPLICATION_CONTEXT_INITIAL_STATE: ISheshaApplicationStateContext = {


### PR DESCRIPTION
- redirect to configuration studio on `Expand` click on the designer modal
- fixed unneeded re-renderd in useAsyncDeepCompareMemo()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized performance through memoized callbacks and improved async memory handling across form and application configuration components.
  * Updated form configuration workflow to use an updated routing prerequisite.

* **Chores**
  * Added new configuration studio route to application routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->