### PR TITLE
Fix/4183/user settings in wrong area

### DIFF
--- a/shesha-reactjs/src/components/settingsEditor/provider/index.tsx
+++ b/shesha-reactjs/src/components/settingsEditor/provider/index.tsx
@@ -42,7 +42,7 @@ const getListFetcherQueryParams = (maxResultCount): IGenericGetAllPayload => {
     maxResultCount: maxResultCount ?? -1,
     entityType: 'Shesha.Domain.SettingConfiguration',
     properties:
-      'id category dataType editorFormModule editorFormName isClientSpecific name, module { id name }, label, description, versionNo',
+      'id category dataType editorFormModule editorFormName isClientSpecific name, module { id name }, label, description, versionNo, isUserSpecific',
     quickSearch: null,
     sorting: 'module.name, name',
     
@@ -64,6 +64,7 @@ interface SettingConfigurationDto {
     id: string;
     name: string;
   };
+  isUserSpecific: boolean;
 }
 
 const SettingsEditorProvider: FC<PropsWithChildren<ISettingsEditorProviderProps>> = ({ children }) => {
@@ -100,6 +101,7 @@ const SettingsEditorProvider: FC<PropsWithChildren<ISettingsEditorProviderProps>
               module: item.module?.name,
               editorForm: item.editorFormName ? { name: item.editorFormName, module: item.editorFormModule } : null,
               isClientSpecific: item.isClientSpecific,
+              isUserSpecific: item.isUserSpecific
             };
           });
 

--- a/shesha-reactjs/src/components/settingsEditor/provider/models.ts
+++ b/shesha-reactjs/src/components/settingsEditor/provider/models.ts
@@ -14,6 +14,7 @@ export interface ISettingConfiguration {
     description?: string;
     module?: string;
     isClientSpecific: boolean;
+    isUserSpecific: boolean;
 }  
 
 export type SettingValue = any;

--- a/shesha-reactjs/src/components/settingsEditor/settingsMenu.tsx
+++ b/shesha-reactjs/src/components/settingsEditor/settingsMenu.tsx
@@ -77,11 +77,11 @@ export const SettingsMenu: FC<ISettingsMenuProps> = () => {
       settingConfigurations.forEach(s => {
         //const moduleName = s.configuration.module?.name ?? 'no module';
         const category = s.category ?? '';
-
+        console.log(s.isUserSpecific);
         if (s.isClientSpecific && selectedApplication) {
           addSetting(category, s, selectedApplication);
         };
-        if (!s.isClientSpecific && !selectedApplication) {
+        if (!s.isClientSpecific && !selectedApplication && !s.isUserSpecific) {
           addSetting(category, s, null);
         }
       });

--- a/shesha-reactjs/src/components/settingsEditor/settingsMenu.tsx
+++ b/shesha-reactjs/src/components/settingsEditor/settingsMenu.tsx
@@ -77,7 +77,6 @@ export const SettingsMenu: FC<ISettingsMenuProps> = () => {
       settingConfigurations.forEach(s => {
         //const moduleName = s.configuration.module?.name ?? 'no module';
         const category = s.category ?? '';
-        console.log(s.isUserSpecific);
         if (s.isClientSpecific && selectedApplication) {
           addSetting(category, s, selectedApplication);
         };


### PR DESCRIPTION
User settings should not be visible under General Settings list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The settings editor now supports marking configuration items as user-specific or application-wide, providing better organization of settings based on scope.
  * Enhanced filtering logic ensures user-specific settings are properly excluded from general settings views when no application context is selected, improving the settings discovery and management experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->