### PR TITLE
fix: add authorization to EntitiesAppService ExportToExcel, Reorder, Specifications

### DIFF
--- a/shesha-core/src/Shesha.Application/DynamicEntities/EntitiesAppService.cs
+++ b/shesha-core/src/Shesha.Application/DynamicEntities/EntitiesAppService.cs
@@ -10,6 +10,7 @@ using Shesha.Application.Services.Dto;
 using Shesha.Authorization;
 using Shesha.Configuration.Runtime;
 using Shesha.Configuration.Runtime.Exceptions;
+using Shesha.Domain.Enums;
 using Shesha.DynamicEntities.Dtos;
 using Shesha.Excel;
 using Shesha.Metadata.Dtos;
@@ -155,6 +156,8 @@ namespace Shesha.DynamicEntities
                 if (entityConfig == null)
                     throw new EntityTypeNotFoundException(input.EntityType);
 
+                await CheckPermissionAsync(entityConfig, "Get");
+
                 var typeName = entityConfig.EntityType.FullName;
 
                 /* we MUST NOT disable it here
@@ -216,7 +219,8 @@ namespace Shesha.DynamicEntities
         /// Get specifications available for the specified entityType
         /// </summary>
         /// <returns></returns>
-        public Task<List<SpecificationDto>> SpecificationsAsync(string entityType) 
+        [SheshaAuthorize(RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
+        public Task<List<SpecificationDto>> SpecificationsAsync(string entityType)
         {
             var entityConfig = _entityConfigStore.Get(entityType);
             if (entityConfig == null)
@@ -246,6 +250,8 @@ namespace Shesha.DynamicEntities
             var entityConfig = _entityConfigStore.Get(input.EntityType);
             if (entityConfig == null)
                 throw new EntityTypeNotFoundException(input.EntityType);
+
+            await CheckPermissionAsync(entityConfig, "Update");
 
             var property = ReflectionHelper.GetProperty(entityConfig.EntityType, input.PropertyName, true);
             if (property == null)

--- a/shesha-core/test/Shesha.Tests/Security/EntitiesAppServiceAuth_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Security/EntitiesAppServiceAuth_Tests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Shesha.Authorization;
+using Shesha.Domain.Enums;
+using Shesha.DynamicEntities;
+using System.Reflection;
+using Xunit;
+
+namespace Shesha.Tests.Security
+{
+    /// <summary>
+    /// Tests to verify that EntitiesAppService has the correct authorization.
+    /// Covers issue #4654: Add authorization to ExportToExcel, Reorder, and Specifications.
+    /// </summary>
+    public class EntitiesAppServiceAuth_Tests
+    {
+        [Fact]
+        public void Specifications_should_require_app_Configurator()
+        {
+            var method = typeof(EntitiesAppService).GetMethod("SpecificationsAsync", BindingFlags.Public | BindingFlags.Instance);
+            var attr = method?.GetCustomAttribute<SheshaAuthorizeAttribute>();
+
+            attr.Should().NotBeNull("SpecificationsAsync should have [SheshaAuthorize]");
+            attr.Access.Should().Be(RefListPermissionedAccess.RequiresPermissions);
+            attr.Permissions.Should().Contain("app:Configurator");
+        }
+
+        [Fact]
+        public void ExportToExcel_should_have_CheckPermission_helper()
+        {
+            var method = typeof(EntitiesAppService).GetMethod("ExportToExcelAsync", BindingFlags.Public | BindingFlags.Instance);
+            method.Should().NotBeNull();
+
+            var methodBody = method.GetMethodBody();
+            methodBody.Should().NotBeNull();
+
+            // The protected CheckPermissionAsync method should exist for runtime permission checks
+            var checkMethod = typeof(EntitiesAppService).GetMethod("CheckPermissionAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            checkMethod.Should().NotBeNull("CheckPermissionAsync helper method should exist");
+        }
+
+        [Fact]
+        public void Reorder_should_have_CheckPermission_helper()
+        {
+            var method = typeof(EntitiesAppService).GetMethod("ReorderAsync", BindingFlags.Public | BindingFlags.Instance);
+            method.Should().NotBeNull();
+
+            var methodBody = method.GetMethodBody();
+            methodBody.Should().NotBeNull();
+
+            // The protected CheckPermissionAsync method should exist for runtime permission checks
+            var checkMethod = typeof(EntitiesAppService).GetMethod("CheckPermissionAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            checkMethod.Should().NotBeNull("CheckPermissionAsync helper method should exist");
+        }
+
+        [Fact]
+        public void CheckPermission_should_be_protected()
+        {
+            var method = typeof(EntitiesAppService).GetMethod("CheckPermissionAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            method.Should().NotBeNull();
+            method.IsFamily.Should().BeTrue("CheckPermissionAsync should be protected");
+        }
+
+        [Fact]
+        public void GetAll_and_ExportToExcel_both_exist()
+        {
+            // Both GetAllAsync and ExportToExcelAsync read entity data,
+            // so both should use CheckPermissionAsync. Verify both methods exist.
+            var getAllMethod = typeof(EntitiesAppService).GetMethod("GetAllAsync", BindingFlags.Public | BindingFlags.Instance);
+            var exportMethod = typeof(EntitiesAppService).GetMethod("ExportToExcelAsync", BindingFlags.Public | BindingFlags.Instance);
+
+            getAllMethod.Should().NotBeNull();
+            exportMethod.Should().NotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CheckPermissionAsync(entityConfig, "Get")` to `ExportToExcelAsync` — export requires same permissions as reading
- Adds `CheckPermissionAsync(entityConfig, "Update")` to `ReorderAsync` — reordering is a write operation
- Adds `[SheshaAuthorize]` requiring `app:Configurator` to `SpecificationsAsync` — specification metadata is a configuration concern

Closes #4654

## Test plan
- [x] 5 reflection-based unit tests verify attribute and method structure
- [ ] Verify ExportToExcel respects entity-level Get permissions
- [ ] Verify Reorder respects entity-level Update permissions
- [ ] Verify Specifications requires app:Configurator permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)