### PR TITLE
fix: filter entities by GenerateAppService flag in DynamicEntityControllerFeatureProvider

### DIFF
--- a/shesha-core/src/Shesha.Application/DynamicEntities/DynamicEntityControllerFeatureProvider.cs
+++ b/shesha-core/src/Shesha.Application/DynamicEntities/DynamicEntityControllerFeatureProvider.cs
@@ -49,7 +49,9 @@ namespace Shesha.DynamicEntities
             using (var uow = _unitOfWorkManager.Begin())
             {
                 var entityConfigRepo = _iocManager.Resolve<IRepository<EntityConfig, Guid>>();
-                var entityToApp = entityConfigRepo.GetAll().ToList();
+                var entityToApp = entityConfigRepo.GetAll()
+                    .Where(x => x.GenerateAppService)
+                    .ToList();
                 foreach (var entityConfig in entityToApp)
                 {
                     try


### PR DESCRIPTION
## Summary
- Add `.Where(x => x.GenerateAppService)` filter to `PopulateFeature()` so entities with `GenerateAppService == false` don't get dynamic CRUD endpoints
- Previously the `GenerateAppService` flag was stored in the DB but had no effect on endpoint registration

## Test plan
- [ ] Set `GenerateAppService = false` on a test entity in the database
- [ ] Restart the application and confirm CRUD endpoints no longer appear in Swagger
- [ ] Verify entities with `GenerateAppService = true` still work normally

Closes #4609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app service generation to only process configurations with the appropriate flag enabled, preventing unintended service creation for certain entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->