### PR TITLE
fix: fixed permissions of forms after expose

### DIFF
--- a/shesha-core/src/Shesha.Framework/ConfigurationItems/ConfigurationItemManager.cs
+++ b/shesha-core/src/Shesha.Framework/ConfigurationItems/ConfigurationItemManager.cs
@@ -110,6 +110,11 @@ namespace Shesha.ConfigurationItems
             return Task.CompletedTask;
         }
 
+        protected virtual Task AfterItemExposedAsync(TItem exposedItem)
+        {
+            return Task.CompletedTask;
+        }
+
         /// <summary>
         /// Copy value of custom properties from <paramref name="source"/> to <paramref name="destination"/>.
         /// Is used in Duplicate and Expose operations
@@ -165,6 +170,8 @@ namespace Shesha.ConfigurationItems
                 });
 
                 await UnitOfWorkManager.Current.SaveChangesAsync();
+
+                await AfterItemExposedAsync(exposedConfig);
 
                 return exposedConfig;
             }            

--- a/shesha-core/src/Shesha.Web.FormsDesigner/Services/FormManager.cs
+++ b/shesha-core/src/Shesha.Web.FormsDesigner/Services/FormManager.cs
@@ -6,6 +6,7 @@ using Shesha.Domain;
 using Shesha.Domain.Enums;
 using Shesha.Dto.Interfaces;
 using Shesha.Permissions;
+using Shesha.Reflection;
 using Shesha.Web.FormsDesigner.Dtos;
 using Shesha.Web.FormsDesigner.Models;
 using System.Collections.Generic;
@@ -116,6 +117,17 @@ namespace Shesha.Web.FormsDesigner.Services
             await _permissionedObjectManager.CopyAsync(
                 GetFormPermissionedObjectName(item.Module?.Name, item.Name),
                 GetFormPermissionedObjectName(duplicate.Module?.Name, duplicate.Name),
+                ShaPermissionedObjectsTypes.Form
+            );
+        }
+
+        protected override async Task AfterItemExposedAsync(FormConfiguration exposedItem)
+        {
+            var sourceItem = exposedItem.ExposedFrom.NotNull();
+
+            await _permissionedObjectManager.CopyAsync(
+                GetFormPermissionedObjectName(sourceItem.Module?.Name, sourceItem.Name),
+                GetFormPermissionedObjectName(exposedItem.Module?.Name, exposedItem.Name),
                 ShaPermissionedObjectsTypes.Form
             );
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced configuration item exposure with improved permission handling capabilities. The system now automatically manages and preserves permission settings, permissioned object associations, and access control configurations when publishing forms and other configuration items. This ensures consistent permission management across exposures, eliminating the need for manual reconfiguration of access controls after item publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->