### PR TITLE
Align StatusTag and RefListStatus components in readonly mode (main)

### DIFF
--- a/shesha-reactjs/src/components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/components/refListStatus/index.tsx
@@ -16,6 +16,7 @@ export interface IRefListStatusProps {
   style?: CSSProperties;
   value?: any;
   isDesigner?: boolean;
+  readOnly?: boolean;
 }
 
 const Icon = ({ type, ...rest }): JSX.Element => {
@@ -33,12 +34,13 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
     showReflistName,
     style = {},
     isDesigner = false,
+    readOnly,
   } = props;
   const { width, height, minHeight, minWidth, maxHeight, maxWidth } = style;
   const dimensionsStyles = { width, height, minHeight, minWidth, maxHeight, maxWidth };
   const { fontSize, fontWeight, textAlign, color, backgroundColor, backgroundImage, ...rest } = style;
   const fontStyles = { fontSize, fontWeight, textAlign };
-  const { styles } = useStyles({ dimensionsStyles, fontStyles });
+  const { styles } = useStyles({ dimensionsStyles, fontStyles, readOnly });
   const listItem = useReferenceListItem(referenceListId?.module, referenceListId?.name, value);
 
   if (listItem?.error && !listItem?.loading) {

--- a/shesha-reactjs/src/components/refListStatus/styles/styles.ts
+++ b/shesha-reactjs/src/components/refListStatus/styles/styles.ts
@@ -15,7 +15,7 @@ export const useStyles = createStyles(({ css, cx }, { dimensionsStyles, fontStyl
       display: flex;
       align-items: center;
       width: fit-content;
-      margin: ${readOnly ? '0 ' + sheshaStyles.paddingLG + 'px' : '0'} !important;
+      margin: ${readOnly ? `0 ${sheshaStyles.paddingLG}px` : '0'} !important;
       ${dimensionsStyles};
 
       > span {

--- a/shesha-reactjs/src/components/refListStatus/styles/styles.ts
+++ b/shesha-reactjs/src/components/refListStatus/styles/styles.ts
@@ -1,6 +1,12 @@
-import { createStyles } from '@/styles';
+import { createStyles, sheshaStyles } from '@/styles';
 
-export const useStyles = createStyles(({ css, cx }, { dimensionsStyles, fontStyles }) => {
+interface RefListStatusStyleProps {
+  dimensionsStyles: Record<string, unknown>;
+  fontStyles: { fontSize?: string | number; fontWeight?: string | number; textAlign?: string };
+  readOnly?: boolean;
+}
+
+export const useStyles = createStyles(({ css, cx }, { dimensionsStyles, fontStyles, readOnly }: RefListStatusStyleProps) => {
   const shaStatusTag = 'sha-status-tag';
   const shaStatusTagContainer = cx(
     'sha-status-tag-container',
@@ -8,6 +14,7 @@ export const useStyles = createStyles(({ css, cx }, { dimensionsStyles, fontStyl
       display: flex;
       align-items: center;
       width: fit-content;
+      margin: ${readOnly ? '0 ' + sheshaStyles.paddingLG + 'px' : '0'} !important;
       ${dimensionsStyles};
 
       > span {

--- a/shesha-reactjs/src/components/refListStatus/styles/styles.ts
+++ b/shesha-reactjs/src/components/refListStatus/styles/styles.ts
@@ -1,8 +1,9 @@
+import { CSSObject } from '@emotion/serialize';
 import { createStyles, sheshaStyles } from '@/styles';
 
 interface RefListStatusStyleProps {
-  dimensionsStyles: Record<string, unknown>;
-  fontStyles: { fontSize?: string | number; fontWeight?: string | number; textAlign?: string };
+  dimensionsStyles: CSSObject;
+  fontStyles: CSSObject;
   readOnly?: boolean;
 }
 

--- a/shesha-reactjs/src/components/statusTag/index.tsx
+++ b/shesha-reactjs/src/components/statusTag/index.tsx
@@ -31,6 +31,7 @@ export interface IStatusTagProps {
   color: string;
   mappings?: IStatusMappings;
   style?: CSSProperties;
+  readOnly?: boolean;
 }
 
 export const StatusTag: FC<IStatusTagProps> = ({
@@ -39,8 +40,9 @@ export const StatusTag: FC<IStatusTagProps> = ({
   color,
   mappings = DEFAULT_STATUS_TAG_MAPPINGS,
   style,
+  readOnly,
 }) => {
-  const { styles } = useStyles();
+  const { styles } = useStyles({ readOnly });
   const memoized = useMemo(() => {
     if (!override && (typeof value === 'undefined' || value === null) && !color) {
       return {};

--- a/shesha-reactjs/src/components/statusTag/styles/styles.ts
+++ b/shesha-reactjs/src/components/statusTag/styles/styles.ts
@@ -1,13 +1,12 @@
 import { createStyles, sheshaStyles } from '@/styles';
 
 
-export const useStyles = createStyles(({ css, cx }) => {
+export const useStyles = createStyles(({ css, cx }, { readOnly }: { readOnly?: boolean }) => {
   const shaStatusTag = cx("sha-status-tag", css`
     text-transform: uppercase;
     text-align: center;
-    margin: 3px 0;
     align-self: center;
-    margin: 0 ${sheshaStyles.paddingMD}px !important;   
+    margin: ${readOnly ? '0 ' + sheshaStyles.paddingLG + 'px' : '0'} !important;
   `);
   return {
     shaStatusTag,

--- a/shesha-reactjs/src/designer-components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/designer-components/refListStatus/index.tsx
@@ -52,6 +52,7 @@ const RefListStatusComponent: IToolboxComponent<IRefListStatusProps> = {
               solidBackground={solidBackground}
               style={model.allStyles?.fullStyle ?? {}}
               isDesigner={formMode === 'designer'}
+              readOnly={formMode === 'readonly'}
             />
           );
         }}

--- a/shesha-reactjs/src/designer-components/statusTag/index.tsx
+++ b/shesha-reactjs/src/designer-components/statusTag/index.tsx
@@ -1,6 +1,6 @@
 import { ArrowsAltOutlined } from '@ant-design/icons';
 import React from 'react';
-import { useGlobalState, useFormData } from '@/providers';
+import { useGlobalState, useFormData, useForm } from '@/providers';
 import { evaluateString, validateConfigurableComponentSettings } from '@/formDesignerUtils';
 import { IConfigurableFormComponent, IToolboxComponent } from '@/interfaces/formDesigner';
 import { getStyle } from '@/providers/form/utils';
@@ -23,6 +23,7 @@ const StatusTagComponent: IToolboxComponent<IStatusTagProps> = {
   isOutput: true,
   icon: <ArrowsAltOutlined />,
   Factory: ({ model }) => {
+    const { formMode } = useForm();
     const { globalState } = useGlobalState();
     const { data } = useFormData();
 
@@ -72,6 +73,7 @@ const StatusTagComponent: IToolboxComponent<IStatusTagProps> = {
             {...props}
             style={getStyle(model?.style, data, globalState)}
             value={valueSource === 'form' ? value : props.value}
+            readOnly={formMode === 'readonly'}
           />
         )}
       </ConfigurableFormItem>

--- a/shesha-reactjs/src/designer-components/statusTag/index.tsx
+++ b/shesha-reactjs/src/designer-components/statusTag/index.tsx
@@ -11,7 +11,7 @@ import { migrateCustomFunctions, migrateFunctionToProp, migratePropertyName } fr
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { jsonSafeParse } from '@/utils/object';
 
-export interface IStatusTagProps extends Omit<ITagProps, 'mappings' | 'style'>, IConfigurableFormComponent {
+export interface IStatusTagProps extends Omit<ITagProps, 'mappings' | 'style' | 'readOnly'>, IConfigurableFormComponent {
   mappings?: string;
   valueSource?: 'form' | 'manual';
 }


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StatusTag and RefListStatus now accept a read-only mode that adjusts their styling (including margins) for more compact, consistent display.
  * Designer/configurable form components propagate read-only state when the form is in read-only mode so these elements render with the intended spacing and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->