### PR TITLE
refactor: remove file name normalization in custom request upload

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -224,13 +224,8 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     },
     customRequest(options: any) {
       // It used to be RcCustomRequestOptions, but it doesn't seem to be found anymore
-      // Normalize file extension to lowercase to avoid case sensitivity issues on Linux
-      const lastDotIndex = options?.file?.name.lastIndexOf(".");
-      const fileName = lastDotIndex === -1 ? options?.file?.name : options?.file?.name.substring(0, lastDotIndex) + options?.file?.name.substring(lastDotIndex).toLowerCase();
 
-      const normalizedFile = new File([options.file], fileName, { type: options.file.type });
-
-      uploadFile({ file: normalizedFile, ownerId, ownerType });
+      uploadFile({ file: options.file, ownerId, ownerType });
     },
     beforeUpload(file: RcFile) {
       const { type, size, name } = file;


### PR DESCRIPTION
#4049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File uploads now preserve original file names instead of automatically converting them to lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->