### PR TITLE
fix: cache enhancements

### DIFF
--- a/shesha-core/src/Shesha.Application/DynamicEntities/ModelConfigurationsAppService.cs
+++ b/shesha-core/src/Shesha.Application/DynamicEntities/ModelConfigurationsAppService.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Shesha.Configuration.Runtime;
 using Shesha.Domain;
 using Shesha.Domain.Enums;
+using Shesha.DynamicEntities.Cache;
 using Shesha.DynamicEntities.Dtos;
 using Shesha.Elmah;
 using Shesha.Extensions;
@@ -29,20 +30,22 @@ namespace Shesha.DynamicEntities
         private readonly IModelConfigurationManager _modelConfigurationManager;
         private readonly ISwaggerProvider _swaggerProvider;
         private readonly IEntityConfigurationStore _entityConfigurationStore;
-
+        private readonly IModelConfigsCacheHolder _modelConfigsCacheHolder;
 
         public ModelConfigurationsAppService(
             IRepository<EntityConfig, Guid> entityConfigRepository,
             IRepository<EntityProperty, Guid> entityPropertyRepository,
             IModelConfigurationManager modelConfigurationProvider,
             ISwaggerProvider swaggerProvider,
-            IEntityConfigurationStore entityConfigurationStore)
+            IEntityConfigurationStore entityConfigurationStore,
+            IModelConfigsCacheHolder modelConfigsCacheHolder)
         {
             _entityConfigRepository = entityConfigRepository;
             _entityPropertyRepository = entityPropertyRepository;
             _modelConfigurationManager = modelConfigurationProvider;
             _swaggerProvider = swaggerProvider;
             _entityConfigurationStore = entityConfigurationStore;
+            _modelConfigsCacheHolder = modelConfigsCacheHolder;
         }
 
         [HttpGet, Route("")]
@@ -122,6 +125,12 @@ namespace Shesha.DynamicEntities
             }
 
             return await _modelConfigurationManager.GetModelConfigurationAsync(destination);
+        }
+
+        [HttpPost, Route("clearCache")]
+        public async Task ClearCacheAsync()
+        {
+            await _modelConfigsCacheHolder.Cache.ClearAsync();
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/DynamicEntities/Cache/ModelConfigsCacheHolder.cs
+++ b/shesha-core/src/Shesha.Framework/DynamicEntities/Cache/ModelConfigsCacheHolder.cs
@@ -1,14 +1,22 @@
 ﻿using Abp.Dependency;
 using Abp.Runtime.Caching;
+using Microsoft.Extensions.Configuration;
 using Shesha.Cache;
 using Shesha.DynamicEntities.Dtos;
+using System;
 
 namespace Shesha.DynamicEntities.Cache
 {
     public class ModelConfigsCacheHolder : CacheHolder<string, ModelConfigurationDto>, IModelConfigsCacheHolder, ISingletonDependency
     {
-        public ModelConfigsCacheHolder(ICacheManager cacheManager) : base("ModelConfigsCache", cacheManager)
+        public ModelConfigsCacheHolder(ICacheManager cacheManager, IConfiguration configuration) : base("ModelConfigsCache", cacheManager)
         {
+            var expiration = configuration.GetValue<int?>("ModelConfigsCacheExpiration");
+            var expirationMins = expiration.HasValue && expiration.Value > 0
+                ? expiration.Value
+                : 24 * 60;
+
+            Cache.DefaultSlidingExpireTime = TimeSpan.FromMinutes(expirationMins);
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/DynamicEntities/IModelConfigurationManager.cs
+++ b/shesha-core/src/Shesha.Framework/DynamicEntities/IModelConfigurationManager.cs
@@ -1,9 +1,7 @@
 ﻿using Shesha.Domain;
 using Shesha.DynamicEntities.Dtos;
 using Shesha.Metadata.Dtos;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Shesha.DynamicEntities
@@ -46,7 +44,5 @@ namespace Shesha.DynamicEntities
         /// <param name="input">Model configuration Dto</param>
         /// <returns></returns>
         Task<ModelConfigurationDto> UpdateAsync(ModelConfigurationDto input);
-
-
     }
 }

--- a/shesha-core/src/Shesha.Web.FormsDesigner/Services/Cache/FormCacheHolder.cs
+++ b/shesha-core/src/Shesha.Web.FormsDesigner/Services/Cache/FormCacheHolder.cs
@@ -7,6 +7,7 @@ using Shesha.Cache;
 using Shesha.ConfigurationItems.Models;
 using Shesha.Domain;
 using Shesha.Web.FormsDesigner.Dtos;
+using System;
 using System.Threading.Tasks;
 
 namespace Shesha.Web.FormsDesigner.Services.Cache
@@ -18,6 +19,13 @@ namespace Shesha.Web.FormsDesigner.Services.Cache
         public FormCacheHolder(ICacheManager cacheManager, IConfiguration configuration) : base("FormsCache", cacheManager)
         {
             IsEnabled = !configuration.GetValue<bool>("disableFormsCache");
+
+            var expiration = configuration.GetValue<int?>("FormsCacheExpiration");
+            var expirationMins = expiration.HasValue && expiration.Value > 0
+                ? expiration.Value
+                : 24 * 60;
+
+            Cache.DefaultSlidingExpireTime = TimeSpan.FromMinutes(expirationMins);
         }
 
         public string GetCacheKey(string module, string name, ConfigurationItemViewMode mode)


### PR DESCRIPTION
- added `FormsCacheExpiration` setting (in mins) for default slide expiration of FormsCache, extended default to 24h
- added `ModelConfigsCacheExpiration` setting (in mins) for default slide expiration of ModelConfigsCache, extended default to 24h
- added `/api/ModelConfigurations/clearCache` endpoint for manual cache cleanup