### PR TITLE
Button ReadOnly property

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/buttonGroupItem.tsx
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/buttonGroupItem.tsx
@@ -78,13 +78,14 @@ export const ButtonGroupItem: FC<IButtonGroupItemProps> = ({ item, actionConfigu
           <Button
             title={tooltip}
             type={buttonType}
+            disabled={readOnly}
             danger={danger}
             icon={icon ? <ShaIcon iconName={icon as IconType} /> : undefined}
             iconPosition={iconPosition}
             className={classNames('sha-toolbar-btn sha-toolbar-btn-configurable')}
             size={size}
             block={block}
-            style={{ ...newStyles, ...(readOnly && { cursor: 'not-allowed' }) }}
+            style={{ ...newStyles}}
           >
             {label}
           </Button>


### PR DESCRIPTION
Fix readonly mode on button group configurator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Button group items now properly respond to the read-only state by being disabled when applicable, ensuring consistent user interaction and preventing unintended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->