### PR TITLE
fix: update ownerId logic in AttachmentsEditor component

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -110,7 +110,7 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
           return (
             <StoredFilesProvider
               name={model.componentName}
-              ownerId={Boolean(ownerId) ? ownerId : Boolean(data?.id) ? data?.id : ''}
+              ownerId={Boolean(model.ownerId) ? ownerId : Boolean(data?.id) ? data?.id : ''}
               ownerType={
                 Boolean(model.ownerType) ? model.ownerType : Boolean(form?.formSettings?.modelType) ? form?.formSettings?.modelType : ''
               }


### PR DESCRIPTION
#4857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected owner ID assignment logic in the attachments editor to properly prioritize configured values and ensure correct fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->