### PR TITLE
validate button group and item visibility for profile dropdown

### DIFF
--- a/shesha-reactjs/src/designer-components/profileDropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/profileDropdown/index.tsx
@@ -122,7 +122,7 @@ const ProfileDropdown: IToolboxComponent<IProfileDropdown> = {
         return false;
 
       if (group.hideWhenEmpty) {
-        const firstVisibleItem = group.childItems?.find(item => {
+        const firstVisibleItem = group.childItems?.find((item) => {
           // analyze buttons and groups only
           const isButton = isItem(item) && (item.itemSubType === 'button');
           return (isButton || isGroup(item)) && itemVisibilityFunc(item);
@@ -135,7 +135,7 @@ const ProfileDropdown: IToolboxComponent<IProfileDropdown> = {
     };
 
     const getIsVisible = (item: ButtonGroupItemProps): boolean => {
-      return isItem(item) && isVisibleBase(item) || isGroup(item) && isGroupVisible(item, getIsVisible);
+      return (isItem(item) && isVisibleBase(item)) || (isGroup(item) && isGroupVisible(item, getIsVisible));
     };
 
     const menuItems = getMenuItem(finalItems, executeActionViaConfiguration, getIsVisible);

--- a/shesha-reactjs/src/designer-components/profileDropdown/utils.tsx
+++ b/shesha-reactjs/src/designer-components/profileDropdown/utils.tsx
@@ -23,7 +23,7 @@ type ItemVisibilityFunc = (item: ButtonGroupItemProps) => boolean;
 
 const filterVisibleItems = (
   items: ButtonGroupItemProps[] = [],
-  visibilityChecker: ItemVisibilityFunc
+  visibilityChecker: ItemVisibilityFunc,
 ): ButtonGroupItemProps[] => {
   return items.reduce<ButtonGroupItemProps[]>((acc, item) => {
     if (!visibilityChecker(item)) {
@@ -47,7 +47,7 @@ const filterVisibleItems = (
 export const getMenuItem = (
   items: ButtonGroupItemProps[] = [],
   execute: (payload: IConfigurableActionConfiguration) => void,
-  visibilityChecker?: ItemVisibilityFunc
+  visibilityChecker?: ItemVisibilityFunc,
 ): ItemType[] => {
   // Filter items based on visibility if checker is provided
   const visibleItems = visibilityChecker ? filterVisibleItems(items, visibilityChecker) : items;


### PR DESCRIPTION
#3804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile dropdown menu items now respect permission settings and are shown/hidden accordingly.
  * Menu groups automatically hide when they contain no visible items, including nested groups.
  * Dynamic and computed menu items are evaluated with visibility rules so nested structures reflect permissions and hide/appear consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->