### PR TITLE
Fixed designer component tooltip overlapping with selected radio button and search field

### DIFF
--- a/shesha-reactjs/src/components/editModeSelector/index.tsx
+++ b/shesha-reactjs/src/components/editModeSelector/index.tsx
@@ -8,6 +8,7 @@ export interface IReadOnlyModeSelectorProps {
   readOnly?: boolean;
   onChange?: (value: EditMode) => void;
   size?: 'small' | 'middle' | 'large';
+  className?: string;
 }
 
 const EditModeSelector: FC<IReadOnlyModeSelectorProps> = (props) => {
@@ -18,7 +19,7 @@ const EditModeSelector: FC<IReadOnlyModeSelectorProps> = (props) => {
       : props.value;
 
   return (
-    <Radio.Group buttonStyle="solid" value={val} onChange={(e) => props.onChange(e.target.value)} size={props.size} disabled={props.readOnly}>
+    <Radio.Group buttonStyle="solid" value={val} onChange={(e) => props.onChange(e.target.value)} size={props.size} disabled={props.readOnly} className={props.className}>
       <Radio.Button key="editable" value="editable"><Icon icon="editIcon" hint="Editable" /></Radio.Button>
       <Radio.Button key="readOnly" value="readOnly"><Icon icon="readonlyIcon" hint="Read only" /></Radio.Button>
       <Radio.Button key="inherited" value="inherited"><Icon icon="inheritIcon" hint="Inherited" /></Radio.Button>

--- a/shesha-reactjs/src/designer-components/inputComponent/styles.ts
+++ b/shesha-reactjs/src/designer-components/inputComponent/styles.ts
@@ -17,9 +17,17 @@ export const useStyles = createStyles(({ css, cx }) => {
   const icon = cx(css`
         --icon-fill-color: #1C1B1F;
     `);
+
+  const radioBtns = cx(css`
+      .ant-radio-button-wrapper-checked {
+        z-index: 0 !important;
+      }
+      
+      `);
   return {
     inlineInputs,
     rowInputs,
     icon,
+    radioBtns,
   };
 });

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/editModeSelector.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/editModeSelector.tsx
@@ -1,8 +1,11 @@
 import { IEditModeSelectorSettingsInputProps } from '@/designer-components/settingsInput/interfaces';
 import React, { FC } from 'react';
 import EditModeSelector from '@/components/editModeSelector';
+import { useStyles } from '../styles';
 
 export const EditModeSelectorWrapper: FC<IEditModeSelectorSettingsInputProps> = (props) => {
+  const { styles } = useStyles();
+
   const { value, onChange, readOnly, size } = props;
   return (
     <EditModeSelector
@@ -10,6 +13,7 @@ export const EditModeSelectorWrapper: FC<IEditModeSelectorSettingsInputProps> = 
       value={value}
       onChange={onChange}
       size={size}
+      className={styles.radioBtns}
     />
   );
 };

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/radio.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/radio.tsx
@@ -21,6 +21,7 @@ export const RadioWrapper: FC<IRadioSettingsInputProps> = (props) => {
       disabled={readOnly}
       buttonStyle="solid"
       size={size}
+      className={styles.radioBtns}
     >
       {
         buttonGroupOptions?.map(({ value: optionValue, icon, title }) => {

--- a/shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx
+++ b/shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx
@@ -105,8 +105,10 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
                 type="search"
                 size="small"
                 allowClear
+                className={styles.searchField}
                 style={{
                   marginBottom: '16px',
+                  zIndex: 0,
                 }}
                 ref={(el) => {
                   if (el) {
@@ -154,28 +156,6 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
 
   return (
     <>
-      {newFilteredTabs.length === 0 && (
-        <div
-          className={styles.searchField}
-          style={{
-            position: 'sticky',
-            top: -16,
-            zIndex: 2,
-            padding: '8px 0',
-          }}
-        >
-          <Input
-            type="search"
-            size="small"
-            allowClear
-            placeholder="Search properties"
-            value={searchQuery}
-            onChange={handleSearchChange}
-            autoFocus
-            suffix={<SearchOutlined style={{ color: 'rgba(0,0,0,.45)' }} />}
-          />
-        </div>
-      )}
       {newFilteredTabs.length === 0 && searchQuery
         ? <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Property Not Found" />
         : (

--- a/shesha-reactjs/src/designer-components/propertiesTabs/style.ts
+++ b/shesha-reactjs/src/designer-components/propertiesTabs/style.ts
@@ -2,8 +2,11 @@ import { createStyles } from '@/styles';
 
 export const useStyles = createStyles(({ css, cx, token }) => {
   const searchField = cx(css`
-    width: 100%;
-    background: #fff;
+    z-index: unset;
+
+    .ant-input-affix-wrapper-focused, .ant-input-affix-wrapper:hover {
+      z-index: unset !important;
+    }
   `);
 
   const content = cx(css`

--- a/shesha-reactjs/src/designer-components/styleLabel/styles.ts
+++ b/shesha-reactjs/src/designer-components/styleLabel/styles.ts
@@ -10,7 +10,6 @@ export const useStyles = createStyles(({ css, cx, token }) => {
         justify-content: flex-end;
         top: 0px;
         right: 30px;
-        z-index: 1;
     `);
 
   const hidelLabelIcon = cx("", css`


### PR DESCRIPTION
This PR addresses devOps issue: 85292

- Search field on property panel overlaps component's tooltip.
- Component tooltip appears to be obstructed by selected radio buttons in the properties panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added styling customization support to the edit mode selector component.

* **Style**
  * Refined z-index layering for radio buttons and search inputs to improve visual stacking order.
  * Updated search input styling for better focus and hover states.
  * Adjusted component stacking hierarchy for improved UI consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->