### PR TITLE
Button ReadOnly property

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/buttonGroupItem.tsx
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/buttonGroupItem.tsx
@@ -85,7 +85,7 @@ export const ButtonGroupItem: FC<IButtonGroupItemProps> = ({ item, actionConfigu
             className={classNames('sha-toolbar-btn sha-toolbar-btn-configurable')}
             size={size}
             block={block}
-            style={{ ...newStyles}}
+            style={{ ...newStyles }}
           >
             {label}
           </Button>


### PR DESCRIPTION
Fix readonly mode on button group configurator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only buttons are now genuinely disabled and non-interactive (improves accessibility).
  * Visual cursor treatment adjusted so read-only buttons no longer force a "not-allowed" cursor, aligning pointer behavior with disabled state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->