### PR TITLE
when the designer's outcomeValueFunc can't find the configured keyPro…

### DIFF
--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -17,6 +17,7 @@ import { ValueRenderer } from '../valueRenderer';
 import { AutocompleteDataSourceType, DisplayValueFunc, FilterSelectedFunc, IAutocompleteBaseProps, IAutocompleteProps, ISelectOption, KayValueFunc, OutcomeValueFunc, getColumns } from './models';
 import { useStyles } from './style';
 import { isEntityTypeIdEmpty } from '@/providers/metadataDispatcher/entities/utils';
+import { createOutcomeValueFunc } from './utils';
 
 const getNormalizedValues = (value: unknown): unknown[] => {
   const values = Array.isArray(value) ? value : [value];
@@ -48,24 +49,13 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
   }, [filterKeysFunc]);
   const displayValueFunc: DisplayValueFunc = useMemo(() => props.displayValueFunc ??
     ((value: unknown) => (Boolean(value) ? String(getValueByPropertyName(value as Record<string, unknown>, displayPropName) ?? value?.toString()) : '')), [props.displayValueFunc, displayPropName]);
-  const outcomeValueFunc: OutcomeValueFunc = useMemo(() => {
-    const base = props.outcomeValueFunc ??
-      // --- For backward compatibility
-      (props.dataSourceType === 'entitiesList' && !props.keyPropName
-        ? (value: unknown) => ({ id: (value as Record<string, unknown>).id, _displayName: getValueByPropertyName(value as Record<string, unknown>, displayPropName), _className: (value as Record<string, unknown>)._className })
-        // ---
-        : (value: unknown) => getValueByPropertyName(value as Record<string, unknown>, keyPropName) ?? value);
-    // Fallback when the configured keyPropName isn't present on the row (common for URL endpoints returning {id, ...})
-    return (item: unknown, args: object) => {
-      const result = base(item, args);
-      if (result !== undefined && result !== null) return result;
-      if (item !== null && typeof item === 'object') {
-        const r = item as Record<string, unknown>;
-        return r.id ?? r.value ?? item;
-      }
-      return item;
-    };
-  }, [props.outcomeValueFunc, props.dataSourceType, props.keyPropName, displayPropName, keyPropName]);
+  const outcomeValueFunc: OutcomeValueFunc = useMemo(() => createOutcomeValueFunc({
+    providedFunc: props.outcomeValueFunc,
+    dataSourceType: props.dataSourceType,
+    rawKeyPropName: props.keyPropName,
+    displayPropName,
+    keyPropName,
+  }), [props.outcomeValueFunc, props.dataSourceType, displayPropName, keyPropName]);
 
   // register columns
   useDeepCompareEffect(() => source?.registerConfigurableColumns(props.uid, getColumns(props.fields)), [props.fields]);

--- a/shesha-reactjs/src/components/autocomplete/index.tsx
+++ b/shesha-reactjs/src/components/autocomplete/index.tsx
@@ -48,12 +48,24 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
   }, [filterKeysFunc]);
   const displayValueFunc: DisplayValueFunc = useMemo(() => props.displayValueFunc ??
     ((value: unknown) => (Boolean(value) ? String(getValueByPropertyName(value as Record<string, unknown>, displayPropName) ?? value?.toString()) : '')), [props.displayValueFunc, displayPropName]);
-  const outcomeValueFunc: OutcomeValueFunc = useMemo(() => props.outcomeValueFunc ??
-    // --- For backward compatibility
-    (props.dataSourceType === 'entitiesList' && !props.keyPropName
-      ? (value: unknown) => ({ id: (value as Record<string, unknown>).id, _displayName: getValueByPropertyName(value as Record<string, unknown>, displayPropName), _className: (value as Record<string, unknown>)._className })
-      // ---
-      : (value: unknown) => getValueByPropertyName(value as Record<string, unknown>, keyPropName) ?? value), [props.outcomeValueFunc, props.dataSourceType, props.keyPropName, displayPropName]);
+  const outcomeValueFunc: OutcomeValueFunc = useMemo(() => {
+    const base = props.outcomeValueFunc ??
+      // --- For backward compatibility
+      (props.dataSourceType === 'entitiesList' && !props.keyPropName
+        ? (value: unknown) => ({ id: (value as Record<string, unknown>).id, _displayName: getValueByPropertyName(value as Record<string, unknown>, displayPropName), _className: (value as Record<string, unknown>)._className })
+        // ---
+        : (value: unknown) => getValueByPropertyName(value as Record<string, unknown>, keyPropName) ?? value);
+    // Fallback when the configured keyPropName isn't present on the row (common for URL endpoints returning {id, ...})
+    return (item: unknown, args: object) => {
+      const result = base(item, args);
+      if (result !== undefined && result !== null) return result;
+      if (item !== null && typeof item === 'object') {
+        const r = item as Record<string, unknown>;
+        return r.id ?? r.value ?? item;
+      }
+      return item;
+    };
+  }, [props.outcomeValueFunc, props.dataSourceType, props.keyPropName, displayPropName, keyPropName]);
 
   // register columns
   useDeepCompareEffect(() => source?.registerConfigurableColumns(props.uid, getColumns(props.fields)), [props.fields]);
@@ -231,9 +243,9 @@ const AutocompleteInner: FC<IAutocompleteBaseProps> = (props: IAutocompleteBaseP
 
     if (!Boolean(props.onChange))
       return;
-    if (props.mode === 'multiple') {
+    if (props.mode === 'multiple')
       props.onChange(Array.isArray(selectedValue) ? selectedValue : [selectedValue]);
-    } else
+    else
       props.onChange(selectedValue);
   };
 

--- a/shesha-reactjs/src/components/autocomplete/utils.ts
+++ b/shesha-reactjs/src/components/autocomplete/utils.ts
@@ -1,0 +1,42 @@
+import { getValueByPropertyName } from '@/utils/object';
+import { AutocompleteDataSourceType, OutcomeValueFunc } from './models';
+
+interface ICreateOutcomeValueFuncArgs {
+  providedFunc?: OutcomeValueFunc;
+  dataSourceType?: AutocompleteDataSourceType;
+  rawKeyPropName?: string;
+  displayPropName: string;
+  keyPropName: string;
+}
+
+/**
+ * Builds an OutcomeValueFunc that extracts a row's key value, with a fallback
+ * to `id` or `value` when the configured keyPropName isn't present on the row
+ * (common for URL endpoints returning `{ id, ... }` while keyPropName defaults to `value`).
+ */
+export const createOutcomeValueFunc = ({
+  providedFunc,
+  dataSourceType,
+  rawKeyPropName,
+  displayPropName,
+  keyPropName,
+}: ICreateOutcomeValueFuncArgs): OutcomeValueFunc => {
+  const base: OutcomeValueFunc = providedFunc ??
+    (dataSourceType === 'entitiesList' && !rawKeyPropName
+      ? (value: unknown) => ({
+        id: (value as Record<string, unknown>).id,
+        _displayName: getValueByPropertyName(value as Record<string, unknown>, displayPropName),
+        _className: (value as Record<string, unknown>)._className,
+      })
+      : (value: unknown) => getValueByPropertyName(value as Record<string, unknown>, keyPropName));
+
+  return (item: unknown, args: object) => {
+    const result = base(item, args);
+    if (result !== undefined && result !== null) return result;
+    if (item !== null && typeof item === 'object') {
+      const r = item as Record<string, unknown>;
+      return r.id ?? r.value ?? item;
+    }
+    return item;
+  };
+};


### PR DESCRIPTION
when the designer's outcomeValueFunc can't find the configured keyPro…pName on a row (URL endpoint returning {id, ...} with default keyPropName='value'), it falls back to row.id ?? row.value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced autocomplete value extraction with improved fallback logic to handle missing or differently-structured data, ensuring reliable identification of items across various data formats and response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->