### PR TITLE
Handle single and array country restriction values

### DIFF
--- a/shesha-reactjs/src/designer-components/address/utils.ts
+++ b/shesha-reactjs/src/designer-components/address/utils.ts
@@ -88,7 +88,7 @@ export const getSearchOptions = (model: IAddressCompomentProps): PropTypes['sear
   const countries = (Array.isArray(countryRestriction)
     ? countryRestriction
     : [countryRestriction]
-  ).filter(c => c != null && c !== '');
+  ).filter((c) => c != null && c !== '');
 
   if (countries.length) {
     const countryCodes = countries.map((countryLabel) => {


### PR DESCRIPTION
https://dev.azure.com/boxfusion/Shesha%20Web%20v3.0/_workitems/edit/75953/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address search country filtering now accepts both single and multiple country inputs, normalizes and filters empty/invalid entries before use, and applies country code resolution when any country is provided. Existing location and radius handling remain unchanged, improving reliability of country-restricted address searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->