### PR TITLE
Add registration specific OTP email link templates

### DIFF
--- a/shesha-core/src/Shesha.Application/Otp/Configuration/OtpActionTypes.cs
+++ b/shesha-core/src/Shesha.Application/Otp/Configuration/OtpActionTypes.cs
@@ -1,0 +1,8 @@
+namespace Shesha.Otp.Configuration
+{
+    public static class OtpActionTypes
+    {
+        public const string Registration = "EmailRegistration";
+        public const string PasswordReset = "password-reset";
+    }
+}

--- a/shesha-core/src/Shesha.Application/Otp/Configuration/OtpDefaults.cs
+++ b/shesha-core/src/Shesha.Application/Otp/Configuration/OtpDefaults.cs
@@ -12,5 +12,7 @@
         public const string DefaultBodyTemplate = "Your One-Time-Pin is {{password}}";
         public const string DefaultEmailSubjectTemplate = "One-Time-Pin";
         public const string DefaultEmailBodyTemplate = @"Click the following link to verify your email address: <a href='http://localhost:3000/no-auth/shesha/email-link-verification/?isRegistration={{isRegistration}}&operationId={{operationId}}&token={{token}}&identifier={{userid}}'>link</a>";
+        public const string DefaultRegistrationEmailSubjectTemplate = "Complete Your Registration";
+        public const string DefaultRegistrationEmailBodyTemplate = @"Click the following link to complete your registration: <a href='http://localhost:3000/no-auth/shesha/email-link-verification/?isRegistration={{isRegistration}}&operationId={{operationId}}&token={{token}}&identifier={{userid}}'>link</a>";
     }
 }

--- a/shesha-core/src/Shesha.Application/Otp/Configuration/OtpSettings.cs
+++ b/shesha-core/src/Shesha.Application/Otp/Configuration/OtpSettings.cs
@@ -42,5 +42,15 @@
         /// Email link body template
         /// </summary>
         public string DefaultEmailBodyTemplate { get; set; }
+
+        /// <summary>
+        /// Registration email link subject template
+        /// </summary>
+        public string DefaultRegistrationEmailSubjectTemplate { get; set; }
+
+        /// <summary>
+        /// Registration email link body template
+        /// </summary>
+        public string DefaultRegistrationEmailBodyTemplate { get; set; }
     }
 }

--- a/shesha-core/src/Shesha.Application/Otp/Configuration/OtpSettingsDto.cs
+++ b/shesha-core/src/Shesha.Application/Otp/Configuration/OtpSettingsDto.cs
@@ -36,5 +36,15 @@
         /// Email template body
         /// </summary>
         public string EmailBodyTemplate { get; set; }
+
+        /// <summary>
+        /// Subject for the registration email link
+        /// </summary>
+        public string RegistrationEmailSubject { get; set; }
+
+        /// <summary>
+        /// Registration email template body
+        /// </summary>
+        public string RegistrationEmailBodyTemplate { get; set; }
     }
 }

--- a/shesha-core/src/Shesha.Application/Otp/OtpAppService.cs
+++ b/shesha-core/src/Shesha.Application/Otp/OtpAppService.cs
@@ -62,6 +62,8 @@ namespace Shesha.Otp
                 IgnoreOtpValidation = input.IgnoreOtpValidation,
                 DefaultEmailBodyTemplate = input.EmailBodyTemplate,
                 DefaultEmailSubjectTemplate = input.EmailSubject,
+                DefaultRegistrationEmailSubjectTemplate = input.RegistrationEmailSubject,
+                DefaultRegistrationEmailBodyTemplate = input.RegistrationEmailBodyTemplate,
             });
 
             return true;
@@ -81,6 +83,8 @@ namespace Shesha.Otp
                 IgnoreOtpValidation = emailSettings.IgnoreOtpValidation,
                 EmailSubject = emailSettings.DefaultEmailSubjectTemplate,
                 EmailBodyTemplate = emailSettings.DefaultEmailBodyTemplate,
+                RegistrationEmailSubject = emailSettings.DefaultRegistrationEmailSubjectTemplate,
+                RegistrationEmailBodyTemplate = emailSettings.DefaultRegistrationEmailBodyTemplate,
             };
             
             return settings;

--- a/shesha-core/src/Shesha.Application/Otp/OtpManager.cs
+++ b/shesha-core/src/Shesha.Application/Otp/OtpManager.cs
@@ -212,13 +212,32 @@ namespace Shesha.Otp
                     }
                 case OtpSendType.EmailLink:
                     {
-                        var subjectTemplate = settings.DefaultEmailSubjectTemplate;
-                        var bodyTemplate = settings.DefaultEmailBodyTemplate;
+                        string subjectTemplate;
+                        string bodyTemplate;
+
+                        if (otp.ActionType == OtpActionTypes.Registration)
+                        {
+                            subjectTemplate = !string.IsNullOrWhiteSpace(settings.DefaultRegistrationEmailSubjectTemplate)
+                                ? settings.DefaultRegistrationEmailSubjectTemplate
+                                : OtpDefaults.DefaultRegistrationEmailSubjectTemplate;
+                            bodyTemplate = !string.IsNullOrWhiteSpace(settings.DefaultRegistrationEmailBodyTemplate)
+                                ? settings.DefaultRegistrationEmailBodyTemplate
+                                : OtpDefaults.DefaultRegistrationEmailBodyTemplate;
+                        }
+                        else
+                        {
+                            subjectTemplate = !string.IsNullOrWhiteSpace(settings.DefaultEmailSubjectTemplate)
+                                ? settings.DefaultEmailSubjectTemplate
+                                : OtpDefaults.DefaultEmailSubjectTemplate;
+                            bodyTemplate = !string.IsNullOrWhiteSpace(settings.DefaultEmailBodyTemplate)
+                                ? settings.DefaultEmailBodyTemplate
+                                : OtpDefaults.DefaultEmailBodyTemplate;
+                        }
 
                         var body = bodyTemplate.Replace("{{token}}", otp.Pin);
                         body = body.Replace("{{userid}}", otp.RecipientId);
                         body = body.Replace("{{operationId}}", otp.OperationId.ToString());
-                        body = body.Replace("{{isRegistration}}", otp.ActionType == "EmailRegistration" ? "true" : "false");
+                        body = body.Replace("{{isRegistration}}", otp.ActionType == OtpActionTypes.Registration ? "true" : "false");
                         await _emailSender.SendAsync(otp.SendTo, subjectTemplate, body, true);
                         break;
                     }

--- a/shesha-core/src/Shesha.Application/SheshaApplicationModule.cs
+++ b/shesha-core/src/Shesha.Application/SheshaApplicationModule.cs
@@ -135,7 +135,9 @@ namespace Shesha
                     DefaultSubjectTemplate = OtpDefaults.DefaultSubjectTemplate,
                     DefaultBodyTemplate = OtpDefaults.DefaultBodyTemplate,
                     DefaultEmailSubjectTemplate = OtpDefaults.DefaultEmailSubjectTemplate,
-                    DefaultEmailBodyTemplate = OtpDefaults.DefaultEmailBodyTemplate
+                    DefaultEmailBodyTemplate = OtpDefaults.DefaultEmailBodyTemplate,
+                    DefaultRegistrationEmailSubjectTemplate = OtpDefaults.DefaultRegistrationEmailSubjectTemplate,
+                    DefaultRegistrationEmailBodyTemplate = OtpDefaults.DefaultRegistrationEmailBodyTemplate
                 });
             });
 


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration email verification messages can now be customized separately, allowing administrators to configure distinct subject lines and body content for registration-specific OTP communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->