### PR TITLE
refactor: simplify color handling in getGhostStyleOverrides

### DIFF
--- a/shesha-reactjs/src/utils/style.ts
+++ b/shesha-reactjs/src/utils/style.ts
@@ -122,7 +122,7 @@ export const getGhostStyleOverrides = (fontStyles?: React.CSSProperties): React.
     backgroundColor: 'transparent',
     border: 'none',
     boxShadow: 'none',
-    ...(fontStyles?.color ? { color: fontStyles.color } : {}),
+    color: fontStyles?.color ?? '#000',
   };
 };
 


### PR DESCRIPTION
#4749 
- Updated getGhostStyleOverrides to use a default color of '#000' when fontStyles.color is not provided, enhancing style consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ghost style overrides to consistently apply a color property with a default black color when no custom color is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->