### PR TITLE
fix: temporary disabled filtering by module name in EmbeddedPackageSeeder

### DIFF
--- a/shesha-core/src/Shesha.Framework/ConfigurationItems/Distribution/EmbeddedPackageSeeder.cs
+++ b/shesha-core/src/Shesha.Framework/ConfigurationItems/Distribution/EmbeddedPackageSeeder.cs
@@ -88,9 +88,10 @@ namespace Shesha.ConfigurationItems.Distribution
                                 CreateModules = false,
                                 Logger = context.Logger,
                                 ImportResult = importResult,
+                                /* temporary disabled filtering to prevent issues in projects
                                 ShouldImportItem = (item) => { 
                                     return item.ModuleName == moduleName;
-                                }
+                                }*/
                             };
                             try
                             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the scope of items eligible for import during embedded package seeding. Previously, imports were restricted by module name filtering; this limitation has been removed to allow a broader range of items to be imported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->