### PR TITLE
Respect default editors when generating forms from templates 

### DIFF
--- a/shesha-reactjs/src/form-factory/implementation.ts
+++ b/shesha-reactjs/src/form-factory/implementation.ts
@@ -44,7 +44,7 @@ import { ITextAreaComponentProps } from "@/designer-components/textArea/interfac
 import { ITextFieldComponentProps } from "@/designer-components/textField/interfaces";
 import { ITimePickerComponentProps } from "@/designer-components/timeField/models";
 import { DEFAULT_FORM_SETTINGS, IConfigurableFormComponent, IContainerComponentProps, IPropertyMetadata, IToolboxComponent } from "@/interfaces";
-import { ComponentTypes, FluentSettings, FormBuilder, FormBuilderFactory, StandardAppearancePanel, StandardEventHandler } from "./interfaces";
+import { FluentSettings, FormBuilder, FormBuilderFactory, StandardAppearancePanel, StandardEventHandler } from "./interfaces";
 import { nanoid } from "@/utils/uuid";
 import { linkComponentToModelMetadata, upgradeComponent } from "@/providers/form/utils";
 import { getComponentDefinitions } from "@/providers/form/defaults/toolboxComponents";
@@ -88,9 +88,6 @@ const eventConfigs: EventConfig[] = [
 
 
 export class FormBuilderImplementation implements FormBuilder {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: `add${Capitalize<string>}`]: (...args: any[]) => FormBuilder;
-
   addKeyInformationBar = (props: FluentSettings<IKeyInformationBarComponentProps>, meta?: IPropertyMetadata): FormBuilder => this._addProperty(props, 'KeyInformationBar', meta);
 
   addEditModeSelector = (props: FluentSettings<IConfigurableFormComponent>, meta?: IPropertyMetadata): FormBuilder => this._addProperty(props, 'editModeSelector', meta);
@@ -485,7 +482,7 @@ export class FormBuilderImplementation implements FormBuilder {
     this.rootId = rootId ?? nanoid();
   }
 
-  private _addProperty(props: FluentSettings<IConfigurableFormComponent>, type: ComponentTypes, meta?: IPropertyMetadata): FormBuilder {
+  private _addProperty(props: FluentSettings<IConfigurableFormComponent>, type: string, meta?: IPropertyMetadata): FormBuilder {
     const { id, hidden, visible, visibleJs, version, parentId, ...restProps } = props;
 
     const componentDefinition = this.getComponentDefinition(type);
@@ -530,7 +527,7 @@ export class FormBuilderImplementation implements FormBuilder {
   }
 
   addByType = <TProps extends FluentSettings<IConfigurableFormComponent>>(type: string, props: TProps, meta?: IPropertyMetadata): FormBuilder => {
-    return this._addProperty(props, type as ComponentTypes, meta);
+    return this._addProperty(props, type, meta);
   };
 
   toJson(): IConfigurableFormComponent[] {

--- a/shesha-reactjs/src/form-factory/implementation.ts
+++ b/shesha-reactjs/src/form-factory/implementation.ts
@@ -529,6 +529,10 @@ export class FormBuilderImplementation implements FormBuilder {
     return this;
   }
 
+  addByType = (type: string, props: FluentSettings<IConfigurableFormComponent>, meta?: IPropertyMetadata): FormBuilder => {
+    return this._addProperty(props, type as ComponentTypes, meta);
+  };
+
   toJson(): IConfigurableFormComponent[] {
     return this.form;
   }

--- a/shesha-reactjs/src/form-factory/implementation.ts
+++ b/shesha-reactjs/src/form-factory/implementation.ts
@@ -89,7 +89,7 @@ const eventConfigs: EventConfig[] = [
 
 export class FormBuilderImplementation implements FormBuilder {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: `add${Capitalize<string>}`]: (props: any, metadata?: IPropertyMetadata) => FormBuilder;
+  [key: `add${Capitalize<string>}`]: (...args: any[]) => FormBuilder;
 
   addKeyInformationBar = (props: FluentSettings<IKeyInformationBarComponentProps>, meta?: IPropertyMetadata): FormBuilder => this._addProperty(props, 'KeyInformationBar', meta);
 
@@ -529,7 +529,7 @@ export class FormBuilderImplementation implements FormBuilder {
     return this;
   }
 
-  addByType = (type: string, props: FluentSettings<IConfigurableFormComponent>, meta?: IPropertyMetadata): FormBuilder => {
+  addByType = <TProps extends FluentSettings<IConfigurableFormComponent>>(type: string, props: TProps, meta?: IPropertyMetadata): FormBuilder => {
     return this._addProperty(props, type as ComponentTypes, meta);
   };
 

--- a/shesha-reactjs/src/form-factory/interfaces.ts
+++ b/shesha-reactjs/src/form-factory/interfaces.ts
@@ -156,6 +156,11 @@ export type FluentFormBuilder<
   // build actions
   build(): string;
   toJson(): IConfigurableFormComponent[];
+  /**
+   * Add a component by its toolbox type string. Use when the type is known dynamically (e.g. from `IPropertyMetadata.formatting.defaultEditor`).
+   * Falls back gracefully when the type isn't a registered toolbox component.
+   */
+  addByType(type: string, props: FluentSettings<IConfigurableFormComponent>, metadata?: IPropertyMetadata): FluentFormBuilder<TConfig>;
 } & {
   // standart components and component groups
   stdPrefixSuffixInputs(visibleJs?: string | undefined): FluentFormBuilder<TConfig>;

--- a/shesha-reactjs/src/form-factory/interfaces.ts
+++ b/shesha-reactjs/src/form-factory/interfaces.ts
@@ -160,7 +160,7 @@ export type FluentFormBuilder<
    * Add a component by its toolbox type string. Use when the type is known dynamically (e.g. from `IPropertyMetadata.formatting.defaultEditor`).
    * Falls back gracefully when the type isn't a registered toolbox component.
    */
-  addByType(type: string, props: FluentSettings<IConfigurableFormComponent>, metadata?: IPropertyMetadata): FluentFormBuilder<TConfig>;
+  addByType<TProps extends FluentSettings<IConfigurableFormComponent>>(type: string, props: TProps, metadata?: IPropertyMetadata): FluentFormBuilder<TConfig>;
 } & {
   // standart components and component groups
   stdPrefixSuffixInputs(visibleJs?: string | undefined): FluentFormBuilder<TConfig>;

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/details-view/detailsViewGenerationLogic.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/details-view/detailsViewGenerationLogic.ts
@@ -4,7 +4,7 @@ import { nanoid } from "@/utils/uuid";
 import { toCamelCase } from "@/utils/string";
 import { FormMetadataHelper } from "../formMetadataHelper";
 import { IConfigurableColumnsProps, standardCellComponentTypes } from "@/providers/datatableColumnsConfigurator/models";
-import { findContainersWithPlaceholder, castToExtensionType, humanizeModelType, addDetailsPanel, getDataTypePriority, getColumnWidthByDataType } from "../viewGenerationUtils";
+import { findContainersWithPlaceholder, findComponentsWithPlaceholder, castToExtensionType, humanizeModelType, addDetailsPanel, getDataTypePriority, getColumnWidthByDataType } from "../viewGenerationUtils";
 import { DetailsViewExtensionJson } from "../../models/DetailsViewExtensionJson";
 import { ROW_COUNT } from "../../constants";
 import { BaseGenerationLogic } from "../baseGenerationLogic";
@@ -97,14 +97,13 @@ export class DetailsViewGenerationLogic extends BaseGenerationLogic {
       ? `{{${toCamelCase(displayNameProperty)}}}`
       : `${entity.typeAccessor} Details`;
 
-    const titleContainer = findContainersWithPlaceholder(markup, "//*TITLE*//");
+    const titleComponents = findComponentsWithPlaceholder(markup, "//*TITLE*//");
 
-    if (titleContainer.length === 0) {
+    if (titleComponents.length === 0) {
       throw new Error("No title container found in the markup.");
     }
 
-    // text
-    const titleComponent = titleContainer[0];
+    const titleComponent = titleComponents[0];
     if (isConfigurableFormComponent(titleComponent) && isTextComponent(titleComponent))
       titleComponent.content = title;
 

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/details-view/detailsViewGenerationLogic.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/details-view/detailsViewGenerationLogic.ts
@@ -100,7 +100,7 @@ export class DetailsViewGenerationLogic extends BaseGenerationLogic {
     const titleComponents = findComponentsWithPlaceholder(markup, "//*TITLE*//");
 
     if (titleComponents.length === 0) {
-      throw new Error("No title container found in the markup.");
+      throw new Error("No title component found in the markup.");
     }
 
     const titleComponent = titleComponents[0];

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/formMetadataHelper.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/formMetadataHelper.ts
@@ -142,80 +142,93 @@ export class FormMetadataHelper {
       hideBorder: isReadOnly,
     };
 
-    switch (property.dataType) {
-      case DataTypes.string:
-        if (property.dataFormat === 'multiline') {
-          builder.addTextArea(styledProps, property);
-        } else {
-          builder.addTextField(styledProps, property);
-        }
-        break;
+    const defaultEditor = property.formatting?.defaultEditor;
+    const pickType = (fallback: string): string =>
+      isDefined(defaultEditor) && defaultEditor !== '' ? defaultEditor : fallback;
 
-      case DataTypes.number:
-        builder.addNumberField(styledProps, property);
-        break;
+    try {
+      switch (property.dataType) {
+        case DataTypes.string:
+          if (property.dataFormat === 'multiline') {
+            builder.addByType(pickType('textArea'), styledProps, property);
+          } else {
+            builder.addByType(pickType('textField'), styledProps, property);
+          }
+          break;
 
-      case DataTypes.entityReference:
-        if (!property.entityType) {
-          throw new Error(`Entity type is required for entityReference type. Property: ${property.path}`);
-        }
-        builder.addAutocomplete({
-          ...commonProps,
-          entityType: property.entityType
-            ? { name: property.entityType, module: property.entityModule } as IEntityTypeIdentifier
-            : undefined,
-          dataSourceType: 'entitiesList',
-        }, property);
-        break;
+        case DataTypes.number:
+          builder.addByType(pickType('numberField'), styledProps, property);
+          break;
 
-      case DataTypes.referenceListItem:
-        if (!property.referenceListName || !property.referenceListModule) {
-          throw new Error('Reference list name and namespace are required for referenceListItem type');
-        }
-        builder.addDropdown({
-          ...styledProps,
-          dataSourceType: 'referenceList',
-          border: {
-            hideBorder: false,
-            radiusType: 'all',
-            borderType: 'all',
+        case DataTypes.entityReference:
+          if (!property.entityType) {
+            console.warn(`Entity type is missing for entityReference property '${property.path}'; skipping`);
+            break;
+          }
+          builder.addByType(pickType('autocomplete'), {
+            ...commonProps,
+            entityType: { name: property.entityType, module: property.entityModule } as IEntityTypeIdentifier,
+            dataSourceType: 'entitiesList',
+          } as IConfigurableFormComponent, property);
+          break;
+
+        case DataTypes.referenceListItem:
+          if (!property.referenceListName || !property.referenceListModule) {
+            console.warn(`Reference list metadata missing for property '${property.path}'; skipping`);
+            break;
+          }
+          builder.addByType(pickType('dropdown'), {
+            ...styledProps,
+            dataSourceType: 'referenceList',
             border: {
-              all: { width: 1, style: 'solid', color: '#d9d9d9' },
+              hideBorder: false,
+              radiusType: 'all',
+              borderType: 'all',
+              border: {
+                all: { width: 1, style: 'solid', color: '#d9d9d9' },
+              },
+              radius: { all: 8 },
             },
-            radius: { all: 8 },
-          },
-          referenceListName: property.referenceListName,
-          referenceListId: {
-            module: property.referenceListModule,
-            name: property.referenceListName,
-          },
-        }, property);
-        break;
+            referenceListName: property.referenceListName,
+            referenceListId: {
+              module: property.referenceListModule,
+              name: property.referenceListName,
+            },
+          } as IConfigurableFormComponent, property);
+          break;
 
-      case DataTypes.boolean:
-        builder.addCheckbox(styledProps, property);
-        break;
+        case DataTypes.boolean:
+          builder.addByType(pickType('checkbox'), styledProps, property);
+          break;
 
-      case DataTypes.date:
-      case DataTypes.dateTime:
-        builder.addDateField(styledProps, property);
-        break;
+        case DataTypes.date:
+        case DataTypes.dateTime:
+          builder.addByType(pickType('dateField'), styledProps, property);
+          break;
 
-      case DataTypes.time:
-        builder.addTimePicker(styledProps, property);
-        break;
+        case DataTypes.time:
+          builder.addByType(pickType('timePicker'), styledProps, property);
+          break;
 
-      case DataTypes.file:
-        builder.addFileUpload({
-          ...commonProps,
-          font: { size: 14 },
-          ownerId: '{data.id}',
-          ownerType: this._modelType || '',
-          useSync: false,
-        }, property);
-        break;
-      default:
-        break;
+        case DataTypes.file:
+          builder.addByType(pickType('fileUpload'), {
+            ...commonProps,
+            font: { size: 14 },
+            ownerId: '{data.id}',
+            ownerType: this._modelType || '',
+            useSync: false,
+          } as IConfigurableFormComponent, property);
+          break;
+
+        default:
+          // Unmapped dataType — if the user picked a default editor, honour it; otherwise drop.
+          if (isDefined(defaultEditor) && defaultEditor !== '') {
+            builder.addByType(defaultEditor, styledProps, property);
+          }
+          break;
+      }
+    } catch (err) {
+      console.warn(`Failed to generate field for property '${property.path}':`, err);
     }
   }
 }

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/formMetadataHelper.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/formMetadataHelper.ts
@@ -169,7 +169,7 @@ export class FormMetadataHelper {
             ...commonProps,
             entityType: { name: property.entityType, module: property.entityModule } as IEntityTypeIdentifier,
             dataSourceType: 'entitiesList',
-          } as IConfigurableFormComponent, property);
+          }, property);
           break;
 
         case DataTypes.referenceListItem:
@@ -194,7 +194,7 @@ export class FormMetadataHelper {
               module: property.referenceListModule,
               name: property.referenceListName,
             },
-          } as IConfigurableFormComponent, property);
+          }, property);
           break;
 
         case DataTypes.boolean:
@@ -217,7 +217,7 @@ export class FormMetadataHelper {
             ownerId: '{data.id}',
             ownerType: this._modelType || '',
             useSync: false,
-          } as IConfigurableFormComponent, property);
+          }, property);
           break;
 
         default:

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/viewGenerationUtils.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/viewGenerationUtils.ts
@@ -229,7 +229,11 @@ export function addDetailsPanel(
   if (sortedMetadata.length > ROW_COUNT) {
     sortedMetadata.forEach((prop, index) => {
       const columnBuilder = formBuilderFactory();
-      metadataHelper.getConfigFields(prop, columnBuilder);
+      try {
+        metadataHelper.getConfigFields(prop, columnBuilder);
+      } catch (err) {
+        console.warn(`Skipping property '${prop.path}' due to error:`, err);
+      }
 
       if (index % 2 === 0) {
         column1.push(...columnBuilder.toJson());
@@ -267,7 +271,11 @@ export function addDetailsPanel(
     });
   } else {
     sortedMetadata.forEach((prop) => {
-      metadataHelper.getConfigFields(prop, builder);
+      try {
+        metadataHelper.getConfigFields(prop, builder);
+      } catch (err) {
+        console.warn(`Skipping property '${prop.path}' due to error:`, err);
+      }
     });
   }
 

--- a/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/viewGenerationUtils.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/publicApi/forms/generation-logic/viewGenerationUtils.ts
@@ -47,6 +47,39 @@ export function findContainersWithPlaceholder(markup: object, placeholder: strin
   return containers;
 }
 
+function findComponentsWithPlaceholderRecursive(
+  token: unknown,
+  placeholder: string,
+  results: IConfigurableFormComponent[],
+  visited: WeakSet<object>,
+): void {
+  if (!isDefined(token)) return;
+
+  if (typeof token === 'object') {
+    if (visited.has(token)) return;
+    visited.add(token);
+    if (isConfigurableFormComponent(token) && (token.componentName === placeholder || token.propertyName === placeholder)) {
+      results.push(token);
+    }
+    if (Array.isArray(token)) {
+      token.forEach((item) =>
+        findComponentsWithPlaceholderRecursive(item, placeholder, results, visited),
+      );
+    } else {
+      Object.entries(token).forEach(([_key, value]) => {
+        findComponentsWithPlaceholderRecursive(value, placeholder, results, visited);
+      });
+    }
+  }
+}
+
+export function findComponentsWithPlaceholder(markup: object, placeholder: string): IConfigurableFormComponent[] {
+  const components: IConfigurableFormComponent[] = [];
+  const visited = new WeakSet();
+  findComponentsWithPlaceholderRecursive(markup, placeholder, components, visited);
+  return components;
+}
+
 /**
  * Casts the provided data to the specified extension type T.
  * Throws an error if the data is not an object.


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during form generation—now warns and skips problematic fields instead of failing when required metadata is missing.
  * More reliable title placeholder resolution in detail views.

* **Improvements**
  * Form field generation respects custom default editor settings and better handles unmapped data types.
  * Generation faults for individual properties are caught and logged rather than propagating.

* **New Features**
  * New runtime API to add form components by toolbox type string for more flexible form building.

* **Refactor**
  * Placeholder scanning now targets configurable components directly for more accurate matching.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4931)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->