### PR TITLE
chore: added blob string normalisation and logging

### DIFF
--- a/shesha-core/src/Shesha.Framework/Services/StoredFiles/AzureStoredFileService.cs
+++ b/shesha-core/src/Shesha.Framework/Services/StoredFiles/AzureStoredFileService.cs
@@ -57,12 +57,6 @@ namespace Shesha.Services.StoredFiles
         private BlobContainerClient CreateBlobContainerClient()
         {
             var value = GetStorageValue();
-            if (string.IsNullOrWhiteSpace(value))
-                throw new InvalidOperationException(
-                    "Azure Blob Storage connection is not configured. " +
-                    "Set 'CloudStorage:ConnectionString' or 'ConnectionStrings:BlobStorage' " +
-                    "to a connection string, SAS URL, or account URL.");
-
             var containerName = _configuration.GetSection(CloudStorageName)
                 .GetValue<string>("ContainerName") ?? ContainerName;
 
@@ -113,7 +107,7 @@ namespace Shesha.Services.StoredFiles
 
             var blobPath = string.IsNullOrWhiteSpace(directoryName)
                 ? normalizedBlobName
-                : $"{normalizedDirectory}/{blobName}";
+                : $"{normalizedDirectory}/{normalizedBlobName}";
             return BlobContainerClient.GetBlobClient(blobPath);
         }
 
@@ -159,7 +153,7 @@ namespace Shesha.Services.StoredFiles
         public override async Task UpdateVersionContentAsync(StoredFileVersion version, Stream stream)
         {
             if (stream == null)
-                throw new ArgumentException($"{nameof(stream)} must not be null");
+                throw new ArgumentNullException($"{nameof(stream)} must not be null");
 
             var blob = GetBlobClient(GetAzureFileName(version));
 


### PR DESCRIPTION
#4559 
Extends Azure Blob Storage configuration to support multiple credential formats through a single config value,
with automatic fallback to local file storage when no Azure config is present.

Changes

AzureStoredFileService now auto-detects the authentication method from the format of the configured value — no
extra flags needed
Added CloudStorage:ConnectionString as the preferred config key (falls back to ConnectionStrings:BlobStorage
for backwards compatibility)
Fixed blob path construction to use forward slashes on all platforms (Path.Combine → string formatting)
DI factory auto-activates Azure storage when a credential is present — IsAzureEnvironment: true is no longer
required but still works
Supported credential formats

Classic connection string DefaultEndpointsProtocol=https;AccountName=…;AccountKey=…
Container SAS URL [https://account.blob.core.windows.net/container?sv=…&sig=…](https://account.blob.core.windows.net/container?sv=%E2%80%A6&sig=%E2%80%A6)
Account SAS URL [https://account.blob.core.windows.net?sv=…&sig=…](https://account.blob.core.windows.net/?sv=%E2%80%A6&sig=%E2%80%A6)
Not configured Falls back to local StoredFileService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file path normalization and resolution for more robust blob handling.
  * Enhanced input validation for better error reporting.

* **Improvements**
  * Expanded Azure storage configuration support, including SAS URLs and various connection string formats.
  * Optimized blob container client initialization for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->