### PR TITLE
Prevent loader flash by moving centering styles to inline style

### DIFF
--- a/shesha-reactjs/src/components/sheshaLoader/index.tsx
+++ b/shesha-reactjs/src/components/sheshaLoader/index.tsx
@@ -1,4 +1,3 @@
-import { Flex } from 'antd';
 import React, { FC } from 'react';
 
 interface ISheshaLoader {
@@ -6,10 +5,10 @@ interface ISheshaLoader {
 }
 
 const SheshaLoader: FC<ISheshaLoader> = ({ message = 'Initializing...' }) => (
-  <Flex vertical style={{ height: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+  <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
     <img src={`/images/SheshaLoadingAnimation.gif`} alt="Shesha Loading Animation" />
     <div>{message}</div>
-  </Flex>
+  </div>
 );
 
 export default SheshaLoader;

--- a/shesha-reactjs/src/components/sheshaLoader/index.tsx
+++ b/shesha-reactjs/src/components/sheshaLoader/index.tsx
@@ -6,7 +6,7 @@ interface ISheshaLoader {
 }
 
 const SheshaLoader: FC<ISheshaLoader> = ({ message = 'Initializing...' }) => (
-  <Flex vertical justify="center" align="center" style={{ height: '100vh' }}>
+  <Flex vertical style={{ height: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
     <img src={`/images/SheshaLoadingAnimation.gif`} alt="Shesha Loading Animation" />
     <div>{message}</div>
   </Flex>


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved styling implementation for the loader component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->