### PR TITLE
Lihlumise/b/4527 fix

### DIFF
--- a/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
@@ -1,4 +1,10 @@
-import React, { FC, PropsWithChildren, useEffect, useRef } from 'react';
+import React, { FC, PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import { Tooltip } from 'antd';
+
+interface TooltipState {
+  open: boolean;
+  title: string;
+}
 
 interface Props {
   className?: string;
@@ -6,10 +12,11 @@ interface Props {
 
 export const PasswordFieldWrapper: FC<PropsWithChildren<Props>> = ({ children, className }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [tooltipState, setTooltipState] = useState<TooltipState>({ open: false, title: '' });
 
-  useEffect(() => {
+  useEffect((): (() => void) => {
     const container = containerRef.current;
-    if (!container) return;
+    if (!container) return (): void => undefined;
 
     let resizeObserver: ResizeObserver | null = null;
 
@@ -25,7 +32,6 @@ export const PasswordFieldWrapper: FC<PropsWithChildren<Props>> = ({ children, c
         }
       });
       resizeObserver.observe(input);
-
       container.style.setProperty('--sha-password-input-width', `${input.getBoundingClientRect().width}px`);
     };
 
@@ -33,15 +39,44 @@ export const PasswordFieldWrapper: FC<PropsWithChildren<Props>> = ({ children, c
     mutationObserver.observe(container, { childList: true, subtree: true });
     attachResizeObserver();
 
-    return () => {
+    return (): void => {
       mutationObserver.disconnect();
       resizeObserver?.disconnect();
     };
   }, []);
 
+  const showTooltip = useCallback((title: string): void => {
+    setTooltipState((prev) => (prev.open && prev.title === title ? prev : { open: true, title }));
+  }, []);
+
+  const hideTooltip = useCallback((): void => {
+    setTooltipState((prev) => (prev.open ? { ...prev, open: false } : prev));
+  }, []);
+
+  const handleMouseOver = (e: React.MouseEvent<HTMLDivElement>): void => {
+    const el = e.target as HTMLElement;
+    if (el.classList.contains('ant-form-item-explain-error') && el.scrollWidth > el.clientWidth) {
+      showTooltip(el.textContent ?? '');
+    } else {
+      hideTooltip();
+    }
+  };
+
   return (
-    <div ref={containerRef} className={className}>
-      {children}
-    </div>
+    <Tooltip
+      title={tooltipState.title}
+      open={tooltipState.open}
+      placement="bottom"
+      destroyTooltipOnHide
+    >
+      <div
+        ref={containerRef}
+        className={className}
+        onMouseOver={handleMouseOver}
+        onMouseLeave={hideTooltip}
+      >
+        {children}
+      </div>
+    </Tooltip>
   );
 };

--- a/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
@@ -1,0 +1,47 @@
+import React, { FC, PropsWithChildren, useEffect, useRef } from 'react';
+
+interface Props {
+  className?: string;
+}
+
+export const PasswordFieldWrapper: FC<PropsWithChildren<Props>> = ({ children, className }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let resizeObserver: ResizeObserver | null = null;
+
+    const attachResizeObserver = (): void => {
+      if (resizeObserver) return;
+      const input = container.querySelector<HTMLElement>('.ant-input-affix-wrapper');
+      if (!input) return;
+
+      resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]): void => {
+        for (const entry of entries) {
+          const width = entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+          container.style.setProperty('--sha-password-input-width', `${width}px`);
+        }
+      });
+      resizeObserver.observe(input);
+
+      container.style.setProperty('--sha-password-input-width', `${input.getBoundingClientRect().width}px`);
+    };
+
+    const mutationObserver = new MutationObserver(attachResizeObserver);
+    mutationObserver.observe(container, { childList: true, subtree: true });
+    attachResizeObserver();
+
+    return () => {
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className={className}>
+      {children}
+    </div>
+  );
+};

--- a/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
@@ -71,7 +71,7 @@ export const PasswordFieldWrapper: FC<PropsWithChildren<Props>> = ({ children, c
       title={tooltipState.title}
       open={tooltipState.open}
       placement="bottom"
-      destroyTooltipOnHide
+      destroyOnHidden
     >
       <div
         ref={containerRef}

--- a/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/textField/passwordFieldWrapper.tsx
@@ -54,9 +54,13 @@ export const PasswordFieldWrapper: FC<PropsWithChildren<Props>> = ({ children, c
   }, []);
 
   const handleMouseOver = (e: React.MouseEvent<HTMLDivElement>): void => {
-    const el = e.target as HTMLElement;
-    if (el.classList.contains('ant-form-item-explain-error') && el.scrollWidth > el.clientWidth) {
-      showTooltip(el.textContent ?? '');
+    if (!(e.target instanceof HTMLElement)) {
+      hideTooltip();
+      return;
+    }
+    const errorEl = e.target.closest<HTMLElement>('.ant-form-item-explain-error');
+    if (errorEl && errorEl.scrollWidth > errorEl.clientWidth) {
+      showTooltip(errorEl.textContent ?? '');
     } else {
       hideTooltip();
     }

--- a/shesha-reactjs/src/designer-components/textField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/textField/settingsForm.ts
@@ -123,6 +123,11 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                 label: 'Spell Check',
                 inputType: 'switch',
                 jsSetting: true,
+                hidden: {
+                  _code: 'return getSettingValue(data?.textType) === "password";',
+                  _mode: 'code',
+                  _value: false,
+                } as any,
               })
               .toJson(),
             ],

--- a/shesha-reactjs/src/designer-components/textField/styles.ts
+++ b/shesha-reactjs/src/designer-components/textField/styles.ts
@@ -16,6 +16,12 @@ export const useStyles = createStyles(({ css, cx, token }, { fontWeight, fontFam
   `);
 
   const passwordFieldWrapper = cx("sha-password-field-wrapper", css`
+    .ant-form-item-explain,
+    .ant-form-item-explain-connected {
+      max-width: var(--sha-password-input-width, 100%);
+      overflow: hidden;
+    }
+
     .ant-form-item-explain-error {
       white-space: nowrap;
       overflow: hidden;

--- a/shesha-reactjs/src/designer-components/textField/textField.tsx
+++ b/shesha-reactjs/src/designer-components/textField/textField.tsx
@@ -14,6 +14,7 @@ import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem/index'
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { IconType, ShaIcon } from '@/components/shaIcon';
 import { useStyles } from './styles';
+import { PasswordFieldWrapper } from './passwordFieldWrapper';
 import { migratePrevStyles } from '../_common-migrations/migrateStyles';
 import { getSettings } from './settingsForm';
 import { defaultStyles, buildPasswordValidatorString, usePasswordComplexitySettings, validatePasswordValue } from './utils';
@@ -157,7 +158,7 @@ const TextFieldComponent: TextFieldComponentDefinition = {
           if (isPassword) {
             return (
               <Tooltip title={passwordError ?? undefined} placement="bottom">
-                <div className={styles.passwordFieldWrapper}>{inputElement}</div>
+                {inputElement}
               </Tooltip>
             );
           }
@@ -166,6 +167,10 @@ const TextFieldComponent: TextFieldComponentDefinition = {
         }}
       </ConfigurableFormItem>
     );
+
+    if (isPassword) {
+      return <PasswordFieldWrapper className={styles.passwordFieldWrapper}>{fieldContent}</PasswordFieldWrapper>;
+    }
 
     return fieldContent;
   },

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/execute-sign-in.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/execute-sign-in.ts
@@ -15,9 +15,13 @@ export const useExecuteSignIn = (): void => {
       ownerUid: SheshaActionOwners.Common,
       sortOrder: 8,
       hasArguments: false,
-      executer: (_, actionContext) => {
+      executer: async (_, actionContext) => {
         if (!auth)
           throw new Error("Authentication is not available");
+
+        const formInstance = actionContext.form?.formInstance;
+        if (formInstance)
+          await formInstance.validateFields();
 
         const data = actionContext.form?.data as ILoginForm;
         return auth.loginUserAsync(data);


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password fields now show full error text in a hover tooltip when error messages overflow.
  * Sign-in action now validates form fields before attempting to authenticate.

* **Bug Fixes**
  * Improved handling of password input layout to prevent error text clipping and ensure tooltip accuracy.

* **Style**
  * Spell check is disabled for password inputs; input width constraints added to prevent overflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->