### PR TITLE
fix: Fixed the forced password-change flow after first login

### DIFF
--- a/shesha-core/src/Shesha.Application/Users/UserAppService.cs
+++ b/shesha-core/src/Shesha.Application/Users/UserAppService.cs
@@ -623,6 +623,7 @@ namespace Shesha.Users
 
         #endregion
 
+        [SheshaAuthorize(RefListPermissionedAccess.AnyAuthenticated)]
         public async Task<bool> ChangePasswordAsync(ChangePasswordDto input)
         {
             if (!_abpSession.UserId.HasValue)

--- a/shesha-core/src/Shesha.Application/Users/UserAppService.cs
+++ b/shesha-core/src/Shesha.Application/Users/UserAppService.cs
@@ -576,6 +576,7 @@ namespace Shesha.Users
 
             user.Password = _passwordHasher.HashPassword(user, input.NewPassword);
             user.PasswordResetCode = null;
+            user.RequireChangePassword = false;
 
             await CurrentUnitOfWork.SaveChangesAsync();
 

--- a/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionManager.cs
@@ -40,11 +40,14 @@ namespace Shesha.Authorization
         public override void Initialize()
         {
             base.Initialize();
+        }
 
+        [UnitOfWork]
+        public virtual void InitializeDbPermissions()
+        {
             AsyncHelper.RunSync(async () => await InitializeDbPermissionsAsync());
         }
 
-        
         private async Task InitializeDbPermissionsAsync()
         {
             var dbPermissions = await _permissionDefinitionRepository.GetAllListAsync();

--- a/shesha-core/src/Shesha.NHibernate/NHibernate/SheshaNHibernateModule.cs
+++ b/shesha-core/src/Shesha.NHibernate/NHibernate/SheshaNHibernateModule.cs
@@ -14,6 +14,7 @@ using Castle.MicroKernel.Registration;
 using Microsoft.Extensions.Configuration;
 using NHibernate;
 using Shesha.Attributes;
+using Shesha.Authorization;
 using Shesha.Bootstrappers;
 using Shesha.Configuration.Startup;
 using Shesha.Domain;
@@ -217,6 +218,7 @@ namespace Shesha.NHibernate
                 AsyncHelper.RunSync(async () => {
                     await SeedDatabaseAsync();
                 });
+                IocManager.Resolve<ShaPermissionManager>().InitializeDbPermissions();
                 Configuration.EntityHistory.IsEnabledForAnonymousUsers = prev;
             }
         }

--- a/shesha-core/src/Shesha.NHibernate/NHibernate/SheshaNHibernateModule.cs
+++ b/shesha-core/src/Shesha.NHibernate/NHibernate/SheshaNHibernateModule.cs
@@ -215,11 +215,17 @@ namespace Shesha.NHibernate
             {
                 var prev = Configuration.EntityHistory.IsEnabledForAnonymousUsers;
                 Configuration.EntityHistory.IsEnabledForAnonymousUsers = false;
-                AsyncHelper.RunSync(async () => {
-                    await SeedDatabaseAsync();
-                });
-                IocManager.Resolve<ShaPermissionManager>().InitializeDbPermissions();
-                Configuration.EntityHistory.IsEnabledForAnonymousUsers = prev;
+                try
+                {
+                    AsyncHelper.RunSync(async () => {
+                        await SeedDatabaseAsync();
+                    });
+                    IocManager.Resolve<ShaPermissionManager>().InitializeDbPermissions();
+                }
+                finally
+                {
+                    Configuration.EntityHistory.IsEnabledForAnonymousUsers = prev;
+                }
             }
         }
 

--- a/shesha-core/src/Shesha.NHibernate/NHibernate/SheshaNHibernateModule.cs
+++ b/shesha-core/src/Shesha.NHibernate/NHibernate/SheshaNHibernateModule.cs
@@ -220,7 +220,25 @@ namespace Shesha.NHibernate
                     AsyncHelper.RunSync(async () => {
                         await SeedDatabaseAsync();
                     });
-                    IocManager.Resolve<ShaPermissionManager>().InitializeDbPermissions();
+
+                    // InitializeDbPermissions uses a check-then-act pattern against the local in-memory
+                    // permissions cache, which is not shared across instances. Without a distributed lock,
+                    // concurrent startups race to write the same permission rows (InsertOrUpdateAsync) and
+                    // delete the same orphaned permissions, causing DB inconsistencies. Each instance must
+                    // still run this to populate its own cache, so we use a separate lock key rather than
+                    // the SeedDb key (which has an early-exit that would skip other instances entirely).
+                    var lockFactory = IocManager.Resolve<ILockFactory>();
+                    const string initPermissionsKey = "AppStart:InitDbPermissions";
+                    AsyncHelper.RunSync(() => lockFactory.DoExclusiveAsync(
+                        initPermissionsKey,
+                        TimeSpan.FromSeconds(30),
+                        TimeSpan.FromSeconds(10),
+                        TimeSpan.FromSeconds(1),
+                        () =>
+                        {
+                            IocManager.Resolve<ShaPermissionManager>().InitializeDbPermissions();
+                            return Task.CompletedTask;
+                        }));
                 }
                 finally
                 {
@@ -359,11 +377,19 @@ namespace Shesha.NHibernate
 
                     await appStartup.StartupSuccessAsync(startupDto.Id);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
-                    if (startupDto != null) {
-                        await appStartup.StartupFailedAsync(startupDto.Id, e);
-                    }                        
+                    if (startupDto != null)
+                    {
+                        try
+                        {
+                            await appStartup.StartupFailedAsync(startupDto.Id, e);
+                        }
+                        catch (Exception logEx)
+                        {
+                            Logger.Error("Failed to write startup failure log", logEx);
+                        }
+                    }
                     throw;
                 }
 

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/appsettings.json
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Data Source=.; Initial Catalog=functional-shesha-test;Integrated Security=SSPI;TrustServerCertificate=True;"
+    "Default": "Data Source=.; Initial Catalog=ShaProjectName;Integrated Security=SSPI;TrustServerCertificate=True;"
   },
   "App": {
     "ServerRootAddress": "http://localhost:21021",

--- a/shesha-reactjs/src/providers/auth/authenticator.ts
+++ b/shesha-reactjs/src/providers/auth/authenticator.ts
@@ -18,7 +18,10 @@ import { ISettingsActionsContext } from "../settings/contexts";
 type RerenderTrigger = () => void;
 
 const RETURN_URL_KEY = 'returnUrl';
-const REQUIRED_PASSWORD_CHANGE_URL = '/no-auth/Shesha/change-password?mode=edit';
+const getRequiredPasswordChangeUrl = (returnUrl?: string) =>
+    returnUrl
+        ? `/no-auth/Shesha/change-password?mode=edit&${RETURN_URL_KEY}=${encodeURIComponent(returnUrl)}`
+        : '/no-auth/Shesha/change-password?mode=edit';
 
 const isAccessToken = (value: unknown): value is IAccessToken =>
     typeof value === 'object' &&
@@ -195,8 +198,11 @@ export class Authenticator implements IAuthenticator {
     };
 
     #getRedirectUrl = (currentPath: string, userLogin: UserLoginInfoDto): string => {
-        if (userLogin?.requireChangePassword)
-            return REQUIRED_PASSWORD_CHANGE_URL;
+        if (userLogin?.requireChangePassword) {
+            const returnUrlParam = this.#router.query[RETURN_URL_KEY];
+            const returnUrl = returnUrlParam ? decodeURIComponent(returnUrlParam.toString()) : undefined;
+            return getRequiredPasswordChangeUrl(returnUrl);
+        }
 
         const currentUrlWithoutReturn = this.#stripReturnUrl(currentPath);
 
@@ -231,9 +237,11 @@ export class Authenticator implements IAuthenticator {
 
             if (userProfile.user?.requireChangePassword) {
                 this.#updateState('waiting', 'Password change required', null);
+                const returnUrlParam = this.#router.query[RETURN_URL_KEY];
+                const returnUrl = returnUrlParam ? decodeURIComponent(returnUrlParam.toString()) : undefined;
                 return {
                     userProfile: userProfile,
-                    url: REQUIRED_PASSWORD_CHANGE_URL
+                    url: getRequiredPasswordChangeUrl(returnUrl)
                 };
             }
 
@@ -275,8 +283,9 @@ export class Authenticator implements IAuthenticator {
                 URLS.LOGOFF,
                 {},
                 { headers: { 'Authorization': `Bearer ${currentToken.accessToken}` } }
-            ).catch((error) => {
-                console.warn('Logout API call failed, but local session is cleared:', error);
+            ).catch((error: unknown) => {
+                const message = error instanceof Error ? error.message : 'Unknown error';
+                console.warn(`Logout API call failed after local session clear: ${message}`);
             });
         }
     };
@@ -343,7 +352,9 @@ export class Authenticator implements IAuthenticator {
                     if (userProfile.user.requireChangePassword) {
                         this.#startTokenExpirationTimer(token.expireOn);
                         this.#updateState('waiting', 'Password change required', null);
-                        this.#router.push(REQUIRED_PASSWORD_CHANGE_URL);
+                        const currentFullPath = this.#router.fullPath;
+                        const returnUrl = currentFullPath.startsWith('/no-auth/') ? undefined : currentFullPath;
+                        this.#router.push(getRequiredPasswordChangeUrl(returnUrl));
                         return;
                     }
 

--- a/shesha-reactjs/src/providers/auth/authenticator.ts
+++ b/shesha-reactjs/src/providers/auth/authenticator.ts
@@ -228,12 +228,19 @@ export class Authenticator implements IAuthenticator {
         try {
             // fetch user profile
             const userProfile = await this.#fetchUserInfoHttp();
-            this.#loginInfo = userProfile;
 
+            if (userProfile.user?.requireChangePassword) {
+                this.#updateState('waiting', 'Password change required', null);
+                return {
+                    userProfile: userProfile,
+                    url: REQUIRED_PASSWORD_CHANGE_URL
+                };
+            }
+
+            this.#loginInfo = userProfile;
             this.#updateState('ready', null, null);
 
             const redirectUrl = this.#getRedirectUrl(this.#router.fullPath, userProfile.user);
-
             return {
                 userProfile: userProfile,
                 url: redirectUrl ?? this.#router.fullPath
@@ -259,24 +266,19 @@ export class Authenticator implements IAuthenticator {
         // This propagates the cleared state to all components before logout API call
         this.refreshAuthHeaders();
 
-        // Now make the logout API call with the token we saved earlier
-        // We pass the token explicitly in headers since it's no longer in localStorage
-        try {
-            if (currentToken?.accessToken) {
-                await this.#httpClient.post<void, void>(
-                    URLS.LOGOFF,
-                    {},
-                    { headers: { 'Authorization': `Bearer ${currentToken.accessToken}` } }
-                );
-            }
-        } catch (error) {
-            // Ignore logout API errors - we've already cleared everything locally
-            console.warn('Logout API call failed, but local session is cleared:', error);
-        }
-
         this.#updateState('waiting', null, null);
-
         this.#redirect(this.#unauthorizedRedirectUrl);
+
+        // Fire-and-forget: best-effort server-side token invalidation
+        if (currentToken?.accessToken) {
+            this.#httpClient.post<void, void>(
+                URLS.LOGOFF,
+                {},
+                { headers: { 'Authorization': `Bearer ${currentToken.accessToken}` } }
+            ).catch((error) => {
+                console.warn('Logout API call failed, but local session is cleared:', error);
+            });
+        }
     };
 
     #timer: NodeJS.Timeout | undefined;

--- a/shesha-reactjs/src/providers/auth/authenticator.ts
+++ b/shesha-reactjs/src/providers/auth/authenticator.ts
@@ -18,6 +18,7 @@ import { ISettingsActionsContext } from "../settings/contexts";
 type RerenderTrigger = () => void;
 
 const RETURN_URL_KEY = 'returnUrl';
+const REQUIRED_PASSWORD_CHANGE_URL = '/no-auth/Shesha/change-password?mode=edit';
 
 const isAccessToken = (value: unknown): value is IAccessToken =>
     typeof value === 'object' &&
@@ -194,6 +195,9 @@ export class Authenticator implements IAuthenticator {
     };
 
     #getRedirectUrl = (currentPath: string, userLogin: UserLoginInfoDto): string => {
+        if (userLogin?.requireChangePassword)
+            return REQUIRED_PASSWORD_CHANGE_URL;
+
         const currentUrlWithoutReturn = this.#stripReturnUrl(currentPath);
 
         if (isSameUrls(currentUrlWithoutReturn, this.#unauthorizedRedirectUrl)) {
@@ -334,6 +338,12 @@ export class Authenticator implements IAuthenticator {
                 // fetch user profile
                 const userProfile = await this.#fetchUserInfoHttp();
                 if (userProfile.user) {
+                    if (userProfile.user.requireChangePassword) {
+                        this.#updateState('waiting', 'Password change required', null);
+                        this.#router.push(REQUIRED_PASSWORD_CHANGE_URL);
+                        return;
+                    }
+
                     this.#loginInfo = userProfile;
                     this.#updateState('ready', null, null);
                     this.#startTokenExpirationTimer(token.expireOn);

--- a/shesha-reactjs/src/providers/auth/authenticator.ts
+++ b/shesha-reactjs/src/providers/auth/authenticator.ts
@@ -339,6 +339,7 @@ export class Authenticator implements IAuthenticator {
                 const userProfile = await this.#fetchUserInfoHttp();
                 if (userProfile.user) {
                     if (userProfile.user.requireChangePassword) {
+                        this.#startTokenExpirationTimer(token.expireOn);
                         this.#updateState('waiting', 'Password change required', null);
                         this.#router.push(REQUIRED_PASSWORD_CHANGE_URL);
                         return;


### PR DESCRIPTION
Enforces RequireChangePassword in the frontend authenticator so users cannot bypass the change-password screen by manually editing the URL.
Clears RequireChangePassword after successful token-based password reset.
Allows authenticated users to call ChangePasswordAsync without requiring the admin Users permission.
Details

Previously, users with RequireChangePassword = true received a valid access token during login and were redirected to the change-password form only by UI logic. If they removed /no-auth/Shesha/change-password?mode=edit from the URL, the app restored the valid token and allowed normal authenticated navigation.

The authenticator now checks requireChangePassword during login redirect and session restore. If the flag is still true, the user is redirected back to the change-password form and the app is not marked as ready.

The backend password reset token flow now clears RequireChangePassword after a successful password update, matching the normal change-password behavior.

ChangePasswordAsync now overrides the class-level Users permission with AnyAuthenticated, so normal logged-in users can change their own password. The method still uses the current session user, validates the existing password, applies password policy validation, and clears RequireChangePassword.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now redirects users to a password-change page when their account requires a password update.
* **Bug Fixes / Behavior Changes**
  * Password-reset via token no longer leaves users flagged to be forced to change their password afterward.
  * Logout is now processed locally immediately for a faster sign-out experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->