### PR TITLE
Add cors, fixed graphql playground registration and security headers …

### DIFF
--- a/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
@@ -212,7 +212,7 @@ namespace Shesha.Web.Host.Startup
             });
 
             app.UseMiddleware<GraphQLMiddleware>();
-            if (_hostEnvironment.IsDevelopment())
+            if (!_hostEnvironment.IsProduction())
             {
                 app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
             }

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/Controllers/HomeController.cs
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/Controllers/HomeController.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +9,6 @@ namespace Boxfusion.SheshaFunctionalTests.Web.Host.Controllers
     [AllowAnonymous]
     public class HomeController : SheshaControllerBase
     {
-        
         private readonly ISecuritySettings _securitySettings;
 
         public HomeController(ISecuritySettings securitySettings)

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/Startup/Startup.cs
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/Startup/Startup.cs
@@ -38,7 +38,9 @@ using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Hosting;
 using Shesha.Specifications;
 
 namespace Boxfusion.SheshaFunctionalTests.Web.Host.Startup
@@ -156,11 +158,21 @@ namespace Boxfusion.SheshaFunctionalTests.Web.Host.Startup
 				options.UseAbpRequestLocalization = false;
 			}); 
 
+			// Security headers
+			app.UseSecurityHeaders();
+
+			// global cors policy
+			var corsOrigins = _appConfiguration["App:CorsOrigins"]?
+				.Split(",", StringSplitOptions.RemoveEmptyEntries)
+				.Select(o => o.Trim().TrimEnd('/'))
+				.Where(o => !string.IsNullOrEmpty(o))
+				.ToArray() ?? Array.Empty<string>();
 			app.UseCors(x => x
 				.AllowAnyMethod()
 				.AllowAnyHeader()
-				.SetIsOriginAllowed(origin => true) // allow any origin
-				.AllowCredentials()); // allow credentials​
+				.WithOrigins(corsOrigins)
+				.AllowCredentials());
+			
 			app.UseStaticFiles();
 			app.UseAuthentication();
 			app.UseAbpRequestLocalization();
@@ -198,15 +210,16 @@ namespace Boxfusion.SheshaFunctionalTests.Web.Host.Startup
 					.GetManifestResourceStream("Boxfusion.SheshaFunctionalTests.Web.Host.wwwroot.swagger.ui.index.html");
 			}); // URL: /swagger​
 			
-			
-			
             app.UseHangfireDashboard("/hangfire",
 				new DashboardOptions
 				{
 					Authorization = new[] { new HangfireAuthorizationFilter() }
 				});
 			app.UseMiddleware<GraphQLMiddleware>();
-			app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+			if (!_hostEnvironment.IsProduction())
+			{
+				app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+			}
 		}
 
 		private void AddApiVersioning(IServiceCollection services)


### PR DESCRIPTION
…on functional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GraphQL Playground is now enabled in all non-production environments, expanding from development-only access and providing better API exploration capabilities across staging and other non-production settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->