### PR TITLE
migrate container styles

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -304,24 +304,19 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
       const defaultStylesCache = defaultStyles();
       const containerDefaultsCache = containerDefaultStyles();
 
-      // Prepare migration data
-      const existingContainer = result.desktop?.container || {};
-      const existingFont = result.desktop?.font || defaultStylesCache.font;
-
-      const containerUpdates = migrateContainerProperties(prev, existingContainer, containerDefaultsCache);
-      const fontUpdates = migrateFontProperties(prev, existingFont);
-
-      // Apply migrations to all device types
+      // Apply migrations to all device types without clobbering existing overrides
       DEVICE_TYPES.forEach((device: DeviceType) => {
         if (!result[device]) {
           result[device] = { ...defaultStylesCache };
         }
-        if (!result[device].container) {
-          result[device].container = { ...containerDefaultsCache };
-        }
 
-        // Apply updates efficiently
-        result[device].container = { ...result[device].container, ...containerUpdates };
+        const existingContainer = result[device].container ?? { ...containerDefaultsCache };
+        const existingFont = result[device].font ?? { ...defaultStylesCache.font };
+
+        const containerUpdates = migrateContainerProperties(prev, existingContainer, containerDefaultsCache);
+        const fontUpdates = migrateFontProperties(prev, existingFont);
+
+        result[device].container = { ...existingContainer, ...containerUpdates };
         result[device] = { ...result[device], ...fontUpdates };
       });
 


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated migration of legacy styling into per-device (desktop/tablet/mobile) layout and font structures.
  * Initialize device-specific containers with sensible defaults while preserving existing root-level styles.
  * Remove legacy styling keys after migration to prevent leftover legacy state.
  * Improved migration performance with caching of default style values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->