### PR TITLE
style downloaded files default to false

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -129,7 +129,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
   gap,
   enableStyleOnReadonly = true,
   downloadedFileStyles,
-  styleDownloadedFiles = true,
+  styleDownloadedFiles = false,
   downloadedIcon = 'CheckCircleOutlined',
   ...rest
 }) => {


### PR DESCRIPTION
#4239
[comment](https://github.com/shesha-io/shesha-framework/issues/4239#:~:text=userHasDownloaded%20property%20true%20without%20downloading%20file.%20To%20reproduce%3A%20upload%20file%2C%20check%20Upload%20api%20%2D%3E%20userHasDownloaded%3D%20false%2C%20save%20details%2C%20refresh%20page%20and%20the%20property%20became%20true).
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the default styling behavior for downloaded files to be disabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->