### PR TITLE
fix: fixed style of multiline messages on log viewer (resolves #4863)

### DIFF
--- a/shesha-reactjs/src/components/logViewer/styles.ts
+++ b/shesha-reactjs/src/components/logViewer/styles.ts
@@ -478,6 +478,7 @@ export const useStyles = createStyles(({ token, css }) => {
       overflow: hidden;
       text-overflow: ellipsis;
       padding-right: ${token.padding}px;
+      max-height: 100%;
     `,
 
     taskName: css`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated log message styling to apply maximum height constraint, improving the log viewer's visual layout and preventing content overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->