### PR TITLE
89625 Property with capital letters in a row crashes when saving

### DIFF
--- a/shesha-core/src/Shesha.Framework/Utilities/CamelCaseHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Utilities/CamelCaseHelper.cs
@@ -23,7 +23,7 @@ namespace Shesha.Utilities
 
         public static string Convert(string input) 
         {
-            return Convert(input, new ConvertOptions { PascalCase = false, PreserveConsecutiveUppercase = false });
+            return Convert(input, new ConvertOptions { PascalCase = false, PreserveConsecutiveUppercase = false, KeepLeadingSeparators = false });
         }
 
         public static string Convert(string input, ConvertOptions options)
@@ -48,8 +48,8 @@ namespace Shesha.Utilities
             if (hasUpperCase)
                 input = PreserveCamelCase(input, options.PreserveConsecutiveUppercase);
 
-            
-            input = LEADING_SEPARATORS.Replace(input, "");
+            if (!options.KeepLeadingSeparators)
+                input = LEADING_SEPARATORS.Replace(input, "");
 	        input = options.PreserveConsecutiveUppercase 
                 ? PreserveConsecutiveUppercase(input) 
                 : input.ToLower();
@@ -128,6 +128,10 @@ namespace Shesha.Utilities
 
         public class ConvertOptions 
         {
+            /// <summary>
+            /// NOTE! The camelCase and PascalCase standards remove the leading separators. Use this option with caution.
+            /// </summary>
+            public bool KeepLeadingSeparators { get; set; }
             public bool PascalCase { get; set; }
             public bool PreserveConsecutiveUppercase { get; set; }
         }

--- a/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
@@ -567,47 +567,8 @@ namespace Shesha.Utilities
         /// </summary>
         public static string ToCamelCase(this string input)
         {
-            if (string.IsNullOrWhiteSpace(input))
-                return input;
-
-            // Save the initial underscores
-            string leadingUnderscores = new string(input.TakeWhile(c => c == '_').ToArray());
-            string remaining = input.Substring(leadingUnderscores.Length);
-
-            if (string.IsNullOrWhiteSpace(remaining))
-                return leadingUnderscores;
-
-            var words = Regex.Split(remaining,
-                @"(
-                    [\s\-_.]+ |                   # separators
-                    (?<=[a-z\d])(?=[A-Z]) |       # lowercase letter/number -> uppercase
-                    (?<=[A-Z])(?=[A-Z][a-z])      # abbreviation -> lowercase
-                )", RegexOptions.IgnorePatternWhitespace)
-                .Where(w => !string.IsNullOrWhiteSpace(w))
-                .ToArray();
-
-            if (!words.Any())
-                return leadingUnderscores;
-
-            // Convert to camelCase
-            var result = new StringBuilder();
-#if HAVE_CHAR_TO_STRING_WITH_CULTURE
-            result.Append(words[0].ToLower(CultureInfo.InvariantCulture));
-#else
-            result.Append(words[0].ToLowerInvariant());
-#endif
-
-            for (int i = 1; i < words.Length; i++)
-            {
-                var word = words[i];
-#if HAVE_CHAR_TO_STRING_WITH_CULTURE
-                result.Append(char.ToUpper(word[0], CultureInfo.InvariantCulture)).Append(word.Substring(1).ToLower(CultureInfo.InvariantCulture));
-#else
-                result.Append(char.ToUpperInvariant(word[0])).Append(word.Substring(1).ToLowerInvariant());
-#endif
-            }
-
-            return leadingUnderscores + result.ToString();
+            // The camelCase and PascalCase standards remove the leading separators. But we need it for using special fields like `_className` and `_displayName`
+            return CamelCaseHelper.Convert(input, new CamelCaseHelper.ConvertOptions() { KeepLeadingSeparators = true });
         }
 
         public static string? ToCamelCaseOrNull(this string? s) 

--- a/shesha-reactjs/src/utils/string.ts
+++ b/shesha-reactjs/src/utils/string.ts
@@ -93,8 +93,64 @@ export const getNumericValue = (localValue: number | string): number => {
   }
 };
 
-export function toCamelCase(str: string): string {
-  return camelcase(str);
+export interface CamelCaseOptions {
+  /** Keep the leading separator: `_foo_bar` → `_fooBar`.
+   * NOTE! The camelCase and PascalCase standards remove the leading separators. Use this option with caution.
+   * Default is true because we need it for using special fields like `_className` and `_displayName`
+  @default true
+   */
+  readonly keepLeadingSeparators?: boolean;
+
+  /** Uppercase the first character: `foo-bar` → `FooBar`.
+  @default false
+   */
+  readonly pascalCase?: boolean;
+
+  /** Preserve the consecutive uppercase characters: `foo-BAR` → `FooBAR`.
+  @default false
+   */
+  readonly preserveConsecutiveUppercase?: boolean;
+
+  /**
+  The locale parameter indicates the locale to be used to convert to upper/lower case according to any locale-specific case mappings. If multiple locales are given in an array, the best available locale is used.
+  Setting `locale: false` ignores the platform locale and uses the [Unicode Default Case Conversion](https://unicode-org.github.io/icu/userguide/transforms/casemappings.html#simple-single-character-case-mapping) algorithm.
+  Default: The host environment’s current locale.
+  @example
+  ```
+  import camelCase = require('camelcase');
+  camelCase('lorem-ipsum', {locale: 'en-US'});
+  //=> 'loremIpsum'
+  camelCase('lorem-ipsum', {locale: 'tr-TR'});
+  //=> 'loremİpsum'
+  camelCase('lorem-ipsum', {locale: ['en-US', 'en-GB']});
+  //=> 'loremIpsum'
+  camelCase('lorem-ipsum', {locale: ['tr', 'TR', 'tr-TR']});
+  //=> 'loremİpsum'
+  ```
+   */
+  readonly locale?: false | string | readonly string[];
+}
+
+const leadingSeparatorsRegex = /^[-_.\s]+/;
+
+export function toCamelCase(str: string | null | undefined, options?: CamelCaseOptions): string | null | undefined {
+  const text = str?.trim();
+
+  if (!text) return text;
+
+  // The camelCase and PascalCase standards remove the leading separators.
+  // But we need it for using special fields like `_className` and `_displayName`
+  const leadingSeparators = options?.keepLeadingSeparators ?? true
+    ? text.match(leadingSeparatorsRegex)?.[0] ?? ''
+    : '';
+
+  const result = camelcase(text.replace(leadingSeparatorsRegex, ''), {
+    locale: options?.locale ?? undefined,
+    pascalCase: options?.pascalCase ?? false,
+    preserveConsecutiveUppercase: options?.preserveConsecutiveUppercase ?? false,
+  });
+
+  return leadingSeparators + result;
 }
 
 export function getNumberFormat(str: string, format: string): string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced case-conversion utilities: new option to preserve leading separators, plus configurable pascal-case, consecutive-uppercase preservation, and locale-aware formatting; JS utility now accepts options.

* **Refactor**
  * Unified case-conversion logic to a shared helper for consistent behavior.

* **Documentation**
  * Added documentation for the new leading-separator option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->