### PR TITLE
fix: add GenerateAppService to EntityConfigManager LINQ projection

### DIFF
--- a/shesha-core/src/Shesha.Framework/Configuration/Runtime/EntityConfigManager.cs
+++ b/shesha-core/src/Shesha.Framework/Configuration/Runtime/EntityConfigManager.cs
@@ -59,6 +59,7 @@ namespace Shesha.Configuration.Runtime
                     Label = x.Label,
 
                     VersionStatus = x.VersionStatus,
+                    GenerateAppService = x.GenerateAppService,
                 }).ToListAsync();
             return implemented ?? false
                 ? result.Where(x => !x.NotImplemented).ToList()


### PR DESCRIPTION
## Summary
- Add missing `GenerateAppService = x.GenerateAppService` to the LINQ projection in `EntityConfigManager.GetMainDataListAsync()`
- Without this fix, the API always returns `generateAppService: false` for every entity regardless of the actual database value

## Test plan
- [ ] Call `GET /api/services/app/EntityConfig/GetMainDataList` and verify `generateAppService` reflects actual DB values
- [ ] Cross-check entities against the database

Closes #4608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The GenerateAppService property is now included in entity configuration data, providing enhanced visibility into app service generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->