### PR TITLE
fix: restrict write operations on PermissionAppService and FormConfigurationAppService

### DIFF
--- a/shesha-core/src/Shesha.Application/Permissions/PermissionAppService.cs
+++ b/shesha-core/src/Shesha.Application/Permissions/PermissionAppService.cs
@@ -111,6 +111,7 @@ namespace Shesha.Permissions
         }
 
         [HttpPost]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
         public async Task<PermissionDto> CreateAsync(PermissionDto permission)
         {
             var dbp = new PermissionDefinition()
@@ -130,6 +131,7 @@ namespace Shesha.Permissions
         }
 
         [HttpPut, HttpPost] // ToDo: temporary - Allow HttpPost because permission can be created from edit mode
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
         public async Task<PermissionDto> UpdateAsync(PermissionDto permission)
         {
             if (permission?.Id == emptyId)
@@ -154,7 +156,8 @@ namespace Shesha.Permissions
             return ObjectMapper.Map<PermissionDto>(res);
         }
 
-        [HttpPut] 
+        [HttpPut]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
         public async Task UpdateParentAsync(PermissionDto permission)
         {
             var module = permission.Module != null ? await _moduleRepository.GetAsync(permission.Module.Id) : null;
@@ -162,6 +165,7 @@ namespace Shesha.Permissions
         }
 
         [HttpDelete]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
         public async Task DeleteAsync(string name)
         {
             await _shaPermissionManager.DeletePermissionAsync(name);

--- a/shesha-core/src/Shesha.Web.FormsDesigner/Services/FormConfigurationAppService.cs
+++ b/shesha-core/src/Shesha.Web.FormsDesigner/Services/FormConfigurationAppService.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using Shesha.Application.Services.Dto;
 using Shesha.Attributes;
 using Shesha.AutoMapper.Dto;
+using Shesha.Authorization;
 using Shesha.Configuration.Runtime;
 using Shesha.ConfigurationItems;
 using Shesha.ConfigurationItems.Cache;
@@ -34,6 +35,7 @@ using System.Threading.Tasks;
 
 namespace Shesha.Web.FormsDesigner.Services
 {
+    [SheshaAuthorize(RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
     public class FormConfigurationAppService : SheshaCrudServiceBase<FormConfiguration, FormConfigurationDto, Guid, FilteredPagedAndSortedResultRequestDto, CreateFormConfigurationDto, UpdateFormConfigurationDto, GetFormByIdInput>
     {
 
@@ -80,6 +82,7 @@ namespace Shesha.Web.FormsDesigner.Services
         /// Gets all permissioned shesha forms with anonymous access
         /// </summary>
         /// <returns></returns>
+        [AllowAnonymous]
         public async Task<List<PermissionedObjectDto>> GetAnonymousFormsAsync()
         {
             return await _permissionedObjectManager.GetObjectsByAccessAsync(ShaPermissionedObjectsTypes.Form, RefListPermissionedAccess.AllowAnonymous);

--- a/shesha-core/test/Shesha.Tests/Security/PermissionAndFormServiceAuth_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Security/PermissionAndFormServiceAuth_Tests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Shesha.Authorization;
+using Shesha.Domain.Enums;
+using Shesha.Permissions;
+using Shesha.Web.FormsDesigner.Services;
+using System.Reflection;
+using Xunit;
+
+namespace Shesha.Tests.Security
+{
+    /// <summary>
+    /// Tests to verify authorization attributes on PermissionAppService and FormConfigurationAppService.
+    /// Covers issue #4655.
+    /// </summary>
+    public class PermissionAndFormServiceAuth_Tests
+    {
+        #region PermissionAppService
+
+        [Fact]
+        public void PermissionAppService_class_should_have_AnyAuthenticated()
+        {
+            var attr = typeof(PermissionAppService).GetCustomAttribute<SheshaAuthorizeAttribute>();
+            attr.Should().NotBeNull();
+            attr.Access.Should().Be(RefListPermissionedAccess.AnyAuthenticated);
+        }
+
+        [Theory]
+        [InlineData("CreateAsync")]
+        [InlineData("UpdateAsync")]
+        [InlineData("UpdateParentAsync")]
+        [InlineData("DeleteAsync")]
+        public void PermissionAppService_write_methods_should_require_Configurator(string methodName)
+        {
+            var method = typeof(PermissionAppService).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            method.Should().NotBeNull($"{methodName} should exist");
+
+            var attr = method.GetCustomAttribute<SheshaAuthorizeAttribute>();
+            attr.Should().NotBeNull($"{methodName} should have [SheshaAuthorize]");
+            attr.Access.Should().Be(RefListPermissionedAccess.RequiresPermissions);
+            attr.Permissions.Should().Contain("app:Configurator");
+        }
+
+        [Theory]
+        [InlineData("GetAsync")]
+        [InlineData("GetAllAsync")]
+        [InlineData("GetAllTreeAsync")]
+        [InlineData("AutocompleteAsync")]
+        public void PermissionAppService_read_methods_should_not_have_method_level_auth(string methodName)
+        {
+            var method = typeof(PermissionAppService).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            method.Should().NotBeNull($"{methodName} should exist");
+
+            var attr = method.GetCustomAttribute<SheshaAuthorizeAttribute>();
+            // Read methods should rely on class-level AnyAuthenticated, not have method-level restrictions
+            // (except IsPermissionGrantedAsync which explicitly has AnyAuthenticated)
+            if (attr != null)
+            {
+                attr.Access.Should().NotBe(RefListPermissionedAccess.RequiresPermissions,
+                    $"{methodName} is a read method and should not require specific permissions");
+            }
+        }
+
+        #endregion
+
+        #region FormConfigurationAppService
+
+        [Fact]
+        public void FormConfigurationAppService_class_should_require_Configurator()
+        {
+            var attr = typeof(FormConfigurationAppService).GetCustomAttribute<SheshaAuthorizeAttribute>();
+            attr.Should().NotBeNull("FormConfigurationAppService should have class-level [SheshaAuthorize]");
+            attr.Access.Should().Be(RefListPermissionedAccess.RequiresPermissions);
+            attr.Permissions.Should().Contain("app:Configurator");
+        }
+
+        [Theory]
+        [InlineData("GetByNameAsync")]
+        [InlineData("CheckPermissionsAsync")]
+        [InlineData("GetAnonymousFormsAsync")]
+        public void FormConfigurationAppService_public_methods_should_be_AllowAnonymous(string methodName)
+        {
+            var method = typeof(FormConfigurationAppService).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            method.Should().NotBeNull($"{methodName} should exist");
+
+            var attr = method.GetCustomAttribute<AllowAnonymousAttribute>();
+            attr.Should().NotBeNull($"{methodName} should have [AllowAnonymous] to override class-level auth");
+        }
+
+        [Theory]
+        [InlineData("UpdateMarkupAsync")]
+        [InlineData("UpdateStatusAsync")]
+        [InlineData("ImportJsonAsync")]
+        public void FormConfigurationAppService_write_methods_should_not_be_AllowAnonymous(string methodName)
+        {
+            var method = typeof(FormConfigurationAppService).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            method.Should().NotBeNull($"{methodName} should exist");
+
+            var attr = method.GetCustomAttribute<AllowAnonymousAttribute>();
+            attr.Should().BeNull($"{methodName} should inherit class-level auth (app:Configurator)");
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary
- Adds method-level `[SheshaAuthorize]` requiring `app:Configurator` on PermissionAppService write methods (Create, Update, UpdateParent, Delete)
- Adds class-level `[SheshaAuthorize]` requiring `app:Configurator` on FormConfigurationAppService
- Preserves `[AllowAnonymous]` on GetByName, CheckPermissions, and GetAnonymousForms

Closes #4655

## Test plan
- [x] 16 reflection-based unit tests verify correct attributes on both services
- [ ] Verify read operations on PermissionAppService still work for authenticated users
- [ ] Verify write operations on PermissionAppService require app:Configurator
- [ ] Verify FormConfigurationAppService anonymous endpoints still work
- [ ] Verify FormConfigurationAppService write endpoints require app:Configurator

🤖 Generated with [Claude Code](https://claude.com/claude-code)