### PR TITLE
Hide root drop hint when canvas SVG hint is visible

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/styles/styles.ts
+++ b/shesha-reactjs/src/components/formDesigner/styles/styles.ts
@@ -396,7 +396,7 @@ export const useMainStyles = createStyles(({ css, cx, token, prefixCls, iconPref
             }
 
             /* Hide drop hint in main canvas when background SVG is showing */
-            > div > .${shaDropHint} {
+            > .${shaComponentsContainer} > .${shaDropHint} {
                 display: none;
             }
         }


### PR DESCRIPTION
  https://github.com/shesha-io/shesha-framework/issues/4722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined drop hint visibility behavior to ensure correct display in the form designer interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->