### PR TITLE
refactor: simplify ConfigurableFormItemSetting by removing unused styles

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/components/configurableFormItemSetting.tsx
+++ b/shesha-reactjs/src/components/formDesigner/components/configurableFormItemSetting.tsx
@@ -5,8 +5,6 @@ import { getPropertySettingsFromData } from '@/designer-components/_settings/uti
 import { SettingsControl, useShaFormInstance } from '@/index';
 import { IConfigurableFormItemChildFunc, IConfigurableFormItemProps } from './model';
 import { ConfigurableFormItemLive } from './configurableFormItemLive';
-import { useStyles } from './styles';
-import classNames from 'classnames';
 
 export const ConfigurableFormItemSetting: FC<IConfigurableFormItemProps> = ({
   children,
@@ -14,8 +12,7 @@ export const ConfigurableFormItemSetting: FC<IConfigurableFormItemProps> = ({
   valuePropName,
 }) => {
   const { formData } = useShaFormInstance();
-  const hasLabel = !!model.label;
-  const { styles } = useStyles({ layout: 'vertical', hasLabel });
+
   if (model.hidden) return null;
 
   const { _mode: mode } = getPropertySettingsFromData(formData, model.propertyName);
@@ -25,16 +22,14 @@ export const ConfigurableFormItemSetting: FC<IConfigurableFormItemProps> = ({
     label: model.label,
     // style: model.style,
     required: model.validate?.required,
-    tooltip: model.description || undefined,
+    tooltip: model.description,
     hidden: model.hidden,
-    className: classNames(styles.formItem),
-    style: { margin: '5px 3px' },
   };
 
   if (typeof children === 'function') {
     const childrenFunc = children as IConfigurableFormItemChildFunc;
     return (
-      <Form.Item {...formProps} className={styles.formItem}>
+      <Form.Item {...formProps}>
         <SettingsControl propertyName={model.propertyName} mode={mode}>
           {(value, onChange, propertyName) => childrenFunc(value, onChange, propertyName)}
         </SettingsControl>


### PR DESCRIPTION
Styles and classNames

- Eliminated the useStyles import and classNames from ConfigurableFormItemSetting, streamlining the component.
- Adjusted tooltip handling to ensure proper display of model descriptions.
- Cleaned up the Form.Item component by removing unnecessary className and style properties.