### PR TITLE
fix: update AzureStoredFileService to use original filePath casing

### DIFF
--- a/shesha-core/src/Shesha.Framework/Services/StoredFiles/AzureStoredFileService.cs
+++ b/shesha-core/src/Shesha.Framework/Services/StoredFiles/AzureStoredFileService.cs
@@ -71,7 +71,7 @@ namespace Shesha.Services.StoredFiles
 
         private async Task<Stream> GetStreamInternalAsync(string filePath)
         {
-            var blob = GetBlobClient(filePath.ToLower());
+            var blob = GetBlobClient(filePath);
             var stream = new MemoryStream();
 
             var props = await blob.GetPropertiesAsync();


### PR DESCRIPTION
#4050 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File path handling for cloud storage is now case-sensitive when retrieving stored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->