### PR TITLE
85171 Uploads Not Displayed and File Upload Fails on Details View

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -233,8 +233,6 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
   validateSettings: (model) => validateConfigurableComponentSettings(getSettings, model),
   linkToModelMetadata: (model, metadata) => ({
     ...model,
-    ownerId: '{data.id}',
-    ownerType: metadata.entityType && { module: metadata.entityModule, name: metadata.entityType ?? '' },
     filesCategory: metadata.path,
   }),
   migrator: (m) => m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated Attachments Editor metadata linking: ownerId and ownerType fields are no longer automatically populated when linking model metadata. Only filesCategory will be set from metadata path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->