### PR TITLE
only insist on 100% when orientation is not horizontal

### DIFF
--- a/shesha-reactjs/src/components/codeEditor/client-side/fileTree/icons.tsx
+++ b/shesha-reactjs/src/components/codeEditor/client-side/fileTree/icons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SiHtml5, SiCss3, SiJavascript, SiTypescript, SiJson } from "react-icons/si";
+import { SiHtml5, SiCss, SiJavascript, SiTypescript, SiJson } from "react-icons/si";
 import { FcFolder, FcOpenedFolder, FcPicture, FcFile } from "react-icons/fc";
 import { AiFillFileText } from "react-icons/ai";
 import { AntdTreeNodeAttribute } from 'antd/lib/tree';
@@ -15,7 +15,7 @@ export const getNodeIcon = (nodeProps: AntdTreeNodeAttribute): JSX.Element => {
     case "jsx": return <SiJavascript color="#fbcb38" />;
     case "ts": return <SiTypescript color="#378baa" />;
     case "tsx": return <SiTypescript color="#378baa" />;
-    case "css": return <SiCss3 color="purple" />;
+    case "css": return <SiCss color="purple" />;
     case "json": return <SiJson color="#5656e6" />;
     case "html": return <SiHtml5 color="#e04e2c" />;
     case "png": return <FcPicture />;

--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -838,7 +838,7 @@ export const DataList: FC<Partial<IDataListProps>> = ({
                   style: {
                     ...child.props.style,
                     overflow: 'visible',
-                    flex: '0 0 100%',
+                    ...(orientation !== 'horizontal' && { flex: '0 0 100%' }),
                   },
                 });
               })}


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DataList layout so horizontal mode no longer receives unintended flex styling.

* **Style**
  * Updated the icon shown for .css files to a different CSS-specific icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->