### PR TITLE
[feature] EmailChannelSender allow for send from email

### DIFF
--- a/shesha-core/src/Shesha.Application/Email/Dtos/SmtpSettingsDto.cs
+++ b/shesha-core/src/Shesha.Application/Email/Dtos/SmtpSettingsDto.cs
@@ -48,11 +48,6 @@
         public bool SupportSmtpRelay { get; set; }
 
         /// <summary>
-        /// If true, the from address on all outgoing emails will always be overridden with the address configured in settings, ignoring any caller-supplied from address.
-        /// </summary>
-        public bool ForceFromAddressFromSettings { get; set; }
-
-        /// <summary>
         /// If not null or empty the all outgoing emails will be sent to this email address, is used for testing
         /// </summary>
         public string RedirectAllMessagesTo { get; set; }

--- a/shesha-core/src/Shesha.Application/Email/Dtos/SmtpSettingsDto.cs
+++ b/shesha-core/src/Shesha.Application/Email/Dtos/SmtpSettingsDto.cs
@@ -48,6 +48,11 @@
         public bool SupportSmtpRelay { get; set; }
 
         /// <summary>
+        /// If true, the from address on all outgoing emails will always be overridden with the address configured in settings, ignoring any caller-supplied from address.
+        /// </summary>
+        public bool ForceFromAddressFromSettings { get; set; }
+
+        /// <summary>
         /// If not null or empty the all outgoing emails will be sent to this email address, is used for testing
         /// </summary>
         public string RedirectAllMessagesTo { get; set; }

--- a/shesha-core/src/Shesha.Application/Email/EmailSenderAppService.cs
+++ b/shesha-core/src/Shesha.Application/Email/EmailSenderAppService.cs
@@ -49,7 +49,6 @@ namespace Shesha.Email
                 EnableSsl = input.EnableSsl,
                 DefaultFromAddress = input.DefaultFromAddress,
                 DefaultFromDisplayName = input.DefaultFromDisplayName,
-                ForceFromAddressFromSettings = input.ForceFromAddressFromSettings,
             });
 
             return true;
@@ -74,7 +73,6 @@ namespace Shesha.Email
                 DefaultFromAddress = smtpSettings.DefaultFromAddress,
                 DefaultFromDisplayName = smtpSettings.DefaultFromDisplayName,
                 SupportSmtpRelay = smtpSettings.UseSmtpRelay,
-                ForceFromAddressFromSettings = smtpSettings.ForceFromAddressFromSettings,
 
                 RedirectAllMessagesTo = emailSettings.RedirectAllMessagesTo,
                 EmailsEnabled = emailSettings.EmailsEnabled,

--- a/shesha-core/src/Shesha.Application/Email/EmailSenderAppService.cs
+++ b/shesha-core/src/Shesha.Application/Email/EmailSenderAppService.cs
@@ -40,7 +40,7 @@ namespace Shesha.Email
                 RedirectAllMessagesTo = input.RedirectAllMessagesTo,
             });
 
-            await _emailSettings.SmtpSettings.SetValueAsync(new SmtpSettings { 
+            await _emailSettings.SmtpSettings.SetValueAsync(new SmtpSettings {
                 Host = input.Host,
                 Port = input.Port,
                 Domain = input.Domain,
@@ -49,6 +49,7 @@ namespace Shesha.Email
                 EnableSsl = input.EnableSsl,
                 DefaultFromAddress = input.DefaultFromAddress,
                 DefaultFromDisplayName = input.DefaultFromDisplayName,
+                ForceFromAddressFromSettings = input.ForceFromAddressFromSettings,
             });
 
             return true;
@@ -73,6 +74,7 @@ namespace Shesha.Email
                 DefaultFromAddress = smtpSettings.DefaultFromAddress,
                 DefaultFromDisplayName = smtpSettings.DefaultFromDisplayName,
                 SupportSmtpRelay = smtpSettings.UseSmtpRelay,
+                ForceFromAddressFromSettings = smtpSettings.ForceFromAddressFromSettings,
 
                 RedirectAllMessagesTo = emailSettings.RedirectAllMessagesTo,
                 EmailsEnabled = emailSettings.EmailsEnabled,

--- a/shesha-core/src/Shesha.Application/Notifications/Emails/EmailChannelSender.cs
+++ b/shesha-core/src/Shesha.Application/Notifications/Emails/EmailChannelSender.cs
@@ -140,9 +140,9 @@ namespace Shesha.Notifications
                 IsBodyHtml = true,
             };
 
-            if (string.IsNullOrWhiteSpace(fromAddress) || smtpSettings.ForceFromAddressFromSettings)
+            if (string.IsNullOrWhiteSpace(fromAddress) || !smtpSettings.UseSmtpRelay)
             {
-                if (smtpSettings.UseSmtpRelay && !string.IsNullOrWhiteSpace(smtpSettings.DefaultFromAddress))
+                if (!string.IsNullOrWhiteSpace(smtpSettings.DefaultFromAddress))
                 {
                     message.From = new MailAddress(
                         smtpSettings.DefaultFromAddress,

--- a/shesha-core/src/Shesha.Application/Notifications/Emails/EmailChannelSender.cs
+++ b/shesha-core/src/Shesha.Application/Notifications/Emails/EmailChannelSender.cs
@@ -1,5 +1,4 @@
-﻿using Abp.UI;
-using Castle.Core.Logging;
+﻿using Castle.Core.Logging;
 using Shesha.Configuration;
 using Shesha.Configuration.Email;
 using Shesha.Domain;
@@ -11,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Mail;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Shesha.Notifications
@@ -140,14 +140,24 @@ namespace Shesha.Notifications
                 IsBodyHtml = true,
             };
 
-            if (string.IsNullOrWhiteSpace(fromAddress))
+            if (string.IsNullOrWhiteSpace(fromAddress) || smtpSettings.ForceFromAddressFromSettings)
             {
-                if (!StringHelper.IsValidEmail(smtpSettings.DefaultFromAddress))
+                if (smtpSettings.UseSmtpRelay && !string.IsNullOrWhiteSpace(smtpSettings.DefaultFromAddress))
                 {
-                    throw new UserFriendlyException("Default from address is not valid!");
+                    message.From = new MailAddress(
+                        smtpSettings.DefaultFromAddress,
+                        smtpSettings.DefaultFromDisplayName,
+                        Encoding.UTF8
+                    );
                 }
-
-                message.From = new MailAddress(smtpSettings.DefaultFromAddress);
+                else
+                {
+                    message.From = new MailAddress(
+                        smtpSettings.UserName,
+                        null,
+                        Encoding.UTF8
+                    );
+                }
             }
             else if (StringHelper.IsValidEmail(fromAddress))
             {

--- a/shesha-core/src/Shesha.Framework/Configuration/Email/SmtpSettings.cs
+++ b/shesha-core/src/Shesha.Framework/Configuration/Email/SmtpSettings.cs
@@ -56,9 +56,5 @@
         /// </summary>
         public bool UseSmtpRelay { get; set; }
 
-        /// <summary>
-        /// If true, the from address on all outgoing emails will always be overridden with the address configured in settings, ignoring any caller-supplied from address.
-        /// </summary>
-        public bool ForceFromAddressFromSettings { get; set; }
     }
 }

--- a/shesha-core/src/Shesha.Framework/Configuration/Email/SmtpSettings.cs
+++ b/shesha-core/src/Shesha.Framework/Configuration/Email/SmtpSettings.cs
@@ -55,5 +55,10 @@
         /// If true, indicate that SMTP relay service will be used where it's needed (e.g. if the application needs to notify one person about the action that was performed by another person then real person's email address will be used for the 'from' address, otherwise 'Site Email' will be used)
         /// </summary>
         public bool UseSmtpRelay { get; set; }
+
+        /// <summary>
+        /// If true, the from address on all outgoing emails will always be overridden with the address configured in settings, ignoring any caller-supplied from address.
+        /// </summary>
+        public bool ForceFromAddressFromSettings { get; set; }
     }
 }


### PR DESCRIPTION
We are using Sendgrid as our smtp email sender. There is no way to force the emails to have the defaultFromAddress forced to be set as what is configured in the SMTP settings. If smtpRelay is set we use the defaultFromAddress and if not we use the configured smtp username (This was the functioning in the obsolete SheshaEmailSender)

 We have added this feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sender address resolution for email delivery with improved UTF-8 encoding support and SMTP relay configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->