### PR TITLE
fix: show 'Action Configuration' label in button group item settings

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/itemSettings.ts
@@ -179,7 +179,7 @@ export const getItemSettings: FormMarkupFactory = ({ fbf }) => {
                       id: nanoid(),
                       propertyName: 'actionConfiguration',
                       label: 'Action Configuration',
-                      hideLabel: true,
+                      hideLabel: false,
                       validate: {},
                       settingsValidationErrors: [],
                     }).toJson(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Action Configuration label is now visible in the button group configurator interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->