### PR TITLE
fix: move encryption passphrase from hardcoded constant to configuration

### DIFF
--- a/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
@@ -12,6 +12,7 @@ using Shesha.Authentication.JwtBearer;
 using Shesha.Authorization.Models;
 using Shesha.Authorization.Roles;
 using Shesha.Authorization.Users;
+using Microsoft.Extensions.Configuration;
 using Shesha.Controllers;
 using Shesha.Domain;
 using Shesha.Extensions;
@@ -44,6 +45,7 @@ namespace Shesha.Authorization
         private readonly ITokenBlacklistService _tokenBlacklistService;
         private readonly UserManager<User> _userManager;
         private readonly AbpUserClaimsPrincipalFactory<User, Role> _claimsPrincipalFactory;
+        private readonly IConfiguration _appConfiguration;
 
         public TokenAuthController(
             LogInManager logInManager,
@@ -58,7 +60,8 @@ namespace Shesha.Authorization
             IRepository<MobileDevice, Guid> mobileDeviceRepository,
             ITokenBlacklistService tokenBlacklistService,
             UserManager<User> userManager,
-            AbpUserClaimsPrincipalFactory<User, Role> claimsPrincipalFactory)
+            AbpUserClaimsPrincipalFactory<User, Role> claimsPrincipalFactory,
+            IConfiguration appConfiguration)
         {
             _logInManager = logInManager;
             _tenantCache = tenantCache;
@@ -73,6 +76,7 @@ namespace Shesha.Authorization
             _tokenBlacklistService = tokenBlacklistService;
             _userManager = userManager;
             _claimsPrincipalFactory = claimsPrincipalFactory;
+            _appConfiguration = appConfiguration;
         }
 
         [HttpPost]
@@ -416,7 +420,8 @@ namespace Shesha.Authorization
 
         private string GetEncryptedAccessToken(string accessToken)
         {
-            return SimpleStringCipher.Instance.Encrypt(accessToken, AppConsts.DefaultPassPhrase);
+            var encryptionPassPhrase = _appConfiguration["Authentication:EncryptionPassPhrase"] ?? AppConsts.DefaultPassPhrase;
+            return SimpleStringCipher.Instance.Encrypt(accessToken, encryptionPassPhrase);
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/AppConsts.cs
+++ b/shesha-core/src/Shesha.Framework/AppConsts.cs
@@ -3,7 +3,9 @@
     public class AppConsts
     {
         /// <summary>
-        /// Default pass phrase for SimpleStringCipher decrypt/encrypt operations
+        /// Default pass phrase for SimpleStringCipher — DEPRECATED: Use configuration key
+        /// "Authentication:EncryptionPassPhrase" instead. This fallback value is hardcoded
+        /// in source and should not be relied upon in production.
         /// </summary>
         public const string DefaultPassPhrase = "gsKxGZ012HLL3MI5";
     }

--- a/shesha-core/src/Shesha.Web.Host/Startup/AuthConfigurer.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/AuthConfigurer.cs
@@ -12,8 +12,12 @@ namespace Shesha.Web.Host.Startup
 {
     public static class AuthConfigurer
     {
+        private static IConfiguration _configuration;
+
         public static void Configure(IServiceCollection services, IConfiguration configuration)
         {
+            _configuration = configuration;
+
             if (bool.Parse(configuration["Authentication:JwtBearer:IsEnabled"]))
             {
                 services.AddAuthentication(options => {
@@ -71,7 +75,8 @@ namespace Shesha.Web.Host.Startup
             }
 
             // Set auth token from cookie
-            context.Token = SimpleStringCipher.Instance.Decrypt(qsAuthToken, AppConsts.DefaultPassPhrase);
+            var encryptionPassPhrase = _configuration?["Authentication:EncryptionPassPhrase"] ?? AppConsts.DefaultPassPhrase;
+            context.Token = SimpleStringCipher.Instance.Decrypt(qsAuthToken, encryptionPassPhrase);
             return Task.CompletedTask;
         }
     }

--- a/shesha-core/src/Shesha.Web.Host/appsettings.json
+++ b/shesha-core/src/Shesha.Web.Host/appsettings.json
@@ -12,7 +12,8 @@
       "SecurityKey": "SUUDE4LZ77PT729NV5BEPXDMAFRHFX7F",
       "Issuer": "Shesha",
       "Audience": "Shesha"
-    }
+    },
+    "EncryptionPassPhrase": "CHANGE-THIS-TO-A-UNIQUE-VALUE"
   },
   "DefaultLogFolder": "~/App_Data/Logs/jobss"
 }

--- a/shesha-core/test/Shesha.Tests/Security/EncryptionPassPhrase_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Security/EncryptionPassPhrase_Tests.cs
@@ -1,0 +1,119 @@
+using Abp.Runtime.Security;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Shesha.Authorization;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Shesha.Tests.Security
+{
+    /// <summary>
+    /// Tests to verify that the encryption passphrase is configurable.
+    /// Covers issue #4656: Move hardcoded encryption passphrase from AppConsts to configuration.
+    /// </summary>
+    public class EncryptionPassPhrase_Tests
+    {
+        [Fact]
+        public void DefaultPassPhrase_constant_still_exists_as_fallback()
+        {
+            AppConsts.DefaultPassPhrase.Should().NotBeNullOrEmpty(
+                "DefaultPassPhrase must remain as a backward-compatible fallback");
+        }
+
+        [Fact]
+        public void TokenAuthController_should_have_IConfiguration_field()
+        {
+            var field = typeof(TokenAuthController).GetField("_appConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+            field.Should().NotBeNull("TokenAuthController should inject IConfiguration");
+            field.FieldType.Should().Be(typeof(IConfiguration));
+        }
+
+        [Fact]
+        public void TokenAuthController_constructor_should_accept_IConfiguration()
+        {
+            var ctors = typeof(TokenAuthController).GetConstructors();
+            ctors.Should().NotBeEmpty();
+
+            var ctor = ctors[0];
+            var parameters = ctor.GetParameters();
+            var hasConfigParam = false;
+            foreach (var param in parameters)
+            {
+                if (param.ParameterType == typeof(IConfiguration))
+                {
+                    hasConfigParam = true;
+                    break;
+                }
+            }
+            hasConfigParam.Should().BeTrue("TokenAuthController constructor should accept IConfiguration");
+        }
+
+        [Fact]
+        public void Configured_passphrase_encrypts_and_decrypts_correctly()
+        {
+            var customPassPhrase = "MyCustomP@ssPhrase123";
+            var plainText = "test-access-token-value";
+
+            var encrypted = SimpleStringCipher.Instance.Encrypt(plainText, customPassPhrase);
+            var decrypted = SimpleStringCipher.Instance.Decrypt(encrypted, customPassPhrase);
+
+            decrypted.Should().Be(plainText);
+        }
+
+        [Fact]
+        public void Default_passphrase_still_works_for_backward_compatibility()
+        {
+            var plainText = "test-access-token-value";
+
+            var encrypted = SimpleStringCipher.Instance.Encrypt(plainText, AppConsts.DefaultPassPhrase);
+            var decrypted = SimpleStringCipher.Instance.Decrypt(encrypted, AppConsts.DefaultPassPhrase);
+
+            decrypted.Should().Be(plainText);
+        }
+
+        [Fact]
+        public void Different_passphrases_produce_different_ciphertext()
+        {
+            var plainText = "test-access-token-value";
+            var passPhrase1 = AppConsts.DefaultPassPhrase;
+            var passPhrase2 = "DifferentPassPhrase123";
+
+            var encrypted1 = SimpleStringCipher.Instance.Encrypt(plainText, passPhrase1);
+            var encrypted2 = SimpleStringCipher.Instance.Encrypt(plainText, passPhrase2);
+
+            encrypted1.Should().NotBe(encrypted2,
+                "Different passphrases should produce different ciphertext");
+        }
+
+        [Fact]
+        public void Configuration_fallback_returns_default_when_key_missing()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>())
+                .Build();
+
+            var passPhrase = config["Authentication:EncryptionPassPhrase"] ?? AppConsts.DefaultPassPhrase;
+
+            passPhrase.Should().Be(AppConsts.DefaultPassPhrase,
+                "When config key is missing, should fall back to AppConsts.DefaultPassPhrase");
+        }
+
+        [Fact]
+        public void Configuration_returns_custom_value_when_key_present()
+        {
+            var customValue = "MySecurePassPhrase";
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "Authentication:EncryptionPassPhrase", customValue }
+                })
+                .Build();
+
+            var passPhrase = config["Authentication:EncryptionPassPhrase"] ?? AppConsts.DefaultPassPhrase;
+
+            passPhrase.Should().Be(customValue,
+                "When config key is present, should use configured value");
+        }
+    }
+}

--- a/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/AuthConfigurer.cs
+++ b/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/AuthConfigurer.cs
@@ -13,8 +13,12 @@ namespace ShaCompanyName.ShaProjectName.Web.Host.Startup
 {
     public static class AuthConfigurer
     {
+        private static IConfiguration _configuration;
+
         public static void Configure(IServiceCollection services, IConfiguration configuration)
         {
+            _configuration = configuration;
+
             if (bool.Parse(configuration["Authentication:JwtBearer:IsEnabled"]))
             {
                 services.AddAuthentication(options => {
@@ -72,7 +76,8 @@ namespace ShaCompanyName.ShaProjectName.Web.Host.Startup
             }
 
             // Set auth token from cookie
-            context.Token = SimpleStringCipher.Instance.Decrypt(qsAuthToken, AppConsts.DefaultPassPhrase);
+            var encryptionPassPhrase = _configuration?["Authentication:EncryptionPassPhrase"] ?? AppConsts.DefaultPassPhrase;
+            context.Token = SimpleStringCipher.Instance.Decrypt(qsAuthToken, encryptionPassPhrase);
             return Task.CompletedTask;
         }
     }

--- a/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/appsettings.json
+++ b/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/appsettings.json
@@ -14,7 +14,8 @@
       "SecurityKey": "TLU1F5ZCVSY5DXA6LJQVKSQTGPAXV814",
       "Issuer": "Shesha",
       "Audience": "Shesha"
-    }
+    },
+    "EncryptionPassPhrase": "CHANGE-THIS-TO-A-UNIQUE-VALUE"
   },
   "OpenApiInfo": {
     "Title": "ShaProjectName Api",


### PR DESCRIPTION
## Summary
- TokenAuthController now reads `Authentication:EncryptionPassPhrase` from IConfiguration with fallback to `AppConsts.DefaultPassPhrase`
- Both AuthConfigurer files (shesha-core and starter template) use config-based passphrase with fallback
- Adds `EncryptionPassPhrase` key to appsettings.json in both shesha-core and starter
- Marks `AppConsts.DefaultPassPhrase` as deprecated in XML docs

Closes #4656

## Test plan
- [x] 8 unit tests verify configuration fallback, encryption/decryption, and DI wiring
- [ ] Verify SignalR token decryption works with configured passphrase
- [ ] Verify authentication still works with default passphrase (backward compatibility)
- [ ] Verify custom passphrase from appsettings.json is used when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)