### PR TITLE
[fix] send email validate address - allow address with .afirca domain

### DIFF
--- a/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
@@ -864,13 +864,9 @@ namespace Shesha.Utilities
             return String.Join(" ", SplitUpperCase(source));
         }
 
-        private static readonly Regex ValidEmailExpression = new Regex(
-            @"^([a-zA-Z0-9_\-\.\+]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,}|[0-9]{1,3})(\]?)$",
-            RegexOptions.Compiled);
-
         public static bool IsValidEmail(this string inputEmail)
         {
-            return !string.IsNullOrWhiteSpace(inputEmail) && ValidEmailExpression.IsMatch(inputEmail);
+            return IsEmail(inputEmail);
         }
 
         [DebuggerStepThrough]

--- a/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
@@ -864,14 +864,13 @@ namespace Shesha.Utilities
             return String.Join(" ", SplitUpperCase(source));
         }
 
+        private static readonly Regex ValidEmailExpression = new Regex(
+            @"^([a-zA-Z0-9_\-\.\+]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,}|[0-9]{1,3})(\]?)$",
+            RegexOptions.Compiled);
+
         public static bool IsValidEmail(this string inputEmail)
         {
-            string strRegex = @"^([a-zA-Z0-9_\-\.\+]+)@((\[[0-9]{1,3}" +
-                              @"\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\" +
-                              @".)+))([a-zA-Z]{2,}|[0-9]{1,3})(\]?)$";
-            Regex re = new Regex(strRegex);
-            var normalised = Regex.Replace(inputEmail ?? "", @"\s+", "");
-            return re.IsMatch(normalised);
+            return !string.IsNullOrWhiteSpace(inputEmail) && ValidEmailExpression.IsMatch(inputEmail);
         }
 
         [DebuggerStepThrough]

--- a/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Utilities/StringHelper.cs
@@ -866,14 +866,12 @@ namespace Shesha.Utilities
 
         public static bool IsValidEmail(this string inputEmail)
         {
-            string strRegex = @"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}" +
+            string strRegex = @"^([a-zA-Z0-9_\-\.\+]+)@((\[[0-9]{1,3}" +
                               @"\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\" +
-                              @".)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$";
+                              @".)+))([a-zA-Z]{2,}|[0-9]{1,3})(\]?)$";
             Regex re = new Regex(strRegex);
-            if (re.IsMatch(inputEmail))
-                return (true);
-            else
-                return (false);
+            var normalised = Regex.Replace(inputEmail ?? "", @"\s+", "");
+            return re.IsMatch(normalised);
         }
 
         [DebuggerStepThrough]

--- a/shesha-core/test/Shesha.Tests/StringHelper/StringHelperIsValidEmailTests.cs
+++ b/shesha-core/test/Shesha.Tests/StringHelper/StringHelperIsValidEmailTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shesha.Tests.StringHelper
+{
+    public class StringHelperIsValidEmailTests
+    {
+        [Theory]
+        [InlineData("rob@test.com", true)]
+        [InlineData("rob@test.africa", true)]
+        [InlineData("rob+dep@test.africa", true)]
+        //Invalid email addresses
+        [InlineData("rob", false)]
+        [InlineData("rob@", false)]
+        [InlineData("rob@.com", false)]
+        [InlineData("rob@com", false)]
+        [InlineData("@test.com", false)]
+        [InlineData("rob@test.com ", true)]
+        [InlineData(" rob@test.com", true)]
+        [InlineData("rob@test .com", true)]
+
+        public void Should_Validate_Email_Addresses(string email, bool expected)
+        {
+            var result = Shesha.Utilities.StringHelper.IsValidEmail(email);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/shesha-core/test/Shesha.Tests/StringHelper/StringHelperIsValidEmailTests.cs
+++ b/shesha-core/test/Shesha.Tests/StringHelper/StringHelperIsValidEmailTests.cs
@@ -19,9 +19,12 @@ namespace Shesha.Tests.StringHelper
         [InlineData("rob@.com", false)]
         [InlineData("rob@com", false)]
         [InlineData("@test.com", false)]
-        [InlineData("rob@test.com ", true)]
-        [InlineData(" rob@test.com", true)]
-        [InlineData("rob@test .com", true)]
+        [InlineData("rob@test.com ", false)]
+        [InlineData(" rob@test.com", false)]
+        [InlineData("rob@test .com", false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData(null, false)]
 
         public void Should_Validate_Email_Addresses(string email, bool expected)
         {


### PR DESCRIPTION
We are unable to send emails to address with the .africa domina eg: rob@test.africa

We are unable to send emails to address with + in the mailbox eg: rob+dep@test.com

We added test for these and amended the isValidEmail check

fixes issue: #4830 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email validation updated: accepts "+" and longer TLDs; null/blank inputs are rejected.
* **Refactor**
  * Email validation now delegates to the shared validation routine for consistency and improved efficiency.
* **Behavior Change**
  * Trimming-to-snake-case output was adjusted — result formatting may differ for one trimming variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->