### PR TITLE
feat: enhance ButtonGroupConfigurator

### DIFF
--- a/shesha-reactjs/src/components/buttonGroupConfigurator/index.tsx
+++ b/shesha-reactjs/src/components/buttonGroupConfigurator/index.tsx
@@ -12,6 +12,8 @@ export interface IToolbarSettingsModal {
   onChange?: (newValue: ButtonGroupItemProps[]) => void;
   title?: ReactNode | string;
   size?: SizeType;
+  buttonText?: string;
+  buttonTextReadOnly?: string;
 }
 
 interface IButtonGroupConfiguratorProps extends IToolbarSettingsModal {
@@ -24,6 +26,8 @@ export const ButtonGroupConfigurator: FC<IButtonGroupConfiguratorProps> = ({
   readOnly,
   size,
   title = 'Buttons Configuration',
+  buttonText = 'Customize Button Group',
+  buttonTextReadOnly = 'View Button Group',
 }) => {
   const isSmall = useMedia('(max-width: 480px)');
   const [showModal, setShowModal] = useState(false);
@@ -46,7 +50,7 @@ export const ButtonGroupConfigurator: FC<IButtonGroupConfiguratorProps> = ({
 
   return (
     <Fragment>
-      <Button size={size} onClick={openModal}>{readOnly ? 'View Button Group' : 'Customize Button Group'}</Button>
+      <Button size={size} onClick={openModal}>{readOnly ? buttonTextReadOnly : buttonText }</Button>
 
       <Modal
         width={isSmall ? '90%' : '60%'}

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -213,6 +213,8 @@ export const getSettings = () => {
                               label: 'Custom Actions',
                               type: 'buttonGroupConfigurator',
                               buttonText: 'Customize Actions',
+                              buttonTextReadOnly: 'View Actions',
+                              title: 'Actions Configuration',
                               description: 'Configure custom actions that appear when hovering over files. Each action should have: id, name, label, icon (optional), tooltip (optional), hidden (optional), and actionConfiguration.',
                               jsSetting: false,
                             },

--- a/shesha-reactjs/src/designer-components/inputComponent/index.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/index.tsx
@@ -49,7 +49,7 @@ export const InputComponent: FC<Omit<ISettingsInputProps, 'hidden'>> = (props) =
 
     const metadataBuilderFactory = useMetadataBuilderFactory();
     const { formData } = useShaFormInstance();
-    const { size, className, value, placeholder, type, dropdownOptions, buttonGroupOptions, defaultValue, componentType, tooltipAlt, iconSize,
+    const { size, className, value, placeholder, type, dropdownOptions, buttonGroupOptions, defaultValue, componentType, tooltipAlt, iconSize, buttonText, buttonTextReadOnly, title,
 
         propertyName, tooltip: description, onChange, readOnly, label, availableConstantsExpression, noSelectionItemText, noSelectionItemValue,
         allowClear, dropdownMode, variant, icon, iconAlt, tooltip, dataSourceType, dataSourceUrl, onAddNewItem, listItemSettingsMarkup, propertyAccessor, referenceList, textType, defaultChecked, showSearch = true, settings, templateSettings } = props;
@@ -181,7 +181,7 @@ export const InputComponent: FC<Omit<ISettingsInputProps, 'hidden'>> = (props) =
         case 'filtersList':
             return <FiltersList readOnly={readOnly}  {...props} />;
         case 'buttonGroupConfigurator':
-            return <ButtonGroupConfigurator readOnly={readOnly} size={size} value={value} onChange={onChange} />;
+            return <ButtonGroupConfigurator readOnly={readOnly} size={size} value={value} onChange={onChange} buttonText={buttonText} buttonTextReadOnly={buttonTextReadOnly} title={title} />;
         case 'editModeSelector':
             return <EditModeSelector readOnly={readOnly} value={value} onChange={onChange} size={size} />;
         case 'dynamicItemsConfigurator':


### PR DESCRIPTION
- Added `buttonText` and `buttonTextReadOnly` props to `ButtonGroupConfigurator` for improved flexibility in button labeling.
- Updated the `InputComponent` to pass new props to `ButtonGroupConfigurator`.
- Modified settings in `attachmentsEditor` to include a title and read-only button text for better user guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented customizable button labels in button group configuration components, with separate text options for read-only and editable modes
  * Enhanced action configuration panels with new title and label options to improve interface clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->