### PR TITLE
security: use cryptographic RNG for OTP generation

### DIFF
--- a/shesha-core/src/Shesha.Application/Otp/OtpGenerator.cs
+++ b/shesha-core/src/Shesha.Application/Otp/OtpGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Abp.Dependency;
 using Shesha.Otp.Configuration;
 using System;
+using System.Security.Cryptography;
 
 namespace Shesha.Otp
 {
@@ -15,7 +16,6 @@ namespace Shesha.Otp
 
         public string GeneratePin()
         {
-            var random = new Random();
             var password = string.Empty;
 
             var alphabet = _settings.OneTimePins.GetValue().Alphabet;
@@ -23,7 +23,7 @@ namespace Shesha.Otp
 
             for (int i = 0; i < passwordLength; i++)
             {
-                password += alphabet[random.Next(alphabet.Length)];
+                password += alphabet[RandomNumberGenerator.GetInt32(alphabet.Length)];
             }
 
             return password;


### PR DESCRIPTION
## Summary
- Replace `System.Random` with `System.Security.Cryptography.RandomNumberGenerator` for OTP generation
- `System.Random` is predictable and not suitable for security-critical values like OTPs

## Test plan
- [ ] Verify OTP generation still works (login flows, password reset)
- [ ] Verify OTPs are the correct length and use the configured alphabet

Closes #4617

🤖 Generated with [Claude Code](https://claude.com/claude-code)