### PR TITLE
feat: hide exposed configuration items in autocomplete components

### DIFF
--- a/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
+++ b/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
@@ -46,12 +46,20 @@ interface IOption<TData = ConfigurableItemFullName> {
 
 const baseItemFilter = undefined;
 
-const baseListFilter = {
+const moduleNotEmpty = {
   "!=": [
     {
       var: "module",
     },
     null,
+  ],
+};
+const notExposedFilter = {
+  "!=": [
+    {
+      var: "isExposed",
+    },
+    true,
   ],
 };
 
@@ -64,7 +72,7 @@ const getFilter = (term: string, staticFilter?: object): string => {
       ],
     }
     : undefined;
-  const allFilters = [baseListFilter, termFilter, staticFilter].filter((f) => Boolean(f));
+  const allFilters = [moduleNotEmpty, notExposedFilter, termFilter, staticFilter].filter((f) => Boolean(f));
   const filter = allFilters.length === 0
     ? undefined
     : allFilters.length === 1

--- a/shesha-reactjs/src/components/referenceListAutocomplete/index.tsx
+++ b/shesha-reactjs/src/components/referenceListAutocomplete/index.tsx
@@ -27,12 +27,20 @@ interface IOption {
 const baseItemFilter = [
 ];
 
-const baseListFilter = {
+const moduleNotEmpty = {
   "!=": [
     {
       var: "module",
     },
     null,
+  ],
+};
+const notExposedFilter = {
+  "!=": [
+    {
+      var: "isExposed",
+    },
+    true,
   ],
 };
 
@@ -46,7 +54,7 @@ const getFilter = (term: string): string => {
     }
     : undefined;
 
-  const allFilters = [baseListFilter, termFilter].filter((f) => Boolean(f));
+  const allFilters = [moduleNotEmpty, notExposedFilter, termFilter].filter((f) => Boolean(f));
   const filter = allFilters.length === 0
     ? undefined
     : allFilters.length === 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated filtering behavior in configurable item and reference list autocomplete components to exclude items with null module values and items marked as exposed, improving data consistency and list accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->