### PR TITLE
security: replace wide-open CORS with configurable origin allowlist

### DIFF
--- a/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
@@ -154,11 +154,16 @@ namespace Shesha.Web.Host.Startup
             app.UseAbp(options => { options.UseAbpRequestLocalization = false; }); // Initializes ABP framework.
 
             // global cors policy
+            var corsOrigins = _appConfiguration["App:CorsOrigins"]?
+                .Split(",", StringSplitOptions.RemoveEmptyEntries)
+                .Select(o => o.Trim().TrimEnd('/'))
+                .Where(o => !string.IsNullOrEmpty(o))
+                .ToArray() ?? Array.Empty<string>();
             app.UseCors(x => x
                 .AllowAnyMethod()
                 .AllowAnyHeader()
-                .SetIsOriginAllowed(origin => true) // allow any origin
-                .AllowCredentials()); // allow credentials
+                .WithOrigins(corsOrigins)
+                .AllowCredentials());
             app.UseStaticFiles();
             app.UseAuthentication();
             app.UseAbpRequestLocalization();

--- a/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/Startup.cs
+++ b/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/Startup.cs
@@ -39,6 +39,7 @@ using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace ShaCompanyName.ShaProjectName.Web.Host.Startup
@@ -155,11 +156,16 @@ namespace ShaCompanyName.ShaProjectName.Web.Host.Startup
 			}); // Initializes ABP framework.​
 				//app.UseCors(_defaultCorsPolicyName); // Enable CORS!
 				// global cors policy
+			var corsOrigins = _appConfiguration["App:CorsOrigins"]?
+				.Split(",", StringSplitOptions.RemoveEmptyEntries)
+				.Select(o => o.Trim().TrimEnd('/'))
+				.Where(o => !string.IsNullOrEmpty(o))
+				.ToArray() ?? Array.Empty<string>();
 			app.UseCors(x => x
 				.AllowAnyMethod()
 				.AllowAnyHeader()
-				.SetIsOriginAllowed(origin => true) // allow any origin
-				.AllowCredentials()); // allow credentials​
+				.WithOrigins(corsOrigins)
+				.AllowCredentials());
 			app.UseStaticFiles();
 
 			app.UseAuthentication();


### PR DESCRIPTION
## Summary
- Replace `SetIsOriginAllowed(origin => true)` with `WithOrigins(corsOrigins)` using the existing `App:CorsOrigins` config
- Applied to both framework `Startup.cs` and starter template `Startup.cs`
- The `CorsOrigins` setting already exists in appsettings.json as a comma-separated string

## Test plan
- [ ] Verify requests from configured origins succeed
- [ ] Verify requests from unconfigured origins are blocked by CORS
- [ ] Verify preflight (OPTIONS) requests work correctly

Closes #4618

🤖 Generated with [Claude Code](https://claude.com/claude-code)