### PR TITLE
fix: persist selected entity on non-template forms (#4986)

### DIFF
--- a/shesha-reactjs/src/providers/configurationItemsLoader/utils.ts
+++ b/shesha-reactjs/src/providers/configurationItemsLoader/utils.ts
@@ -60,6 +60,9 @@ export const convertFormConfigurationDto2FormDto = (dto: FormConfigurationDto, r
     }
     result.settings.access = normalizedAccess;
     result.settings.permissions = result.settings.permissions ?? dto.permissions;
+    // fall back to the DTO's modelType for forms created with an entity selected
+    // but no template, where the markup's formSettings.modelType is empty (#4986)
+    result.settings.modelType = result.settings.modelType ?? dto.modelType ?? undefined;
   }
 
   return result;

--- a/shesha-reactjs/src/providers/configurationItemsLoader/utils.ts
+++ b/shesha-reactjs/src/providers/configurationItemsLoader/utils.ts
@@ -62,7 +62,13 @@ export const convertFormConfigurationDto2FormDto = (dto: FormConfigurationDto, r
     result.settings.permissions = result.settings.permissions ?? dto.permissions;
     // fall back to the DTO's modelType for forms created with an entity selected
     // but no template, where the markup's formSettings.modelType is empty (#4986)
-    result.settings.modelType = result.settings.modelType ?? dto.modelType ?? undefined;
+    const hasSettingsModelType =
+      typeof result.settings.modelType === 'string'
+        ? result.settings.modelType.trim().length > 0
+        : result.settings.modelType != null;
+    result.settings.modelType = hasSettingsModelType
+      ? result.settings.modelType
+      : dto.modelType ?? undefined;
   }
 
   return result;


### PR DESCRIPTION
When a form is created without a template but with an entity explicitly selected, the entity lands in the DTO's modelType but the markup's formSettings.modelType is empty, so settings.modelType was undefined on load. The designer gates the Data tab on formSettings.modelType, so it went missing until the entity was re-selected manually.

Backfill settings.modelType from dto.modelType in
convertFormConfigurationDto2FormDto, mirroring the existing access/ permissions fallback. The trailing `?? undefined` coerces the DTO's nullable modelType to match IFormSettings.modelType (no null).

This is the main-line equivalent of the releases/0.43 fix (PR #4988), which lived in configurationItemsLoader/index.tsx before that file was refactored into configurationLoader + utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure form configuration now populates model type when form settings exist but the markup-derived model type is empty; it falls back to the DTO-provided model type so forms without explicit model-type markup continue to load correctly.
  * Retains existing permissions and conversion behavior while improving robustness for missing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->