### PR TITLE
fix: adding conditional checks on migration for FormConfiguration properties

### DIFF
--- a/shesha-core/src/Shesha.Framework/Migrations/M20251110113300.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/M20251110113300.cs
@@ -8,12 +8,35 @@ namespace Shesha.Migrations
     {
         public override void Up()
         {
-            Alter.Table("Frwk_FormConfigurations")
-                .AddColumn("ConfigurationFormModule").AsString().Nullable()
-                .AddColumn("ConfigurationFormName").AsString().Nullable()
-                .AddColumn("GenerationLogicTypeName").AsString().Nullable()
-                .AddColumn("PlaceholderIcon").AsString().Nullable()
-                .AddColumn("GenerationLogicExtensionJson").AsStringMax().Nullable();
+            if (!Schema.Table("Frwk_FormConfigurations").Column("ConfigurationFormModule").Exists())
+            {
+                Alter.Table("Frwk_FormConfigurations")
+                    .AddColumn("ConfigurationFormModule").AsString().Nullable();
+            }
+
+            if (!Schema.Table("Frwk_FormConfigurations").Column("ConfigurationFormName").Exists())
+            {
+                Alter.Table("Frwk_FormConfigurations")
+                    .AddColumn("ConfigurationFormName").AsString().Nullable();
+            }
+
+            if (!Schema.Table("Frwk_FormConfigurations").Column("GenerationLogicTypeName").Exists())
+            {
+                Alter.Table("Frwk_FormConfigurations")
+                    .AddColumn("GenerationLogicTypeName").AsString().Nullable();
+            }
+
+            if (!Schema.Table("Frwk_FormConfigurations").Column("PlaceholderIcon").Exists())
+            {
+                Alter.Table("Frwk_FormConfigurations")
+                    .AddColumn("PlaceholderIcon").AsString().Nullable();
+            }
+
+            if (!Schema.Table("Frwk_FormConfigurations").Column("GenerationLogicExtensionJson").Exists())
+            {
+                Alter.Table("Frwk_FormConfigurations")
+                    .AddColumn("GenerationLogicExtensionJson").AsStringMax().Nullable();
+            }
         }
     }
 }

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/details-view/detailsViewGenerationLogic.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/details-view/detailsViewGenerationLogic.ts
@@ -55,6 +55,29 @@ export class DetailsViewGenerationLogic extends BaseGenerationLogic {
   }
 
   /**
+   * Attempts to find a suitable display name property from the entity metadata.
+   * Checks for common property names like 'fullName' and 'name'.
+   *
+   * @param metadata The properties metadata.
+   * @returns The path to a display name property, or null if not found.
+   */
+  private findDisplayNameProperty(metadata: PropertyMetadataDto[]): string | null {
+    // Common property names that typically serve as display names, in order of preference
+    const commonDisplayNames = ['fullName', 'name'];
+
+    for (const displayName of commonDisplayNames) {
+      const property = metadata.find((prop) =>
+        prop.path?.toLowerCase() === displayName.toLowerCase()
+      );
+      if (property) {
+        return property.path;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Adds header components to the markup.
    * Sets the title and optionally adds a key information bar if configured.
    *
@@ -66,7 +89,11 @@ export class DetailsViewGenerationLogic extends BaseGenerationLogic {
    * @returns Array of property paths used in key information bar, empty array if none used
    */
   private addHeader(entity: IEntityMetadata, metadata: PropertyMetadataDto[], markup: any, extensionJson: DetailsViewExtensionJson, metadataHelper: FormMetadataHelper): string[] {
-    const title = `${entity.typeAccessor} Details`;
+    // Try to find a display name property, falling back to static entity type name
+    const displayNameProperty = this.findDisplayNameProperty(metadata);
+    const title = displayNameProperty
+      ? `{{${toCamelCase(displayNameProperty)}}}`
+      : `${entity.typeAccessor} Details`;
 
     const titleContainer = findContainersWithPlaceholder(markup, "//*TITLE*//");
 


### PR DESCRIPTION
Adding conditional checks on migration for FormConfiguration properties and additional considerations for title on DetailsViewGenerationLogic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration robustness to prevent errors when columns already exist.

* **New Features**
  * Entity details views now display dynamic, meaningful titles derived from entity metadata instead of generic titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->