### PR TITLE
security: restrict PermissionedObjectAppService to admin users

### DIFF
--- a/shesha-core/src/Shesha.Application/Permissions/PermissionedObjectAppService.cs
+++ b/shesha-core/src/Shesha.Application/Permissions/PermissionedObjectAppService.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Shesha.Permissions
 {
-    [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.AnyAuthenticated)]
+    [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "pages:maintenance")]
     public class PermissionedObjectAppService : SheshaCrudServiceBase<PermissionedObject, PermissionedObjectDto, Guid>, IPermissionedObjectAppService
     {
         private readonly IPermissionedObjectManager _permissionedObjectManager;


### PR DESCRIPTION
## Summary
- Change `[SheshaAuthorize(AnyAuthenticated)]` to `[SheshaAuthorize(RequiresPermissions, "pages:maintenance")]` on `PermissionedObjectAppService`
- Prevents low-privilege users from viewing or modifying endpoint security policies

## Test plan
- [ ] Verify admin users can still access permission management endpoints
- [ ] Verify non-admin authenticated users get 403 Forbidden

Closes #4619

🤖 Generated with [Claude Code](https://claude.com/claude-code)