### PR TITLE
fix: datalist orientation rendering and card layout

### DIFF
--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -513,7 +513,7 @@ export const DataList: FC<Partial<IDataListProps>> = ({
 
     return (
       <AttributeDecorator attributes={attributes}>
-        <div onDoubleClick={dblClick}>
+        <div onDoubleClick={dblClick} style={{ width: '100%' }}>
           <DataListItemRenderer
             isNewObject={false}
             markup={entityForm?.formConfiguration?.markup}
@@ -640,8 +640,15 @@ export const DataList: FC<Partial<IDataListProps>> = ({
       }),
     };
 
+    const wrapperStyle: CSSProperties =
+      orientation === 'horizontal'
+        ? { flex: '0 0 auto', width: itemWidth, overflow: 'visible' }
+        : orientation === 'wrap'
+          ? { flex: `0 0 ${itemWidth}`, width: itemWidth, overflow: 'visible' }
+          : { flex: '0 0 100%', overflow: 'visible' };
+
     return (
-      <div key={`row-${index}`}>
+      <div key={`row-${index}`} style={wrapperStyle}>
         <ConditionalWrap
           condition={selectionMode === 'multiple'}
           wrap={(children) => (
@@ -677,7 +684,7 @@ export const DataList: FC<Partial<IDataListProps>> = ({
                 onListItemHover(index, item);
               }
             }}
-            style={{ ...itemStyles, width: orientation === 'wrap' ? 'unset' : itemStyles.width, overflow: 'auto' }}
+            style={{ ...itemStyles, width: orientation === 'wrap' ? '100%' : itemStyles.width, overflow: 'auto' }}
           >
             {rows.current?.length > index ? rows.current[index] : null}
           </div>
@@ -725,6 +732,18 @@ export const DataList: FC<Partial<IDataListProps>> = ({
   };
 
 
+  const rawItemWidth =
+    (style as CSSProperties)?.width ?? props.container?.dimensions?.width;
+  const isFixedWidth = (val: unknown): boolean => {
+    if (val === undefined || val === null || val === '') return false;
+    if (typeof val === 'number') return true;
+    const s = String(val).trim().toLowerCase();
+    return s !== 'auto' && s !== 'unset' && s !== 'inherit' && s !== 'initial' && s !== 'none';
+  };
+  const itemWidth = isFixedWidth(rawItemWidth)
+    ? (typeof rawItemWidth === 'number' ? `${rawItemWidth}px` : rawItemWidth)
+    : '300px';
+
   const getContainerStyles = (): CSSProperties => {
     const containerStyles: CSSProperties = {
       gap: gap !== undefined ? (typeof gap === 'number' ? `${gap}px` : gap) : '0px',
@@ -732,15 +751,6 @@ export const DataList: FC<Partial<IDataListProps>> = ({
       ...fcContainerStyles.stylingBoxAsCSS,
       ...fcContainerStyles.dimensionsStyles,
     };
-
-    const rawItemWidth =
-      (style as CSSProperties)?.width ?? props.container?.dimensions?.width;
-    const itemWidth =
-      rawItemWidth !== undefined
-        ? typeof rawItemWidth === 'number'
-          ? `${rawItemWidth}px`
-          : rawItemWidth
-        : '300px';
 
     switch (orientation) {
       case 'horizontal':
@@ -755,9 +765,10 @@ export const DataList: FC<Partial<IDataListProps>> = ({
       case 'wrap':
         return {
           ...containerStyles,
-          display: 'grid',
-          gridTemplateColumns: `repeat(auto-fill, ${itemWidth})`,
-          alignItems: 'start',
+          width: '100%',
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'flex-start',
         };
 
       case 'vertical':
@@ -832,16 +843,7 @@ export const DataList: FC<Partial<IDataListProps>> = ({
             </Show>
 
             <Show when={records?.length > 0}>
-              {React.Children.map(content, (child, index) => {
-                return React.cloneElement(child, {
-                  key: child.key || index,
-                  style: {
-                    ...child.props.style,
-                    overflow: 'visible',
-                    ...(orientation !== 'horizontal' && { flex: '0 0 100%' }),
-                  },
-                });
-              })}
+              {content}
             </Show>
           </div>
         </ShaSpin>

--- a/shesha-reactjs/src/components/dataList/itemRenderer.tsx
+++ b/shesha-reactjs/src/components/dataList/itemRenderer.tsx
@@ -93,7 +93,7 @@ export const DataListItemRenderer: FC<IDataListItemProps> = (props) => {
 
   return (
     <DataListItemErrorBoundary>
-      <div key={itemListId}>
+      <div key={itemListId} style={{ width: '100%' }}>
 
         <FormMarkupConverter markup={markup} formSettings={formSettings}>
           {(flatComponents) => {

--- a/shesha-reactjs/src/components/dataList/styles/styles.ts
+++ b/shesha-reactjs/src/components/dataList/styles/styles.ts
@@ -130,7 +130,6 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
 
         .${shaDatalistCard} {
             padding: 16px;
-            background-color: #ffffff;
             border-radius: 8px;
             position: relative;
             max-width: 100%;
@@ -145,11 +144,18 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
             }
         }
 
-        .${shaDatalistCard} > * {
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            overflow-wrap: break-word;
+        .${shaDatalistCard} > *,
+        .${shaDatalistComponentItem} > * {
+            width: 100% !important;
             max-width: 100%;
+            overflow-wrap: break-word;
+        }
+
+        .${shaDatalistCard} .sha-components-container,
+        .${shaDatalistCard} .sha-components-container-inner,
+        .${shaDatalistComponentItem} .sha-components-container,
+        .${shaDatalistComponentItem} .sha-components-container-inner {
+            width: 100% !important;
         }
 
         .${shaDatalistHorizontal} {


### PR DESCRIPTION
- Wrap orientation now uses flex-wrap with explicit per-item width instead of CSS grid, which was collapsing to a single column when dimensions.width defaulted to 'auto'.
- Horizontal orientation no longer crushes cards: wrappers get flex: 0 0 auto so they keep their configured width.
- Apply wrapper sizing directly in renderRow instead of via React.cloneElement so styles land on the actual flex child.
- Force form sub-content to fill the card via width: 100% !important on .sha-components-container(-inner) descendants.
- Remove default white background on .sha-datalist-card so users can configure their own background.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data list row rendering and layout logic to ensure proper width and overflow handling across different orientations.
  * Enhanced text wrapping behavior in data list items—content now wraps properly instead of truncating.
  * Refined container sizing and alignment for better display consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shesha-io/shesha-framework/pull/4983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->