### PR TITLE
fix: remove [AbpAllowAnonymous] from ChangePasswordAsync

### DIFF
--- a/shesha-core/src/Shesha.Application/Users/UserAppService.cs
+++ b/shesha-core/src/Shesha.Application/Users/UserAppService.cs
@@ -624,13 +624,8 @@ namespace Shesha.Users
 
         #endregion
 
-        [AbpAllowAnonymous]
         public async Task<bool> ChangePasswordAsync(ChangePasswordDto input)
         {
-            if (_abpSession.UserId == null)
-            {
-                throw new UserFriendlyException("Please log in before attemping to change password.");
-            }
             long userId = _abpSession.UserId.Value;
             var user = await _userManager.GetUserByIdAsync(userId);
             var loginAsync = await _logInManager.LoginAsync(user.UserName, input.CurrentPassword, shouldLockout: false);


### PR DESCRIPTION
## Summary
- Removes `[AbpAllowAnonymous]` attribute from `ChangePasswordAsync` in `UserAppService.cs` so the default authorization pipeline enforces authentication
- Removes the redundant manual `_abpSession.UserId == null` check that was compensating for the missing auth

Closes #4625

## Test plan
- [ ] Verify authenticated users can still change their password successfully
- [ ] Verify unauthenticated requests to `ChangePasswordAsync` are rejected by the framework (401) before reaching the method body
- [ ] Confirm `dotnet build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted change password functionality to authenticated users only. Anonymous users can no longer access the password change endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->