### PR TITLE
Apply NullToDefaultConverter to generic Deserialize<TValue> 

### DIFF
--- a/shesha-core/src/Shesha.Framework/Settings/ShaSettingManager.cs
+++ b/shesha-core/src/Shesha.Framework/Settings/ShaSettingManager.cs
@@ -215,11 +215,19 @@ namespace Shesha.Settings
             };
         }
 
-        private TValue? Deserialize<TValue>(string value) 
+        private TValue? Deserialize<TValue>(string value)
         {
             if (typeof(TValue).IsClass)
             {
-                return JsonConvert.DeserializeObject<TValue>(value);
+                try
+                {
+                    // note: NullToDefaultConverter is used to convert null values to defaults for non nullable types
+                    return JsonConvert.DeserializeObject<TValue>(value, new NullToDefaultConverter());
+                }
+                catch (Exception)
+                {
+                    return default;
+                }
             }
             else
                 return To<TValue>(value);

--- a/shesha-core/src/Shesha.Framework/Settings/ShaSettingManager.cs
+++ b/shesha-core/src/Shesha.Framework/Settings/ShaSettingManager.cs
@@ -2,6 +2,7 @@
 using Abp.Domain.Repositories;
 using Abp.Runtime.Session;
 using Abp.UI;
+using Castle.Core.Logging;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -30,7 +31,8 @@ namespace Shesha.Settings
         private readonly Services.Settings.ISettingStore _settingStore;
         private readonly IRepository<User, long> _userRepository;
 
-        public IAbpSession AbpSession { get; set; } = NullAbpSession.Instance;        
+        public IAbpSession AbpSession { get; set; } = NullAbpSession.Instance;
+        public ILogger Logger { get; set; } = NullLogger.Instance;
 
         public ShaSettingManager(ISettingDefinitionManager settingDefinitionManager, 
             IConfigurationFrameworkRuntime cfRuntime, 
@@ -224,8 +226,9 @@ namespace Shesha.Settings
                     // note: NullToDefaultConverter is used to convert null values to defaults for non nullable types
                     return JsonConvert.DeserializeObject<TValue>(value, new NullToDefaultConverter());
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Logger.Error($"Failed to deserialize setting value to type '{typeof(TValue).FullName}'. Value: {value}", ex);
                     return default;
                 }
             }
@@ -237,13 +240,14 @@ namespace Shesha.Settings
         {
             if (targetType.IsClass)
             {
-                try 
+                try
                 {
                     // note: NullToDefaultConverter is used to convert null values to defaults for non nullable types
                     return JsonConvert.DeserializeObject(value, targetType, new NullToDefaultConverter());
                 }
-                catch (Exception) 
+                catch (Exception ex)
                 {
+                    Logger.Error($"Failed to deserialize setting value to type '{targetType.FullName}'. Value: {value}", ex);
                     return null;
                 }
             }


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4914
The generic overload was missing the converter, causing null int values (e.g. autoLogoffTimeout) in settings JSON to throw on every request via ApiAuthorizationHelper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings deserialization to gracefully handle invalid or null configuration values by returning sensible defaults instead of causing errors
  * Added logging of deserialization issues to aid troubleshooting while preventing failures, enhancing overall application stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->