### PR TITLE
Fix for #1350: switch SMTP email sending to MailKit

### DIFF
--- a/shesha-core/src/Shesha.Application/Email/MailKitEmailHelper.cs
+++ b/shesha-core/src/Shesha.Application/Email/MailKitEmailHelper.cs
@@ -1,0 +1,228 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Mail;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using MimeKit.Utils;
+using Shesha.Configuration;
+
+namespace Shesha.Email
+{
+    internal static class MailKitEmailHelper
+    {
+        public static MimeMessage ConvertToMimeMessage(MailMessage mail)
+        {
+            if (mail == null)
+                throw new ArgumentNullException(nameof(mail));
+
+            var message = new MimeMessage();
+
+            if (mail.From != null)
+                message.From.Add(CreateMailboxAddress(mail.From));
+
+            foreach (var address in mail.To.Cast<MailAddress>())
+            {
+                message.To.Add(CreateMailboxAddress(address));
+            }
+
+            foreach (var address in mail.CC.Cast<MailAddress>())
+            {
+                message.Cc.Add(CreateMailboxAddress(address));
+            }
+
+            foreach (var address in mail.Bcc.Cast<MailAddress>())
+            {
+                message.Bcc.Add(CreateMailboxAddress(address));
+            }
+
+            message.Subject = mail.Subject ?? string.Empty;
+
+            foreach (var headerKey in mail.Headers.AllKeys)
+            {
+                var value = mail.Headers[headerKey];
+                if (!string.IsNullOrEmpty(headerKey) && !string.IsNullOrEmpty(value))
+                {
+                    message.Headers.Replace(headerKey, value);
+                }
+            }
+
+            var builder = new BodyBuilder();
+
+            var htmlView = mail.AlternateViews
+                .Cast<AlternateView>()
+                .FirstOrDefault(v => string.Equals(v.ContentType.MediaType, "text", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(v.ContentType.MediaSubtype, "html", StringComparison.OrdinalIgnoreCase));
+
+            if (htmlView != null)
+            {
+                builder.HtmlBody = ReadAlternateView(htmlView);
+                AddLinkedResources(builder, htmlView);
+            }
+            else if (mail.IsBodyHtml)
+            {
+                builder.HtmlBody = mail.Body;
+            }
+            else
+            {
+                builder.TextBody = mail.Body;
+            }
+
+            foreach (var alternateView in mail.AlternateViews.Cast<AlternateView>())
+            {
+                if (alternateView == htmlView)
+                    continue;
+
+                if (string.Equals(alternateView.ContentType.MediaType, "text", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(alternateView.ContentType.MediaSubtype, "plain", StringComparison.OrdinalIgnoreCase))
+                {
+                    builder.TextBody = ReadAlternateView(alternateView);
+                }
+            }
+
+            foreach (var attachment in mail.Attachments.Cast<Attachment>())
+            {
+                builder.Attachments.Add(CreateAttachmentPart(attachment));
+            }
+
+            message.Body = builder.ToMessageBody();
+
+            return message;
+        }
+
+        public static async Task SendAsync(MimeMessage message, SmtpSettings settings, CancellationToken cancellationToken = default)
+        {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            using var smtpClient = new SmtpClient();
+            await smtpClient.ConnectAsync(settings.Host, settings.Port, GetSecureSocketOption(settings), cancellationToken).ConfigureAwait(false);
+
+            var credential = CreateCredential(settings);
+            if (credential != null)
+            {
+                await smtpClient.AuthenticateAsync(credential, cancellationToken).ConfigureAwait(false);
+            }
+
+            await smtpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+            await smtpClient.DisconnectAsync(true, cancellationToken).ConfigureAwait(false);
+        }
+
+        public static void Send(MimeMessage message, SmtpSettings settings, CancellationToken cancellationToken = default)
+        {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            using var smtpClient = new SmtpClient();
+            smtpClient.Connect(settings.Host, settings.Port, GetSecureSocketOption(settings), cancellationToken);
+
+            var credential = CreateCredential(settings);
+            if (credential != null)
+            {
+                smtpClient.Authenticate(credential, cancellationToken);
+            }
+
+            smtpClient.Send(message, cancellationToken);
+            smtpClient.Disconnect(true, cancellationToken);
+        }
+
+        private static void AddLinkedResources(BodyBuilder builder, AlternateView view)
+        {
+            foreach (var resource in view.LinkedResources.Cast<LinkedResource>())
+            {
+                builder.LinkedResources.Add(CreateLinkedResource(resource));
+            }
+        }
+
+        private static MimeEntity CreateAttachmentPart(Attachment attachment)
+        {
+            var mediaType = attachment.ContentType.MediaType ?? "application";
+            var mediaSubType = attachment.ContentType.MediaSubtype ?? "octet-stream";
+            var mimePart = new MimePart(mediaType, mediaSubType)
+            {
+                Content = new MimeContent(CopyToMemoryStream(attachment.ContentStream)),
+                ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+                ContentTransferEncoding = ContentEncoding.Base64,
+                FileName = attachment.Name
+            };
+
+            return mimePart;
+        }
+
+        private static MimeEntity CreateLinkedResource(LinkedResource resource)
+        {
+            var mediaType = resource.ContentType.MediaType ?? "application";
+            var mediaSubType = resource.ContentType.MediaSubtype ?? "octet-stream";
+            var mimePart = new MimePart(mediaType, mediaSubType)
+            {
+                Content = new MimeContent(CopyToMemoryStream(resource.ContentStream)),
+                ContentDisposition = new ContentDisposition(ContentDisposition.Inline),
+                ContentTransferEncoding = ContentEncoding.Base64,
+                ContentId = string.IsNullOrWhiteSpace(resource.ContentId) ? MimeUtils.GenerateMessageId() : resource.ContentId,
+                FileName = resource.ContentId
+            };
+
+            return mimePart;
+        }
+
+        private static MemoryStream CopyToMemoryStream(Stream stream)
+        {
+            var memoryStream = new MemoryStream();
+            if (stream.CanSeek)
+                stream.Position = 0;
+
+            stream.CopyTo(memoryStream);
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+
+        private static MailboxAddress CreateMailboxAddress(MailAddress address)
+        {
+            return string.IsNullOrEmpty(address.DisplayName)
+                ? MailboxAddress.Parse(address.Address)
+                : new MailboxAddress(address.DisplayName, address.Address);
+        }
+
+        private static string ReadAlternateView(AlternateView view)
+        {
+            var encoding = !string.IsNullOrWhiteSpace(view.ContentType.CharSet)
+                ? Encoding.GetEncoding(view.ContentType.CharSet)
+                : Encoding.UTF8;
+
+            if (view.ContentStream.CanSeek)
+                view.ContentStream.Position = 0;
+
+            using var reader = new StreamReader(view.ContentStream, encoding, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+            var content = reader.ReadToEnd();
+            if (view.ContentStream.CanSeek)
+                view.ContentStream.Position = 0;
+
+            return content;
+        }
+
+        private static NetworkCredential? CreateCredential(SmtpSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(settings.UserName))
+                return null;
+
+            return string.IsNullOrWhiteSpace(settings.Domain)
+                ? new NetworkCredential(settings.UserName, settings.Password)
+                : new NetworkCredential(settings.UserName, settings.Password, settings.Domain);
+        }
+
+        private static SecureSocketOptions GetSecureSocketOption(SmtpSettings settings)
+        {
+            if (!settings.EnableSsl)
+                return SecureSocketOptions.None;
+
+            return settings.Port == 465
+                ? SecureSocketOptions.SslOnConnect
+                : SecureSocketOptions.StartTls;
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Application/Email/SheshaEmailSender.cs
+++ b/shesha-core/src/Shesha.Application/Email/SheshaEmailSender.cs
@@ -8,7 +8,6 @@ using Shesha.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Mail;
 using System.Text;
 using System.Threading.Tasks;
@@ -78,10 +77,8 @@ namespace Shesha.Email
             if (!PrepareAndCheckMail(mail, smtpSettings))
                 return;
 
-            using (var smtpClient = GetSmtpClient(smtpSettings))
-            {
-                await smtpClient.SendMailAsync(mail);
-            }
+            var mimeMessage = MailKitEmailHelper.ConvertToMimeMessage(mail);
+            await MailKitEmailHelper.SendAsync(mimeMessage, smtpSettings);
         }
 
         protected override void SendEmail(MailMessage mail)
@@ -95,10 +92,8 @@ namespace Shesha.Email
             if (!PrepareAndCheckMail(mail, smtpSettings))
                 return;
 
-            using (var smtpClient = GetSmtpClient(smtpSettings))
-            {
-                smtpClient.Send(mail);
-            }
+            var mimeMessage = MailKitEmailHelper.ConvertToMimeMessage(mail);
+            MailKitEmailHelper.Send(mimeMessage, smtpSettings);
         }
 
         #region private methods
@@ -195,22 +190,6 @@ namespace Shesha.Email
                         );
                 }
             }
-        }
-
-        /// <summary>
-        /// Returns SmtpClient configured according to the current application settings
-        /// </summary>
-        private SmtpClient GetSmtpClient(SmtpSettings smtpSettings)
-        {
-            var client = new SmtpClient(smtpSettings.Host, smtpSettings.Port)
-            {
-                EnableSsl = smtpSettings.EnableSsl,
-                Credentials = string.IsNullOrWhiteSpace(smtpSettings.Domain)
-                    ? new NetworkCredential(smtpSettings.UserName, smtpSettings.Password)
-                    : new NetworkCredential(smtpSettings.UserName, smtpSettings.Password, smtpSettings.Domain)
-            };
-
-            return client;
         }
 
         #endregion

--- a/shesha-core/src/Shesha.Application/Notifications/Emails/EmailChannelSender.cs
+++ b/shesha-core/src/Shesha.Application/Notifications/Emails/EmailChannelSender.cs
@@ -3,13 +3,13 @@ using Castle.Core.Logging;
 using Shesha.Configuration;
 using Shesha.Configuration.Email;
 using Shesha.Domain;
+using Shesha.Email;
 using Shesha.Email.Dtos;
 using Shesha.Notifications.Dto;
 using Shesha.Notifications.MessageParticipants;
 using Shesha.Utilities;
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Mail;
 using System.Threading.Tasks;
 
@@ -86,38 +86,15 @@ namespace Shesha.Notifications
         {
             try
             {
-                using (var smtpClient = await GetSmtpClientAsync())
-                {
-                    smtpClient.Send(mail);
-                }
+                var mimeMessage = MailKitEmailHelper.ConvertToMimeMessage(mail);
+                var smtpSettings = await _emailSettings.SmtpSettings.GetValueAsync();
+                await MailKitEmailHelper.SendAsync(mimeMessage, smtpSettings);
             }
             catch (Exception ex)
             {
                 Logger.Error($"Error sending email: {ex.Message}", ex);
                 throw new InvalidOperationException($"An error occurred while sending the email. Message: {ex.Message} ", ex);
             }
-        }
-
-        private async Task<SmtpClient> GetSmtpClientAsync() 
-        {
-            var smtpSettings = await _emailSettings.SmtpSettings.GetValueAsync();
-            return GetSmtpClient(smtpSettings);
-        }
-
-        /// <summary>
-        /// Returns SmtpClient configured according to the current application settings
-        /// </summary>
-        private SmtpClient GetSmtpClient(SmtpSettings smtpSettings)
-        {
-            var client = new SmtpClient(smtpSettings.Host, smtpSettings.Port)
-            {
-                EnableSsl = smtpSettings.EnableSsl,
-                Credentials = string.IsNullOrWhiteSpace(smtpSettings.Domain)
-                    ? new NetworkCredential(smtpSettings.UserName, smtpSettings.Password)
-                    : new NetworkCredential(smtpSettings.UserName, smtpSettings.Password, smtpSettings.Domain)
-            };
-
-            return client;
         }
 
         /// <summary>

--- a/shesha-core/src/Shesha.Application/Shesha.Application.csproj
+++ b/shesha-core/src/Shesha.Application/Shesha.Application.csproj
@@ -166,6 +166,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="MailKit" Version="4.7.0" />
         <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2">


### PR DESCRIPTION
## Summary
- replace System.Net-based SMTP usage with MailKit for Shesha email senders
- add a helper to convert MailMessage instances to MimeMessage and handle sending via MailKit
- reference the MailKit package from Shesha.Application

## Testing
- `dotnet build shesha-core/src/Shesha.Application/Shesha.Application.csproj` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912dfa656cc8330b5b3607e75df527b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email sending infrastructure to use MailKit library, improving the robustness and flexibility of the email transmission system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->