### PR TITLE
Hotfix/4774/dynamic linq sort navigation traversal

### DIFF
--- a/shesha-core/src/Shesha.Application/AbpCrudAppService.cs
+++ b/shesha-core/src/Shesha.Application/AbpCrudAppService.cs
@@ -5,8 +5,8 @@ using Abp.Domain.Repositories;
 using Abp.Extensions;
 using Abp.Linq.Extensions;
 using Abp.ObjectMapping;
+using Shesha.Extensions;
 using System.Linq;
-using System.Linq.Dynamic.Core;
 
 namespace Shesha
 {
@@ -50,6 +50,7 @@ namespace Shesha
             {
                 if (!sortInput.Sorting.IsNullOrWhiteSpace())
                 {
+                    SortingValidator.EnsureSortingAllowed(typeof(TEntity), sortInput.Sorting);
                     return query.OrderBy(sortInput.Sorting);
                 }
             }

--- a/shesha-core/src/Shesha.Application/AbpCrudAppService.cs
+++ b/shesha-core/src/Shesha.Application/AbpCrudAppService.cs
@@ -6,7 +6,10 @@ using Abp.Extensions;
 using Abp.Linq.Extensions;
 using Abp.ObjectMapping;
 using Shesha.Extensions;
+using Shesha.Utilities;
+using System;
 using System.Linq;
+using System.Linq.Dynamic.Core;
 
 namespace Shesha
 {
@@ -51,7 +54,34 @@ namespace Shesha
                 if (!sortInput.Sorting.IsNullOrWhiteSpace())
                 {
                     SortingValidator.EnsureSortingAllowed(typeof(TEntity), sortInput.Sorting);
-                    return query.OrderBy(sortInput.Sorting);
+
+                    var sorted = false;
+                    foreach (var sortColumn in sortInput.Sorting.Split(','))
+                    {
+                        var trimmed = sortColumn.Trim();
+                        if (string.IsNullOrEmpty(trimmed))
+                            continue;
+
+                        var column = trimmed.LeftPart(' ', ProcessDirection.LeftToRight);
+                        if (string.IsNullOrEmpty(column))
+                            continue;
+
+                        var descending = trimmed.RightPart(' ', ProcessDirection.LeftToRight)?.Trim()
+                            .Equals("desc", StringComparison.InvariantCultureIgnoreCase) == true;
+
+                        if (sorted)
+                        {
+                            var orderedQuery = (IOrderedQueryable<TEntity>)query;
+                            query = descending ? orderedQuery.ThenByDescending(column) : orderedQuery.ThenBy(column);
+                        }
+                        else
+                        {
+                            query = descending ? query.OrderByDescending(column) : query.OrderBy(column);
+                            sorted = true;
+                        }
+                    }
+
+                    return query;
                 }
             }
 

--- a/shesha-core/src/Shesha.Core/Domain/Person.cs
+++ b/shesha-core/src/Shesha.Core/Domain/Person.cs
@@ -6,12 +6,12 @@ using Abp.Auditing;
 using Abp.Localization;
 using Abp.Timing;
 using JetBrains.Annotations;
+using Newtonsoft.Json;
 using Shesha.Authorization.Users;
 using Shesha.Domain.Attributes;
 using Shesha.Domain.Enums;
 using Shesha.DynamicEntities;
 using Shesha.EntityHistory;
-using Shesha.Extensions;
 
 namespace Shesha.Domain
 {
@@ -114,6 +114,7 @@ namespace Shesha.Domain
         /// User record, may be null for non registered users
         /// </summary>
         [CanBeNull]
+        [JsonIgnore]
         [CascadeUpdateRules(false, true)]
         public virtual User User { get; set; }
 

--- a/shesha-core/src/Shesha.Core/Domain/Person.cs
+++ b/shesha-core/src/Shesha.Core/Domain/Person.cs
@@ -114,7 +114,6 @@ namespace Shesha.Domain
         /// User record, may be null for non registered users
         /// </summary>
         [CanBeNull]
-        [JsonIgnore]
         [CascadeUpdateRules(false, true)]
         public virtual User User { get; set; }
 

--- a/shesha-core/src/Shesha.Framework/Authorization/Users/User.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/Users/User.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Abp.Authorization.Users;
 using Abp.Extensions;
+using Newtonsoft.Json;
 using Shesha.Domain.Attributes;
 using Shesha.Domain.Enums;
 using Shesha.EntityHistory;
@@ -23,6 +24,34 @@ namespace Shesha.Authorization.Users
         }
 
         public virtual DateTime? LastLoginDate { get; set; }
+
+        /// <summary>
+        /// Password hash. Marked [JsonIgnore] so it cannot be exposed via
+        /// metadata, GraphQL, or used as a sort key — see issue #4774.
+        /// </summary>
+        [JsonIgnore]
+        public override string Password { get; set; }
+
+        /// <summary>
+        /// Password reset code. Marked [JsonIgnore] so it cannot be exposed via
+        /// metadata, GraphQL, or used as a sort key — see issue #4774.
+        /// </summary>
+        [JsonIgnore]
+        public override string PasswordResetCode { get; set; }
+
+        /// <summary>
+        /// Security stamp used for token/session invalidation. Marked [JsonIgnore]
+        /// so it cannot be exposed via metadata, GraphQL, or used as a sort key.
+        /// </summary>
+        [JsonIgnore]
+        public override string SecurityStamp { get; set; }
+
+        /// <summary>
+        /// Concurrency stamp. Marked [JsonIgnore] so it cannot be exposed via
+        /// metadata, GraphQL, or used as a sort key.
+        /// </summary>
+        [JsonIgnore]
+        public override string ConcurrencyStamp { get; set; }
 
         public static string CreateRandomPassword()
         {

--- a/shesha-core/src/Shesha.Framework/Extensions/SortingValidator.cs
+++ b/shesha-core/src/Shesha.Framework/Extensions/SortingValidator.cs
@@ -1,0 +1,70 @@
+using Shesha.Reflection;
+using Shesha.Utilities;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Shesha.Extensions
+{
+    /// <summary>
+    /// Validates user-supplied sort strings before they are passed to LINQ
+    /// OrderBy / ThenBy. Sort strings follow the dynamic LINQ format
+    /// "Property1 [asc|desc][, Property2 [asc|desc] ...]" and may use dot
+    /// notation to traverse navigation properties.
+    /// </summary>
+    public static class SortingValidator
+    {
+        /// <summary>
+        /// Throws if any segment of any column in <paramref name="sorting"/> targets
+        /// a property marked with [JsonIgnore] (Newtonsoft or System.Text.Json).
+        /// Without this check, dynamic LINQ sorting can traverse navigation
+        /// properties to leak ordering information about sensitive fields
+        /// (e.g. password hashes) — see issue #4774.
+        /// </summary>
+        public static void EnsureSortingAllowed(Type entityType, string sorting)
+        {
+            if (string.IsNullOrWhiteSpace(sorting) || entityType == null)
+                return;
+
+            foreach (var sortColumn in sorting.Split(','))
+            {
+                var trimmed = sortColumn.Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                    continue;
+
+                var path = trimmed.LeftPart(' ', ProcessDirection.LeftToRight);
+                if (string.IsNullOrEmpty(path))
+                    continue;
+
+                EnsurePathAllowed(entityType, path);
+            }
+        }
+
+        private static void EnsurePathAllowed(Type rootType, string propertyPath)
+        {
+            var currentType = rootType;
+            foreach (var segment in propertyPath.Split('.'))
+            {
+                if (currentType == null || string.IsNullOrEmpty(segment))
+                    return;
+
+                var prop = currentType
+                    .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .FirstOrDefault(p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
+
+                if (prop == null)
+                    return;
+
+                if (prop.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
+                    || prop.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
+                {
+                    throw new ArgumentException(
+                        $"Sorting by '{propertyPath}' is not allowed: property '{prop.Name}' is not sortable.",
+                        nameof(propertyPath));
+                }
+
+                currentType = prop.PropertyType;
+            }
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/Extensions/SortingValidator.cs
+++ b/shesha-core/src/Shesha.Framework/Extensions/SortingValidator.cs
@@ -55,8 +55,7 @@ namespace Shesha.Extensions
                 if (prop == null)
                     return;
 
-                if (prop.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
-                    || prop.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
+                if (prop.IsJsonIgnored())
                 {
                     throw new ArgumentException(
                         $"Sorting by '{propertyPath}' is not allowed: property '{prop.Name}' is not sortable.",

--- a/shesha-core/src/Shesha.Framework/Metadata/HardcodeMetadataProvider.cs
+++ b/shesha-core/src/Shesha.Framework/Metadata/HardcodeMetadataProvider.cs
@@ -44,7 +44,11 @@ namespace Shesha.Metadata
 
             var flags = BindingFlags.Public | BindingFlags.Instance;
 
-            var allProps = containerType.GetPropertiesWithoutHidden(flags).OrderBy(p => p.Name).ToList();
+            var allProps = containerType.GetPropertiesWithoutHidden(flags)
+                .Where(p => !p.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
+                        && !p.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
+                .OrderBy(p => p.Name)
+                .ToList();
             if (containerType.IsEntityType())
                 allProps = allProps.Where(p => MappingHelper.IsPersistentProperty(p) || p.CanRead && p.HasAttribute<NotMappedAttribute>()).ToList();
 

--- a/shesha-core/src/Shesha.Framework/Metadata/HardcodeMetadataProvider.cs
+++ b/shesha-core/src/Shesha.Framework/Metadata/HardcodeMetadataProvider.cs
@@ -45,8 +45,7 @@ namespace Shesha.Metadata
             var flags = BindingFlags.Public | BindingFlags.Instance;
 
             var allProps = containerType.GetPropertiesWithoutHidden(flags)
-                .Where(p => !p.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
-                        && !p.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
+                .Where(p => !p.IsJsonIgnored())
                 .OrderBy(p => p.Name)
                 .ToList();
             if (containerType.IsEntityType())

--- a/shesha-core/src/Shesha.Framework/Reflection/ReflectionHelper.cs
+++ b/shesha-core/src/Shesha.Framework/Reflection/ReflectionHelper.cs
@@ -1,5 +1,4 @@
-﻿using Abp.Dependency;
-using Abp.Domain.Entities;
+﻿using Abp.Domain.Entities;
 using Abp.Reflection;
 using Shesha.Attributes;
 using Shesha.Domain;
@@ -74,6 +73,24 @@ namespace Shesha.Reflection
         public static bool HasAttribute<T>(this MemberInfo memberInfo, bool inherit = false) where T : Attribute
         {
             return memberInfo.GetAttribute<T>() != null;
+        }
+
+        /// <summary>
+        /// Returns true if the specified <paramref name="memberInfo"/> is marked with a JsonIgnore attribute
+        /// that causes the property to be unconditionally omitted from JSON serialization. Matches
+        /// Newtonsoft's <see cref="Newtonsoft.Json.JsonIgnoreAttribute"/> (always ignores) and
+        /// <see cref="System.Text.Json.Serialization.JsonIgnoreAttribute"/> with
+        /// <see cref="System.Text.Json.Serialization.JsonIgnoreCondition.Always"/> (the default).
+        /// Conditional STJ variants (<c>Never</c>, <c>WhenWritingNull</c>, <c>WhenWritingDefault</c>) do not count.
+        /// </summary>
+        public static bool IsJsonIgnored(this MemberInfo memberInfo)
+        {
+            if (memberInfo.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>())
+                return true;
+
+            var stjIgnore = memberInfo.GetAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>();
+            return stjIgnore != null
+                && stjIgnore.Condition == System.Text.Json.Serialization.JsonIgnoreCondition.Always;
         }
 
         // todo: added unique check

--- a/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLGenericType.cs
+++ b/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLGenericType.cs
@@ -51,6 +51,8 @@ namespace Shesha.GraphQL.Provider.GraphTypes
 
             var properties = genericType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.PropertyType != typeof(Type))
+                .Where(p => !p.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
+                        && !p.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
                 .ToList();
             foreach (var property in properties) 
             {

--- a/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLGenericType.cs
+++ b/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLGenericType.cs
@@ -51,8 +51,7 @@ namespace Shesha.GraphQL.Provider.GraphTypes
 
             var properties = genericType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.PropertyType != typeof(Type))
-                .Where(p => !p.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
-                        && !p.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
+                .Where(p => !p.IsJsonIgnored())
                 .ToList();
             foreach (var property in properties) 
             {

--- a/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLInputGenericType.cs
+++ b/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLInputGenericType.cs
@@ -1,6 +1,7 @@
 ﻿using GraphQL;
 using GraphQL.Types;
 using Shesha.GraphQL.Provider.AstValueNodes;
+using Shesha.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,6 +39,8 @@ namespace Shesha.GraphQL.Provider.GraphTypes
             }
 
             targetType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => !p.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
+                        && !p.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
                 .ToList()
                 .ForEach(pi =>
                 {

--- a/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLInputGenericType.cs
+++ b/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/GraphTypes/GraphQLInputGenericType.cs
@@ -39,8 +39,7 @@ namespace Shesha.GraphQL.Provider.GraphTypes
             }
 
             targetType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(p => !p.HasAttribute<Newtonsoft.Json.JsonIgnoreAttribute>()
-                        && !p.HasAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>())
+                .Where(p => !p.IsJsonIgnored())
                 .ToList()
                 .ForEach(pi =>
                 {

--- a/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/Queries/EntityQuery.cs
+++ b/shesha-core/src/Shesha.GraphQL/GraphQL/Provider/Queries/EntityQuery.cs
@@ -340,6 +340,8 @@ where
             if (string.IsNullOrWhiteSpace(sorting))
                 return query;
 
+            SortingValidator.EnsureSortingAllowed(typeof(TEntity), sorting);
+
             var sortColumns = sorting.Split(',').Select(c => c.Trim()).Where(c => !string.IsNullOrWhiteSpace(c)).ToList();
             var sorted = false;
             foreach (var sortColumn in sortColumns)

--- a/shesha-core/test/Shesha.Tests/Extensions/SortingValidatorTests.cs
+++ b/shesha-core/test/Shesha.Tests/Extensions/SortingValidatorTests.cs
@@ -1,0 +1,122 @@
+using Shesha.Extensions;
+using System;
+using Xunit;
+using NewtonsoftJsonIgnore = Newtonsoft.Json.JsonIgnoreAttribute;
+using StjJsonIgnore = System.Text.Json.Serialization.JsonIgnoreAttribute;
+using StjJsonIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition;
+
+namespace Shesha.Tests.Extensions
+{
+    public class SortingValidatorTests
+    {
+        private class Address
+        {
+            public string City { get; set; }
+
+            [NewtonsoftJsonIgnore]
+            public string SecretNote { get; set; }
+        }
+
+        private class TestEntity
+        {
+            public string Name { get; set; }
+
+            public int Age { get; set; }
+
+            public Address PrimaryAddress { get; set; }
+
+            [NewtonsoftJsonIgnore]
+            public string PasswordHash { get; set; }
+
+            [StjJsonIgnore]
+            public string ApiKey { get; set; }
+
+            [StjJsonIgnore(Condition = StjJsonIgnoreCondition.Always)]
+            public string AlwaysIgnored { get; set; }
+
+            [StjJsonIgnore(Condition = StjJsonIgnoreCondition.Never)]
+            public string NeverIgnored { get; set; }
+
+            [StjJsonIgnore(Condition = StjJsonIgnoreCondition.WhenWritingNull)]
+            public string SometimesIgnored { get; set; }
+
+            [NewtonsoftJsonIgnore]
+            public Address SensitiveAddress { get; set; }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void EnsureSortingAllowed_NullOrWhitespace_DoesNotThrow(string sorting)
+        {
+            SortingValidator.EnsureSortingAllowed(typeof(TestEntity), sorting);
+        }
+
+        [Fact]
+        public void EnsureSortingAllowed_NullEntityType_DoesNotThrow()
+        {
+            SortingValidator.EnsureSortingAllowed(null, "Name asc");
+        }
+
+        [Theory]
+        [InlineData("Name")]
+        [InlineData("Name asc")]
+        [InlineData("Name desc")]
+        [InlineData("name")]
+        [InlineData("NAME ASC")]
+        [InlineData("Age desc")]
+        [InlineData("PrimaryAddress.City asc")]
+        [InlineData("Name asc, Age desc")]
+        [InlineData("Name, Age, PrimaryAddress.City desc")]
+        public void EnsureSortingAllowed_AllowedProperties_DoesNotThrow(string sorting)
+        {
+            SortingValidator.EnsureSortingAllowed(typeof(TestEntity), sorting);
+        }
+
+        [Theory]
+        [InlineData("PasswordHash")]
+        [InlineData("PasswordHash asc")]
+        [InlineData("passwordhash desc")]
+        [InlineData("ApiKey")]
+        [InlineData("AlwaysIgnored")]
+        public void EnsureSortingAllowed_DirectIgnoredProperty_Throws(string sorting)
+        {
+            Assert.Throws<ArgumentException>(
+                () => SortingValidator.EnsureSortingAllowed(typeof(TestEntity), sorting));
+        }
+
+        [Theory]
+        [InlineData("SensitiveAddress.City")]
+        [InlineData("SensitiveAddress.City asc")]
+        [InlineData("PrimaryAddress.SecretNote")]
+        [InlineData("PrimaryAddress.SecretNote desc")]
+        public void EnsureSortingAllowed_DotPathTraversesIgnoredProperty_Throws(string sorting)
+        {
+            Assert.Throws<ArgumentException>(
+                () => SortingValidator.EnsureSortingAllowed(typeof(TestEntity), sorting));
+        }
+
+        [Fact]
+        public void EnsureSortingAllowed_MultiColumnWithOneIgnored_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => SortingValidator.EnsureSortingAllowed(typeof(TestEntity), "Name asc, PasswordHash desc"));
+        }
+
+        [Theory]
+        [InlineData("NeverIgnored")]
+        [InlineData("NeverIgnored asc")]
+        [InlineData("SometimesIgnored desc")]
+        public void EnsureSortingAllowed_StjConditionalIgnore_DoesNotThrow(string sorting)
+        {
+            SortingValidator.EnsureSortingAllowed(typeof(TestEntity), sorting);
+        }
+
+        [Fact]
+        public void EnsureSortingAllowed_UnknownProperty_DoesNotThrow()
+        {
+            SortingValidator.EnsureSortingAllowed(typeof(TestEntity), "DoesNotExist asc");
+        }
+    }
+}

--- a/shesha-core/test/Shesha.Tests/GraphQL/JsonIgnoreFiltering_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/GraphQL/JsonIgnoreFiltering_Tests.cs
@@ -1,0 +1,61 @@
+using Abp.Domain.Uow;
+using NSubstitute;
+using Shesha.DynamicEntities;
+using Shesha.DynamicEntities.Cache;
+using Shesha.GraphQL.Provider.GraphTypes;
+using Xunit;
+
+namespace Shesha.Tests.GraphQL
+{
+    /// <summary>
+    /// Tests for issue #4774: properties decorated with [JsonIgnore]
+    /// (Newtonsoft or System.Text.Json) must not be exposed as GraphQL fields,
+    /// otherwise sensitive data (e.g. password hashes) can leak through the
+    /// GraphQL endpoint.
+    /// </summary>
+    public class JsonIgnoreFiltering_Tests
+    {
+        public class SampleModel
+        {
+            public virtual string Name { get; set; }
+            public virtual string Visible { get; set; }
+
+            [Newtonsoft.Json.JsonIgnore]
+            public virtual string SecretNewtonsoft { get; set; }
+
+            [System.Text.Json.Serialization.JsonIgnore]
+            public virtual string SecretSystemTextJson { get; set; }
+        }
+
+        [Fact]
+        public void GraphQLGenericType_ShouldExclude_JsonIgnoreProperties()
+        {
+            var dynamicPropertyManager = Substitute.For<IDynamicPropertyManager>();
+            var entityConfigCache = Substitute.For<IEntityConfigCache>();
+            var dynamicDtoTypeBuilder = Substitute.For<IDynamicDtoTypeBuilder>();
+            var unitOfWorkManager = Substitute.For<IUnitOfWorkManager>();
+
+            var graphType = new GraphQLGenericType<SampleModel>(
+                dynamicPropertyManager,
+                entityConfigCache,
+                dynamicDtoTypeBuilder,
+                unitOfWorkManager);
+
+            Assert.True(graphType.HasField(nameof(SampleModel.Name)));
+            Assert.True(graphType.HasField(nameof(SampleModel.Visible)));
+            Assert.False(graphType.HasField(nameof(SampleModel.SecretNewtonsoft)));
+            Assert.False(graphType.HasField(nameof(SampleModel.SecretSystemTextJson)));
+        }
+
+        [Fact]
+        public void GraphQLInputGenericType_ShouldExclude_JsonIgnoreProperties()
+        {
+            var inputType = new GraphQLInputGenericType<SampleModel>();
+
+            Assert.True(inputType.HasField(nameof(SampleModel.Name)));
+            Assert.True(inputType.HasField(nameof(SampleModel.Visible)));
+            Assert.False(inputType.HasField(nameof(SampleModel.SecretNewtonsoft)));
+            Assert.False(inputType.HasField(nameof(SampleModel.SecretSystemTextJson)));
+        }
+    }
+}

--- a/shesha-core/test/Shesha.Tests/Metadata/EntityWithJsonIgnoreProps.cs
+++ b/shesha-core/test/Shesha.Tests/Metadata/EntityWithJsonIgnoreProps.cs
@@ -1,0 +1,28 @@
+using Abp.Domain.Entities;
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Shesha.Tests.Metadata
+{
+    /// <summary>
+    /// Test entity used to verify that properties decorated with [JsonIgnore]
+    /// (Newtonsoft or System.Text.Json) are excluded from generated metadata,
+    /// preventing them from being usable in dynamic LINQ sorting / property
+    /// projection on Dynamic CRUD and GraphQL endpoints (issue #4774).
+    /// </summary>
+    public class EntityWithJsonIgnoreProps : Entity<Guid>
+    {
+        public virtual string Name { get; set; }
+
+        [NotMapped]
+        public virtual string Visible { get; set; }
+
+        [NotMapped]
+        [Newtonsoft.Json.JsonIgnore]
+        public virtual string SecretNewtonsoft { get; set; }
+
+        [NotMapped]
+        [System.Text.Json.Serialization.JsonIgnore]
+        public virtual string SecretSystemTextJson { get; set; }
+    }
+}

--- a/shesha-core/test/Shesha.Tests/Metadata/HardcodeMetadataProvider_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Metadata/HardcodeMetadataProvider_Tests.cs
@@ -1,0 +1,35 @@
+using NSubstitute;
+using Shesha.Configuration.Runtime;
+using Shesha.Metadata;
+using System.Linq;
+using Xunit;
+
+namespace Shesha.Tests.Metadata
+{
+    /// <summary>
+    /// Unit tests for <see cref="HardcodeMetadataProvider"/>. Constructs the
+    /// provider directly with a mocked <see cref="IEntityConfigurationStore"/>
+    /// so the test does not require the full ABP/NHibernate harness.
+    /// </summary>
+    public class HardcodeMetadataProvider_Tests
+    {
+        // Issue #4774: properties decorated with [JsonIgnore] (Newtonsoft or
+        // System.Text.Json) must not appear in generated metadata, otherwise
+        // they remain reachable via dynamic LINQ sorting / property projection
+        // on Dynamic CRUD endpoints.
+        [Fact]
+        public void GetProperties_ShouldExclude_JsonIgnoreProperties()
+        {
+            var entityConfigurationStore = Substitute.For<IEntityConfigurationStore>();
+            var provider = new HardcodeMetadataProvider(entityConfigurationStore);
+
+            var properties = provider.GetProperties(typeof(EntityWithJsonIgnoreProps));
+            var paths = properties.Select(p => p.Path).ToList();
+
+            Assert.Contains(nameof(EntityWithJsonIgnoreProps.Name), paths);
+            Assert.Contains(nameof(EntityWithJsonIgnoreProps.Visible), paths);
+            Assert.DoesNotContain(nameof(EntityWithJsonIgnoreProps.SecretNewtonsoft), paths);
+            Assert.DoesNotContain(nameof(EntityWithJsonIgnoreProps.SecretSystemTextJson), paths);
+        }
+    }
+}

--- a/shesha-core/test/Shesha.Tests/Security/SortingValidator_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Security/SortingValidator_Tests.cs
@@ -1,0 +1,84 @@
+using Shesha.Extensions;
+using System;
+using Xunit;
+
+namespace Shesha.Tests.Security
+{
+    /// <summary>
+    /// Issue #4774: dynamic LINQ sorting must not allow ordering by properties
+    /// marked with [JsonIgnore], otherwise an authenticated user can observe
+    /// the ordering of sensitive fields (e.g. password hashes) reachable via
+    /// navigation properties — the JsonIgnore filter on metadata/GraphQL types
+    /// alone does not cover the sort path.
+    /// </summary>
+    public class SortingValidator_Tests
+    {
+        public class SampleNested
+        {
+            public virtual string Visible { get; set; }
+
+            [Newtonsoft.Json.JsonIgnore]
+            public virtual string SecretNewtonsoft { get; set; }
+
+            [System.Text.Json.Serialization.JsonIgnore]
+            public virtual string SecretSystemTextJson { get; set; }
+        }
+
+        public class SampleEntity
+        {
+            public virtual string Name { get; set; }
+            public virtual SampleNested Child { get; set; }
+
+            [Newtonsoft.Json.JsonIgnore]
+            public virtual SampleNested Hidden { get; set; }
+        }
+
+        [Theory]
+        [InlineData("Name")]
+        [InlineData("Name asc")]
+        [InlineData("Name desc")]
+        [InlineData("Name asc, Child.Visible desc")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void EnsureSortingAllowed_AllowsVisibleProperties(string sorting)
+        {
+            SortingValidator.EnsureSortingAllowed(typeof(SampleEntity), sorting);
+        }
+
+        [Theory]
+        [InlineData("Hidden")]
+        [InlineData("Hidden desc")]
+        [InlineData("Hidden.Visible")]
+        [InlineData("Name asc, Hidden desc")]
+        public void EnsureSortingAllowed_RejectsJsonIgnoreNavigation(string sorting)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                SortingValidator.EnsureSortingAllowed(typeof(SampleEntity), sorting));
+        }
+
+        [Theory]
+        [InlineData("Child.SecretNewtonsoft")]
+        [InlineData("Child.SecretSystemTextJson")]
+        [InlineData("Child.SecretNewtonsoft desc")]
+        public void EnsureSortingAllowed_RejectsJsonIgnoreLeaf(string sorting)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                SortingValidator.EnsureSortingAllowed(typeof(SampleEntity), sorting));
+        }
+
+        [Fact]
+        public void EnsureSortingAllowed_IsCaseInsensitive()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                SortingValidator.EnsureSortingAllowed(typeof(SampleEntity), "hidden"));
+        }
+
+        [Fact]
+        public void EnsureSortingAllowed_IgnoresUnknownProperties()
+        {
+            // Unknown segments are left for the actual OrderBy call to surface
+            // a clearer error — the validator only blocks known-but-hidden fields.
+            SortingValidator.EnsureSortingAllowed(typeof(SampleEntity), "DoesNotExist");
+        }
+    }
+}


### PR DESCRIPTION
- Closes #4774. 
- Hardens the Dynamic CRUD and GraphQL endpoints against a navigation-property traversal leak in dynamic LINQ sorting and property projection (e.g. an authenticated user could request ?properties=user.password or ?sorting=user.password desc to observe ordering of password hashes, security stamps, or reset codes through any entity that exposes a navigation to User).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds validation of user-supplied sorting expressions to allow only permitted properties.
  * Fields marked to be excluded from JSON are now consistently omitted from GraphQL inputs/outputs and metadata.

* **Bug Fixes**
  * Prevents sorting by restricted or sensitive properties.
  * Sensitive credential/session fields are now excluded from serialization to avoid accidental exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->