### PR TITLE
Fix ownerId assignment in AttachmentsEditor

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -223,7 +223,7 @@ const AttachmentsEditor: IToolboxComponent<IAttachmentsEditorProps> = {
           return (
             <AttachmentsEditorProvider
               name={model.componentName}
-              ownerId={!isNullOrWhiteSpace(ownerId) ? ownerId : getIdOrUndefined(data) ?? ""}
+              ownerId={!isNullOrWhiteSpace(model.ownerId) ? ownerId : getIdOrUndefined(data) ?? ""}
               ownerType={!isEntityTypeIdEmpty(model.ownerType) ? model.ownerType : !isEntityTypeIdEmpty(form?.formSettings?.modelType) ? form?.formSettings?.modelType : ''}
               ownerName={model.ownerName}
               filesCategory={model.filesCategory}


### PR DESCRIPTION
#4857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with attachment ownership validation to properly handle empty or whitespace identifiers, ensuring attachments function correctly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->