### PR TITLE
fix: persist user logins on external registration

### DIFF
--- a/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
@@ -337,7 +337,9 @@ namespace Shesha.Authorization
                     true
                 );
 
-                user.Logins.Add(new UserLogin
+                var persistedUser = await _userRepository.GetAsync(user.Id);
+
+                persistedUser.Logins.Add(new UserLogin
                 {
                     LoginProvider = externalUser.Provider,
                     ProviderKey = externalUser.ProviderKey,
@@ -345,7 +347,6 @@ namespace Shesha.Authorization
                     UserId = user.Id
                 });
 
-                await _userRepository.UpdateAsync(user);
                 await uow.CompleteAsync();
 
                 return user;

--- a/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
@@ -47,7 +47,7 @@ namespace Shesha.Authorization
         private readonly UserManager<User> _userManager;
         private readonly AbpUserClaimsPrincipalFactory<User, Role> _claimsPrincipalFactory;
         private readonly IConfiguration _appConfiguration;
-        private readonly IRepository<User, long> _userRepository;
+        private readonly IRepository<UserLogin, long> _userLoginRepository;
 
         public TokenAuthController(
             LogInManager logInManager,
@@ -64,7 +64,7 @@ namespace Shesha.Authorization
             UserManager<User> userManager,
             AbpUserClaimsPrincipalFactory<User, Role> claimsPrincipalFactory,
             IConfiguration appConfiguration,
-            IRepository<User, long> userRepository)
+            IRepository<UserLogin, long> userLoginRepository)
         {
             _logInManager = logInManager;
             _tenantCache = tenantCache;
@@ -80,7 +80,7 @@ namespace Shesha.Authorization
             _userManager = userManager;
             _claimsPrincipalFactory = claimsPrincipalFactory;
             _appConfiguration = appConfiguration;
-            _userRepository = userRepository;
+            _userLoginRepository = userLoginRepository;
         }
 
         [HttpPost]
@@ -337,9 +337,7 @@ namespace Shesha.Authorization
                     true
                 );
 
-                var persistedUser = await _userRepository.GetAsync(user.Id);
-
-                persistedUser.Logins.Add(new UserLogin
+                await _userLoginRepository.InsertAsync(new UserLogin
                 {
                     LoginProvider = externalUser.Provider,
                     ProviderKey = externalUser.ProviderKey,

--- a/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
@@ -337,6 +337,8 @@ namespace Shesha.Authorization
                     true
                 );
 
+                user.Logins = new List<UserLogin>();
+
                 await _userLoginRepository.InsertAsync(new UserLogin
                 {
                     LoginProvider = externalUser.Provider,

--- a/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/TokenAuthController.cs
@@ -337,15 +337,14 @@ namespace Shesha.Authorization
                     true
                 );
 
-                user.Logins = new List<UserLogin>();
-
-                await _userLoginRepository.InsertAsync(new UserLogin
+                var userLogin = new UserLogin
                 {
                     LoginProvider = externalUser.Provider,
                     ProviderKey = externalUser.ProviderKey,
                     TenantId = user.TenantId,
                     UserId = user.Id
-                });
+                };
+                await _userLoginRepository.InsertAsync(userLogin);
 
                 await uow.CompleteAsync();
 


### PR DESCRIPTION
#4828 

Persist user logins on register external user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external login association persistence so external authentication accounts are now reliably linked during registration. This resolves cases where external sign-ins were not stored or linked correctly, improving account continuity and sign-in reliability for users who register via third-party providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->