### PR TITLE
security: add auth to GraphQL middleware and restrict Playground to dev

### DIFF
--- a/shesha-core/src/Shesha.GraphQL/GraphQL/Middleware/GraphQLMiddleware.cs
+++ b/shesha-core/src/Shesha.GraphQL/GraphQL/Middleware/GraphQLMiddleware.cs
@@ -43,7 +43,7 @@ namespace Shesha.GraphQL.Middleware
 
         private bool IsGraphQLRequest(HttpContext context, out string schemaName)
         {
-            if (context.Request.Path.StartsWithSegments(_settings.Path) && string.Equals(context.Request.Method, "POST", StringComparison.OrdinalIgnoreCase)) 
+            if (context.Request.Path.StartsWithSegments(_settings.Path) && string.Equals(context.Request.Method, "POST", StringComparison.OrdinalIgnoreCase))
             {
                 schemaName = context.Request.Path.HasValue
                     ? context.Request.Path.Value.RemovePrefix(_settings.Path).Trim('/')
@@ -56,6 +56,12 @@ namespace Shesha.GraphQL.Middleware
 
         private async Task ExecuteAsync(HttpContext context, string schemaName = null)
         {
+            if (context.User?.Identity?.IsAuthenticated != true)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                return;
+            }
+
             var request = await _serializer.ReadAsync<GraphQLRequest>(context.Request.Body, context.RequestAborted);
 
             var start = DateTime.UtcNow;

--- a/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
@@ -197,7 +198,10 @@ namespace Shesha.Web.Host.Startup
             });
 
             app.UseMiddleware<GraphQLMiddleware>();
-            app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+            if (_hostEnvironment.IsDevelopment())
+            {
+                app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+            }
         }
 
         private void AddApiVersioning(IServiceCollection services)

--- a/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/Startup.cs
+++ b/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
@@ -199,7 +200,10 @@ namespace ShaCompanyName.ShaProjectName.Web.Host.Startup
 					Authorization = new[] { new HangfireAuthorizationFilter() }
 				});
 			app.UseMiddleware<GraphQLMiddleware>();
-			app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+			if (_hostEnvironment.IsDevelopment())
+			{
+				app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+			}
 		}
 
 		private void AddApiVersioning(IServiceCollection services)


### PR DESCRIPTION
## Summary
- Add authentication check to `GraphQLMiddleware` — unauthenticated requests now return 401
- Restrict `UseGraphQLPlayground()` to development environment only in both framework and starter template Startup.cs

## Test plan
- [ ] Verify unauthenticated GraphQL POST requests return 401
- [ ] Verify authenticated GraphQL queries work as before
- [ ] Verify GraphQL Playground is accessible in Development but not in Production

Closes #4620

🤖 Generated with [Claude Code](https://claude.com/claude-code)