### PR TITLE
Restore striped rows and row dividers on entity picker modal table

### DIFF
--- a/shesha-reactjs/src/components/entityPicker/modal.tsx
+++ b/shesha-reactjs/src/components/entityPicker/modal.tsx
@@ -1,5 +1,6 @@
 import { DataTable, DataTableProvider, GlobalTableFilter, IAnyObject, TablePager, useDataContextManagerActionsOrUndefined, useDataTable, useGlobalState, useModal, useNestedPropertyMetadatAccessor } from '@/index';
 import { evaluateDynamicFilters } from '@/utils/datatable';
+import { getTableDefaults } from '@/designer-components/dataTable/table/utils';
 import React, { useEffect, useState } from 'react';
 import { useStyles } from './styles/styles';
 import { useMedia } from 'react-use';
@@ -230,7 +231,7 @@ const EntityPickerModalInternal = (props: IEntityPickerModalProps): JSX.Element 
           <TablePager />
         </div>
 
-        <DataTable onSelectRow={onSelectRow} onDblClick={onDblClick} options={{ omitClick: true }} />
+        <DataTable onSelectRow={onSelectRow} onDblClick={onDblClick} options={{ omitClick: true }} striped rowDividers rowAlternateBackgroundColor={getTableDefaults().rowAlternateBackgroundColor} />
       </>
     </Modal>
   );


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced DataTable styling with alternate row backgrounds and dividers for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->