### PR TITLE
fix: disables unneeded onChange call in the SettingsControl

### DIFF
--- a/shesha-reactjs/src/designer-components/_settings/settingsControl.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/settingsControl.tsx
@@ -58,7 +58,8 @@ export const SettingsControl = <Value = any>(props: ISettingsControlProps<Value>
   };
 
   useEffect(() => {
-    onInternalChange({ ...setting, _mode: mode }, mode);
+    if (setting._mode !== mode)
+      onInternalChange({ ...setting, _mode: mode }, mode);
   }, [mode]);
 
   const codeOnChange = (val: any): void => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redundant setting updates that occurred when the mode hadn't actually changed in the settings control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->