### PR TITLE
fix: restrict SettingsAppService GetConfigurations and UpdateValue

### DIFF
--- a/shesha-core/src/Shesha.Application/Settings/SettingsAppService.cs
+++ b/shesha-core/src/Shesha.Application/Settings/SettingsAppService.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Shesha.Authorization;
 using Shesha.ConfigurationItems;
+using Shesha.Domain.Enums;
 using Shesha.Settings.Dto;
 using System.Collections.Generic;
 using System.Linq;
@@ -97,6 +99,7 @@ namespace Shesha.Settings
         /// <param name="input"></param>
         /// <returns></returns>
         [HttpPost]
+        [SheshaAuthorize(RefListPermissionedAccess.RequiresPermissions, "pages:maintenance")]
         public async Task UpdateValueAsync(UpdateSettingValueInput input)
         {
             await _settingProvider.SetAsync(input.Module, input.Name, input.Value, !string.IsNullOrWhiteSpace(input.AppKey) ?
@@ -108,7 +111,7 @@ namespace Shesha.Settings
         }
 
         [HttpGet]
-        [AllowAnonymous]
+        [SheshaAuthorize(RefListPermissionedAccess.RequiresPermissions, "pages:maintenance")]
         public Task<List<SettingConfigurationDto>> GetConfigurationsAsync()
         {
             var settings = _settingDefinitionManager.GetAll();

--- a/shesha-core/test/Shesha.Tests/Security/SettingsAppServiceAuth_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Security/SettingsAppServiceAuth_Tests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Shesha.Authorization;
+using Shesha.Domain.Enums;
+using Shesha.Settings;
+using System.Reflection;
+using Xunit;
+
+namespace Shesha.Tests.Security
+{
+    /// <summary>
+    /// Tests to verify that SettingsAppService has the correct authorization attributes.
+    /// Covers issue #4653: Restrict SettingsAppService GetConfigurations and UpdateValue to admin.
+    /// </summary>
+    public class SettingsAppServiceAuth_Tests
+    {
+        private static SheshaAuthorizeAttribute GetMethodSheshaAuthorize(string methodName)
+        {
+            var method = typeof(SettingsAppService).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            return method?.GetCustomAttribute<SheshaAuthorizeAttribute>();
+        }
+
+        private static AllowAnonymousAttribute GetMethodAllowAnonymous(string methodName)
+        {
+            var method = typeof(SettingsAppService).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            return method?.GetCustomAttribute<AllowAnonymousAttribute>();
+        }
+
+        [Fact]
+        public void GetConfigurationsAsync_should_require_pages_maintenance()
+        {
+            var attr = GetMethodSheshaAuthorize("GetConfigurationsAsync");
+
+            attr.Should().NotBeNull("GetConfigurationsAsync should have [SheshaAuthorize]");
+            attr.Access.Should().Be(RefListPermissionedAccess.RequiresPermissions);
+            attr.Permissions.Should().Contain("pages:maintenance");
+        }
+
+        [Fact]
+        public void GetConfigurationsAsync_should_not_have_AllowAnonymous()
+        {
+            var attr = GetMethodAllowAnonymous("GetConfigurationsAsync");
+            attr.Should().BeNull("GetConfigurationsAsync should no longer be [AllowAnonymous]");
+        }
+
+        [Fact]
+        public void UpdateValueAsync_should_require_pages_maintenance()
+        {
+            var attr = GetMethodSheshaAuthorize("UpdateValueAsync");
+
+            attr.Should().NotBeNull("UpdateValueAsync should have [SheshaAuthorize]");
+            attr.Access.Should().Be(RefListPermissionedAccess.RequiresPermissions);
+            attr.Permissions.Should().Contain("pages:maintenance");
+        }
+
+        [Fact]
+        public void GetValueAsync_should_remain_AllowAnonymous()
+        {
+            var attr = GetMethodAllowAnonymous("GetValueAsync");
+            attr.Should().NotBeNull("GetValueAsync must remain [AllowAnonymous] for frontend settings");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces `[AllowAnonymous]` on `GetConfigurationsAsync` with `[SheshaAuthorize]` requiring `pages:maintenance`
- Adds `[SheshaAuthorize]` requiring `pages:maintenance` to `UpdateValueAsync`
- `GetValueAsync` intentionally remains `[AllowAnonymous]` (deferred to v0.47 for per-item read permissions)

Closes #4653

## Test plan
- [x] 4 reflection-based unit tests verify correct attributes
- [ ] Verify anonymous users can no longer access GetConfigurations or UpdateValue
- [ ] Verify GetValueAsync still works for anonymous users (frontend theme settings)
- [ ] Verify admin users with `pages:maintenance` can access both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Settings maintenance operations now require appropriate user permissions to access and update system configurations. Previously, configuration access was available to all users; this is now restricted based on user authorization levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->