### PR TITLE
fix: added preferGenericEndpoint property to GenericConfigurableItemAutocompleteInternal

### DIFF
--- a/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
+++ b/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
@@ -8,7 +8,7 @@ import { IAbpWrappedGetEntityListResponse, IGenericGetAllPayload } from '@/inter
 import HelpTextPopover from '@/components/helpTextPopover';
 import { ConfigurableItemFullName, ConfigurableItemIdentifier, isConfigurableItemFullName, isConfigurableItemRawId, isEntityMetadata } from '@/interfaces';
 import { MetadataProvider, useMetadata } from '@/providers';
-import { StandardEntityActions } from '@/interfaces/metadata';
+import { IApiEndpoint, StandardEntityActions } from '@/interfaces/metadata';
 
 interface EditorProps<TValue> {
     value?: TValue;
@@ -22,6 +22,7 @@ export type StandardAutocompleteProps = {
     readOnly?: boolean;
     maxResultCount?: number;
     filter?: object;
+    preferGenericEndpoint?: boolean;
 };
 type EditorWithMode<TValue> = SingleEditorProps<TValue> | MultipleEditorProps<TValue>;
 
@@ -182,11 +183,15 @@ export const GenericConfigurableItemAutocompleteInternal = <TValue extends Confi
         value,
         onChange,
         filter,
+        preferGenericEndpoint = true,
     } = props;
 
     const { metadata } = useMetadata(true);
     const endpoints = isEntityMetadata(metadata) ? metadata.apiEndpoints : {};
-    const listEndpoint = endpoints[StandardEntityActions.list] ?? { httpVerb: 'get', url: `${GENERIC_ENTITIES_ENDPOINT}/GetAll` };
+    const genericEndpoint: IApiEndpoint = { httpVerb: 'get', url: `${GENERIC_ENTITIES_ENDPOINT}/GetAll` };
+    const listEndpoint = preferGenericEndpoint 
+        ? genericEndpoint 
+        : endpoints[StandardEntityActions.list] ?? genericEndpoint;
 
     const listFetcher = useGet<IAbpWrappedGetEntityListResponse<IResponseItem>, any, IGenericGetAllPayload>(
         listEndpoint.url,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable endpoint selection for the autocomplete component, allowing it to use either a unified generic endpoint or entity-specific endpoints for data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4941)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->