### PR TITLE
security: increase default minimum password length from 3 to 6

### DIFF
--- a/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
+++ b/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
@@ -154,7 +154,7 @@ namespace Shesha
             });
 
             IocManager.RegisterSettingAccessor<IPasswordComplexitySettings>(s => {
-                s.RequiredLength.WithDefaultValue(3);
+                s.RequiredLength.WithDefaultValue(6);
             });
             IocManager.RegisterSettingAccessor<ISheshaSettings>(s => {
                 s.UploadFolder.WithDefaultValue("~/App_Data/Upload");


### PR DESCRIPTION
## Summary
- Change default `RequiredLength` from 3 to 6 in `SheshaFrameworkModule.cs`
- Prevents trivially weak passwords like `abc` or `123`

## Test plan
- [ ] Verify new user registration rejects passwords shorter than 6 characters
- [ ] Verify passwords of 6+ characters are accepted

Closes #4616

🤖 Generated with [Claude Code](https://claude.com/claude-code)