### PR TITLE
Katleho/feat/request config modal

### DIFF
--- a/shesha-reactjs/src/components/requestConfigModal/__tests__/transformationRunner.test.ts
+++ b/shesha-reactjs/src/components/requestConfigModal/__tests__/transformationRunner.test.ts
@@ -1,0 +1,81 @@
+import { executeResponseTransformation, validateTransformationScript } from '../transformationRunner';
+
+describe('validateTransformationScript', () => {
+  it('rejects an empty script', () => {
+    expect(validateTransformationScript('')).toMatch(/cannot be empty/i);
+    expect(validateTransformationScript('   ')).toMatch(/cannot be empty/i);
+  });
+
+  it('rejects a script with no return', () => {
+    expect(validateTransformationScript('const x = response.a;')).toMatch(/must return/i);
+  });
+
+  it('accepts a valid script', () => {
+    expect(validateTransformationScript('return response;')).toBeNull();
+  });
+});
+
+describe('executeResponseTransformation', () => {
+  it('transforms the response and returns the new shape', async () => {
+    const script = 'return { fullName: response.firstName + " " + response.lastName, email: response.email };';
+    const result = await executeResponseTransformation(script, {
+      response: {
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        email: 'ada@example.com',
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({ fullName: 'Ada Lovelace', email: 'ada@example.com' });
+  });
+
+  it('exposes the other context constants to the script', async () => {
+    const result = await executeResponseTransformation('return { ok: globalState.flag, count: response.count };', {
+      response: { count: 7 },
+      globalState: { flag: true },
+    });
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({ ok: true, count: 7 });
+  });
+
+  it('supports awaiting inside the script', async () => {
+    const result = await executeResponseTransformation('const v = await Promise.resolve(response.count * 2); return v;', {
+      response: { count: 21 },
+    });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe(42);
+  });
+
+  it('fails validation when the script is empty', async () => {
+    const result = await executeResponseTransformation('', { response: { a: 1 } });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/cannot be empty/i);
+  });
+
+  it('fails when the script does not return a value', async () => {
+    const result = await executeResponseTransformation('const x = 1;', { response: { a: 1 } });
+    expect(result.success).toBe(false);
+    // caught at static validation (no `return` keyword)
+    expect(result.error).toMatch(/must return/i);
+  });
+
+  it('reports a failure instead of throwing on a runtime error', async () => {
+    // Accessing a property of undefined throws; the runner catches it and reports it as a failure.
+    const result = await executeResponseTransformation('return response.a.b.c;', { response: {} });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('reports a failure instead of throwing on a syntax error', async () => {
+    const result = await executeResponseTransformation('return {;', { response: {} });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('handles a transformation that returns a primitive', async () => {
+    const result = await executeResponseTransformation('return response.count * 2;', { response: { count: 21 } });
+    expect(result.success).toBe(true);
+    expect(result.output).toBe(42);
+  });
+});

--- a/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
@@ -4,7 +4,7 @@ import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { BodyType, IFormDataField, IRequestBody, IResponseTransformationConfiguration, RawBodySubType } from './models';
 import { ExpressionContext } from '@/components/expressionEditor';
 import { TableValueEditor } from './tableValueEditor';
-import { TransformationTab } from './transformationTab';
+import { TransformationTab, DEFAULT_TRANSFORMATION_SCRIPT } from './transformationTab';
 import { CodeEditor as BaseCodeEditor } from '@/components/codeEditor/codeEditor';
 import { CodeLanguages } from '@/designer-components/codeEditor/types';
 import { useAvailableConstantsMetadata } from '@/utils/metadata/hooks';
@@ -55,7 +55,7 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
 
   // Remember the raw sub-type (Text/JSON/XML/…) so leaving and returning to the "raw" tab keeps the
   // last choice instead of resetting to "text".
-  const [lastRawSubType, setLastRawSubType] = useState<RawBodySubType>(body.rawSubType ?? 'text');
+  const [lastRawSubType, setLastRawSubType] = useState<RawBodySubType>(body.type === 'raw' ? body.rawSubType : 'text');
 
   const defaultContentFor = (type: BodyType): IRequestBody['content'] =>
     type === 'form-data' || type === 'x-www-form-urlencoded' ? ([] as IFormDataField[]) : '';
@@ -82,11 +82,16 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
   };
 
   const handleTypeChange = (type: BodyType): void => {
-    // Restore the previously-entered content for this type instead of resetting it.
     const stashed = contentByType[type];
     const content = stashed !== undefined ? stashed : defaultContentFor(type);
-    const next: IRequestBody = { type, content };
-    if (type === 'raw') next.rawSubType = lastRawSubType;
+    let next: IRequestBody;
+    if (type === 'raw') {
+      next = { type, content: (content as string | undefined) ?? '', rawSubType: lastRawSubType };
+    } else if (type === 'form-data' || type === 'x-www-form-urlencoded') {
+      next = { type, content: (content as IFormDataField[] | undefined) ?? [] };
+    } else {
+      next = { type, content: (content as string | undefined) ?? '' };
+    }
     onChange(next);
     setJsonError(null);
   };
@@ -97,20 +102,27 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
       return;
     }
     const type = view;
-    const cleared = defaultContentFor(type);
-    setContentByType((prev) => ({ ...prev, [type]: cleared }));
-    onChange({ ...body, content: cleared });
+    setContentByType((prev) => ({ ...prev, [type]: defaultContentFor(type) }));
+    let clearedBody: IRequestBody;
+    if (type === 'raw') {
+      clearedBody = { type, content: '', rawSubType: lastRawSubType };
+    } else if (type === 'form-data' || type === 'x-www-form-urlencoded') {
+      clearedBody = { type, content: [] };
+    } else {
+      clearedBody = { type, content: '' };
+    }
+    onChange(clearedBody);
     setJsonError(null);
   };
 
   const handleRawSubTypeChange = (rawSubType: RawBodySubType): void => {
     setLastRawSubType(rawSubType);
-    onChange({ ...body, rawSubType });
+    if (body.type === 'raw') onChange({ ...body, rawSubType });
   };
 
   const handleJsonChange = (value: string): void => {
     setContentByType((prev) => ({ ...prev, json: value }));
-    onChange({ ...body, content: value });
+    onChange({ type: 'json', content: value });
 
     if (!value.trim()) {
       setJsonError(null);
@@ -121,13 +133,13 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
       JSON.parse(value);
       setJsonError(null);
     } catch (err) {
-      setJsonError('Invalid JSON: ' + (err as Error).message);
+      setJsonError('Invalid JSON: ' + (err instanceof Error ? err.message : String(err)));
     }
   };
 
   const handleRawChange = (value: string): void => {
     setContentByType((prev) => ({ ...prev, raw: value }));
-    onChange({ ...body, content: value });
+    onChange({ type: 'raw', content: value, rawSubType: lastRawSubType });
   };
 
   const parseFormData = (): IFormDataField[] => {
@@ -147,7 +159,9 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
 
   const updateFormData = (rows: IFormDataField[]): void => {
     setContentByType((prev) => ({ ...prev, [body.type]: rows }));
-    onChange({ ...body, content: rows });
+    if (body.type === 'form-data' || body.type === 'x-www-form-urlencoded') {
+      onChange({ ...body, content: rows });
+    }
   };
 
   const handleFormDataAdd = (): void => {
@@ -262,7 +276,10 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
         <TransformationTab
           {...(transformation !== undefined ? { value: transformation } : {})}
           onChange={(t) => {
-            onTransformationChange?.(t);
+            const seeded = t.enabled && !t.script.trim()
+              ? { ...t, script: DEFAULT_TRANSFORMATION_SCRIPT }
+              : t;
+            onTransformationChange?.(seeded);
           }}
         />
       );
@@ -309,7 +326,7 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
         );
 
       case 'raw': {
-        const activeSubType = body.rawSubType ?? 'text';
+        const activeSubType = body.rawSubType;
         const subTypeMeta = (RAW_SUB_TYPES.find((s) => s.value === activeSubType) ?? RAW_SUB_TYPES[0])!;
         // The JavaScript sub-type is executed at request time, so it gets the templated editor with
         // exposed constants (like the Transformation tab). Other sub-types are sent as plain text.

--- a/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
@@ -1,10 +1,9 @@
 import React, { FC, useState } from 'react';
 import { AutoComplete, Button, Checkbox, Radio, Select, Space, Table, Tooltip, Typography } from 'antd';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
-import { BodyType, IFormDataField, IRequestBody, IResponseTransformationConfiguration, RawBodySubType } from './models';
+import { BodyType, IFormDataField, IRequestBody, RawBodySubType } from './models';
 import { ExpressionContext } from '@/components/expressionEditor';
 import { TableValueEditor } from './tableValueEditor';
-import { TransformationTab, DEFAULT_TRANSFORMATION_SCRIPT } from './transformationTab';
 import { CodeEditor as BaseCodeEditor } from '@/components/codeEditor/codeEditor';
 import { CodeLanguages } from '@/designer-components/codeEditor/types';
 import { useAvailableConstantsMetadata } from '@/utils/metadata/hooks';
@@ -30,21 +29,13 @@ const { Text } = Typography;
 export interface IBodyTabProps {
   body: IRequestBody;
   onChange: (body: IRequestBody) => void;
-  /** Response transformation config — persisted alongside the request, edited under the "Transformation" body option. */
-  transformation?: IResponseTransformationConfiguration;
-  onTransformationChange?: (transformation: IResponseTransformationConfiguration) => void;
   expressionContext: ExpressionContext;
 }
 
-// "transformation" is a view-only selection in the body type bar — it edits the response
-// transformation (a sibling of the request body) rather than a real request body type, so it
-// is tracked in local state and never written to body.type.
-type BodyView = BodyType | 'transformation';
-
-export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onTransformationChange, expressionContext }) => {
+export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, expressionContext }) => {
   const { styles } = useStyles();
   const [jsonError, setJsonError] = useState<string | null>(null);
-  const [view, setView] = useState<BodyView>(body.type);
+  const [view, setView] = useState<BodyType>(body.type);
 
   // Remembers each body type's content while the user toggles between formats, so switching tabs
   // never wipes what was entered. Seeded from the incoming body; entries are only emptied by the
@@ -73,12 +64,9 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
     label: p.path,
   }));
 
-  const handleViewChange = (next: BodyView): void => {
+  const handleViewChange = (next: BodyType): void => {
     setView(next);
-    // Only real body types mutate the request body; "transformation" leaves the body untouched.
-    if (next !== 'transformation') {
-      handleTypeChange(next);
-    }
+    handleTypeChange(next);
   };
 
   const handleTypeChange = (type: BodyType): void => {
@@ -97,10 +85,6 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
   };
 
   const handleClear = (): void => {
-    if (view === 'transformation') {
-      onTransformationChange?.({ enabled: false, script: '' });
-      return;
-    }
     const type = view;
     setContentByType((prev) => ({ ...prev, [type]: defaultContentFor(type) }));
     let clearedBody: IRequestBody;
@@ -271,20 +255,6 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
   };
 
   const renderBodyContent = (): JSX.Element | null => {
-    if (view === 'transformation') {
-      return (
-        <TransformationTab
-          {...(transformation !== undefined ? { value: transformation } : {})}
-          onChange={(t) => {
-            const seeded = t.enabled && !t.script.trim()
-              ? { ...t, script: DEFAULT_TRANSFORMATION_SCRIPT }
-              : t;
-            onTransformationChange?.(seeded);
-          }}
-        />
-      );
-    }
-
     switch (body.type) {
       case 'none':
         return <Text type="secondary">This request does not have a body.</Text>;
@@ -371,12 +341,9 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
     }
   };
 
-  // Whether the current view has anything worth clearing (drives the Clear button's enabled state).
-  const hasContent = view === 'transformation'
-    ? Boolean(transformation?.enabled || transformation?.script.trim())
-    : typeof body.content === 'string'
-      ? Boolean(body.content.trim())
-      : Array.isArray(body.content) && body.content.length > 0;
+  const hasContent = typeof body.content === 'string'
+    ? Boolean(body.content.trim())
+    : Array.isArray(body.content) && body.content.length > 0;
 
   return (
     <div className={styles.bodyEditor}>
@@ -387,7 +354,6 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onT
           <Radio.Button value="form-data">form-data</Radio.Button>
           <Radio.Button value="x-www-form-urlencoded">x-www-form-urlencoded</Radio.Button>
           <Radio.Button value="raw">raw</Radio.Button>
-          <Radio.Button value="transformation">Transformation</Radio.Button>
         </Radio.Group>
         <Button
           size="small"

--- a/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
@@ -1,0 +1,387 @@
+import React, { FC, useState } from 'react';
+import { AutoComplete, Button, Checkbox, Radio, Select, Space, Table, Tooltip, Typography } from 'antd';
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { BodyType, IFormDataField, IRequestBody, IResponseTransformationConfiguration, RawBodySubType } from './models';
+import { ExpressionContext } from '@/components/expressionEditor';
+import { TableValueEditor } from './tableValueEditor';
+import { TransformationTab } from './transformationTab';
+import { CodeEditor as BaseCodeEditor } from '@/components/codeEditor/codeEditor';
+import { CodeLanguages } from '@/designer-components/codeEditor/types';
+import { useAvailableConstantsMetadata } from '@/utils/metadata/hooks';
+import { DataTypes } from '@/interfaces';
+import { asPropertiesArray } from '@/interfaces/metadata';
+import { useMetadataOrUndefined } from '@/providers/metadata';
+import { useStyles } from './styles';
+
+// The raw JavaScript body is executed as a script that returns the payload, so its wrapper reads
+// `async (): Promise<any>` (returning any value, not void). Stable reference avoids editor rebuilds.
+const JS_BODY_RESULT_TYPE = { dataType: DataTypes.any };
+
+const RAW_SUB_TYPES: { value: RawBodySubType; label: string; language: CodeLanguages }[] = [
+  { value: 'text', label: 'Text', language: 'plain_text' },
+  { value: 'json', label: 'JSON', language: 'json' },
+  { value: 'xml', label: 'XML', language: 'xml' },
+  { value: 'html', label: 'HTML', language: 'html' },
+  { value: 'javascript', label: 'JavaScript', language: 'javascript' },
+];
+
+const { Text } = Typography;
+
+export interface IBodyTabProps {
+  body: IRequestBody;
+  onChange: (body: IRequestBody) => void;
+  /** Response transformation config — persisted alongside the request, edited under the "Transformation" body option. */
+  transformation?: IResponseTransformationConfiguration;
+  onTransformationChange?: (transformation: IResponseTransformationConfiguration) => void;
+  expressionContext: ExpressionContext;
+}
+
+// "transformation" is a view-only selection in the body type bar — it edits the response
+// transformation (a sibling of the request body) rather than a real request body type, so it
+// is tracked in local state and never written to body.type.
+type BodyView = BodyType | 'transformation';
+
+export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, transformation, onTransformationChange, expressionContext }) => {
+  const { styles } = useStyles();
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [view, setView] = useState<BodyView>(body.type);
+
+  // Remembers each body type's content while the user toggles between formats, so switching tabs
+  // never wipes what was entered. Seeded from the incoming body; entries are only emptied by the
+  // explicit Clear button. The persisted request still carries a single `content` (the active type).
+  const [contentByType, setContentByType] = useState<Partial<Record<BodyType, IRequestBody['content']>>>(
+    () => ({ [body.type]: body.content }),
+  );
+
+  // Remember the raw sub-type (Text/JSON/XML/…) so leaving and returning to the "raw" tab keeps the
+  // last choice instead of resetting to "text".
+  const [lastRawSubType, setLastRawSubType] = useState<RawBodySubType>(body.rawSubType ?? 'text');
+
+  const defaultContentFor = (type: BodyType): IRequestBody['content'] =>
+    type === 'form-data' || type === 'x-www-form-urlencoded' ? ([] as IFormDataField[]) : '';
+
+  // Standard constants exposed to the executable JavaScript body (data, globalState, http, form,
+  // pageContext, selectedRow, …). `response` is intentionally excluded — it doesn't exist yet when
+  // the request body is being built. Mirrors what the executer provides at runtime.
+  const jsBodyConstants = useAvailableConstantsMetadata({ addGlobalConstants: true });
+
+  // Properties of the model the host form is bound to (if any) — offered as autocomplete suggestions
+  // for form-data field keys. Undefined when there's no metadata context; free typing always works.
+  const metadataCtx = useMetadataOrUndefined();
+  const keyOptions = asPropertiesArray(metadataCtx?.metadata?.properties, []).map((p) => ({
+    value: p.path,
+    label: p.path,
+  }));
+
+  const handleViewChange = (next: BodyView): void => {
+    setView(next);
+    // Only real body types mutate the request body; "transformation" leaves the body untouched.
+    if (next !== 'transformation') {
+      handleTypeChange(next);
+    }
+  };
+
+  const handleTypeChange = (type: BodyType): void => {
+    // Restore the previously-entered content for this type instead of resetting it.
+    const stashed = contentByType[type];
+    const content = stashed !== undefined ? stashed : defaultContentFor(type);
+    const next: IRequestBody = { type, content };
+    if (type === 'raw') next.rawSubType = lastRawSubType;
+    onChange(next);
+    setJsonError(null);
+  };
+
+  const handleClear = (): void => {
+    if (view === 'transformation') {
+      onTransformationChange?.({ enabled: false, script: '' });
+      return;
+    }
+    const type = view;
+    const cleared = defaultContentFor(type);
+    setContentByType((prev) => ({ ...prev, [type]: cleared }));
+    onChange({ ...body, content: cleared });
+    setJsonError(null);
+  };
+
+  const handleRawSubTypeChange = (rawSubType: RawBodySubType): void => {
+    setLastRawSubType(rawSubType);
+    onChange({ ...body, rawSubType });
+  };
+
+  const handleJsonChange = (value: string): void => {
+    setContentByType((prev) => ({ ...prev, json: value }));
+    onChange({ ...body, content: value });
+
+    if (!value.trim()) {
+      setJsonError(null);
+      return;
+    }
+
+    try {
+      JSON.parse(value);
+      setJsonError(null);
+    } catch (err) {
+      setJsonError('Invalid JSON: ' + (err as Error).message);
+    }
+  };
+
+  const handleRawChange = (value: string): void => {
+    setContentByType((prev) => ({ ...prev, raw: value }));
+    onChange({ ...body, content: value });
+  };
+
+  const parseFormData = (): IFormDataField[] => {
+    const raw = body.content;
+    if (Array.isArray(raw)) return [...(raw as IFormDataField[])];
+    if (typeof raw === 'string') {
+      // Legacy storage: JSON-stringified array
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        return Array.isArray(parsed) ? (parsed as IFormDataField[]) : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  };
+
+  const updateFormData = (rows: IFormDataField[]): void => {
+    setContentByType((prev) => ({ ...prev, [body.type]: rows }));
+    onChange({ ...body, content: rows });
+  };
+
+  const handleFormDataAdd = (): void => {
+    const rows = parseFormData();
+    updateFormData([...rows, { key: '', value: '', enabled: true }]);
+  };
+
+  const handleFormDataUpdate = <K extends keyof IFormDataField>(
+    index: number,
+    field: K,
+    value: IFormDataField[K],
+  ): void => {
+    const rows = parseFormData();
+    rows[index] = { ...rows[index], [field]: value } as IFormDataField;
+    updateFormData(rows);
+  };
+
+  const handleFormDataDelete = (index: number): void => {
+    const rows = parseFormData();
+    updateFormData(rows.filter((_, i) => i !== index));
+  };
+
+  const renderFormDataTable = (): JSX.Element => {
+    const rows = parseFormData();
+
+    const columns = [
+      {
+        title: <Tooltip title="Include this field in the payload">Include</Tooltip>,
+        key: 'enabled',
+        width: '12%',
+        align: 'center' as const,
+        render: (_: unknown, row: IFormDataField, index: number) => (
+          <Checkbox
+            checked={row.enabled !== false}
+            onChange={(e) => handleFormDataUpdate(index, 'enabled', e.target.checked)}
+          />
+        ),
+      },
+      {
+        title: 'Key',
+        dataIndex: 'key',
+        key: 'key',
+        width: '30%',
+        render: (text: string, _: IFormDataField, index: number) => (
+          <AutoComplete
+            value={text}
+            options={keyOptions}
+            placeholder="Field name"
+            style={{ width: '100%' }}
+            // Suggest model properties but let the user type any key (free text).
+            filterOption={(input, option) => String(option?.value ?? '').toLowerCase().includes(input.toLowerCase())}
+            onChange={(value) => handleFormDataUpdate(index, 'key', value)}
+          />
+        ),
+      },
+      {
+        title: 'Value',
+        dataIndex: 'value',
+        key: 'value',
+        width: '43%',
+        render: (value: string, _: IFormDataField, index: number) => (
+          <TableValueEditor
+            value={value}
+            onChange={(v) => handleFormDataUpdate(index, 'value', v)}
+            context={expressionContext}
+            placeholder="Value or {{expression}}"
+          />
+        ),
+      },
+      {
+        title: '',
+        key: 'action',
+        width: '15%',
+        render: (_: unknown, __: IFormDataField, index: number) => (
+          <Button
+            type="text"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleFormDataDelete(index)}
+          />
+        ),
+      },
+    ];
+
+    return (
+      <>
+        <Table
+          dataSource={rows.map((row, index) => ({ ...row, rowKey: index }))}
+          columns={columns}
+          pagination={false}
+          size="small"
+          className={styles.requestTable}
+          rowKey="rowKey"
+          rowClassName={(record: IFormDataField) => (record.enabled === false ? styles.disabledRow : '')}
+        />
+        <Button
+          type="dashed"
+          icon={<PlusOutlined />}
+          onClick={handleFormDataAdd}
+          className={styles.addRowBtn}
+          block
+        >
+          Add Field
+        </Button>
+      </>
+    );
+  };
+
+  const renderBodyContent = (): JSX.Element | null => {
+    if (view === 'transformation') {
+      return (
+        <TransformationTab
+          {...(transformation !== undefined ? { value: transformation } : {})}
+          onChange={(t) => {
+            onTransformationChange?.(t);
+          }}
+        />
+      );
+    }
+
+    switch (body.type) {
+      case 'none':
+        return <Text type="secondary">This request does not have a body.</Text>;
+
+      case 'json': {
+        const jsonValue = typeof body.content === 'string'
+          ? body.content
+          : JSON.stringify(body.content, null, 2);
+        return (
+          <>
+            <div className={styles.codeEditorWrapper}>
+              <BaseCodeEditor
+                value={jsonValue}
+                onChange={(v) => handleJsonChange(v ?? '')}
+                language="json"
+                placeholder='{\n  "key": "value"\n}'
+                fileName="api-call-body.json"
+                wrapInTemplate={false}
+                style={{ height: 300 }}
+              />
+            </div>
+            {jsonError && <div className={styles.jsonError}>{jsonError}</div>}
+          </>
+        );
+      }
+
+      case 'form-data':
+        return (
+          <div className="form-data-table">
+            {renderFormDataTable()}
+          </div>
+        );
+
+      case 'x-www-form-urlencoded':
+        return (
+          <div className="urlencoded-table">
+            {renderFormDataTable()}
+          </div>
+        );
+
+      case 'raw': {
+        const activeSubType = body.rawSubType ?? 'text';
+        const subTypeMeta = (RAW_SUB_TYPES.find((s) => s.value === activeSubType) ?? RAW_SUB_TYPES[0])!;
+        // The JavaScript sub-type is executed at request time, so it gets the templated editor with
+        // exposed constants (like the Transformation tab). Other sub-types are sent as plain text.
+        const isExecutableJs = activeSubType === 'javascript';
+        return (
+          <>
+            <Space style={{ marginBottom: 8 }} size="small">
+              <Text type="secondary">Content type:</Text>
+              <Select<RawBodySubType>
+                value={activeSubType}
+                onChange={handleRawSubTypeChange}
+                options={RAW_SUB_TYPES.map((s) => ({ value: s.value, label: s.label }))}
+                style={{ width: 140 }}
+                size="small"
+              />
+            </Space>
+            {isExecutableJs && (
+              <Text type="secondary" style={{ display: 'block', marginBottom: 4 }}>
+                This script runs at request time and must <Text code>return</Text> the value to send as the body.
+              </Text>
+            )}
+            <div className={styles.codeEditorWrapper}>
+              <BaseCodeEditor
+                value={typeof body.content === 'string' ? body.content : ''}
+                onChange={(v) => handleRawChange(v ?? '')}
+                language={isExecutableJs ? 'javascript' : subTypeMeta.language}
+                placeholder={isExecutableJs ? 'return { /* payload */ };' : 'Enter raw request body'}
+                fileName={isExecutableJs ? 'expression' : `api-call-body.${activeSubType}`}
+                wrapInTemplate={isExecutableJs}
+                templateSettings={isExecutableJs ? { useAsyncDeclaration: true, functionName: 'getRequestBody' } : undefined}
+                availableConstants={isExecutableJs ? jsBodyConstants : undefined}
+                resultType={isExecutableJs ? JS_BODY_RESULT_TYPE : undefined}
+                style={{ height: 300 }}
+              />
+            </div>
+          </>
+        );
+      }
+
+      default:
+        return null;
+    }
+  };
+
+  // Whether the current view has anything worth clearing (drives the Clear button's enabled state).
+  const hasContent = view === 'transformation'
+    ? Boolean(transformation?.enabled || transformation?.script.trim())
+    : typeof body.content === 'string'
+      ? Boolean(body.content.trim())
+      : Array.isArray(body.content) && body.content.length > 0;
+
+  return (
+    <div className={styles.bodyEditor}>
+      <div className={styles.bodyTypeSelector} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Radio.Group value={view} onChange={(e) => handleViewChange(e.target.value as BodyView)}>
+          <Radio.Button value="none">none</Radio.Button>
+          <Radio.Button value="json">JSON</Radio.Button>
+          <Radio.Button value="form-data">form-data</Radio.Button>
+          <Radio.Button value="x-www-form-urlencoded">x-www-form-urlencoded</Radio.Button>
+          <Radio.Button value="raw">raw</Radio.Button>
+          <Radio.Button value="transformation">Transformation</Radio.Button>
+        </Radio.Group>
+        <Button
+          size="small"
+          icon={<DeleteOutlined />}
+          onClick={handleClear}
+          disabled={view === 'none' || !hasContent}
+        >
+          Clear
+        </Button>
+      </div>
+      {renderBodyContent()}
+    </div>
+  );
+};

--- a/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
@@ -16,6 +16,17 @@ import { useStyles } from './styles';
 // `async (): Promise<any>` (returning any value, not void). Stable reference avoids editor rebuilds.
 const JS_BODY_RESULT_TYPE = { dataType: DataTypes.any };
 
+const BODY_TYPES: { value: BodyType; label: string }[] = [
+  { value: 'none', label: 'none' },
+  { value: 'json', label: 'JSON' },
+  { value: 'form-data', label: 'form-data' },
+  { value: 'x-www-form-urlencoded', label: 'x-www-form-urlencoded' },
+  { value: 'raw', label: 'raw' },
+];
+
+const isBodyType = (value: unknown): value is BodyType =>
+  BODY_TYPES.some((t) => t.value === value);
+
 const RAW_SUB_TYPES: { value: RawBodySubType; label: string; language: CodeLanguages }[] = [
   { value: 'text', label: 'Text', language: 'plain_text' },
   { value: 'json', label: 'JSON', language: 'json' },
@@ -348,12 +359,16 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, expressionContext }
   return (
     <div className={styles.bodyEditor}>
       <div className={styles.bodyTypeSelector} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Radio.Group value={view} onChange={(e) => handleViewChange(e.target.value as BodyType)}>
-          <Radio.Button value="none">none</Radio.Button>
-          <Radio.Button value="json">JSON</Radio.Button>
-          <Radio.Button value="form-data">form-data</Radio.Button>
-          <Radio.Button value="x-www-form-urlencoded">x-www-form-urlencoded</Radio.Button>
-          <Radio.Button value="raw">raw</Radio.Button>
+        <Radio.Group
+          value={view}
+          onChange={(e) => {
+            const next: unknown = e.target.value;
+            if (isBodyType(next)) handleViewChange(next);
+          }}
+        >
+          {BODY_TYPES.map((t) => (
+            <Radio.Button key={t.value} value={t.value}>{t.label}</Radio.Button>
+          ))}
         </Radio.Group>
         <Button
           size="small"

--- a/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/bodyTab.tsx
@@ -348,7 +348,7 @@ export const BodyTab: FC<IBodyTabProps> = ({ body, onChange, expressionContext }
   return (
     <div className={styles.bodyEditor}>
       <div className={styles.bodyTypeSelector} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Radio.Group value={view} onChange={(e) => handleViewChange(e.target.value as BodyView)}>
+        <Radio.Group value={view} onChange={(e) => handleViewChange(e.target.value as BodyType)}>
           <Radio.Button value="none">none</Radio.Button>
           <Radio.Button value="json">JSON</Radio.Button>
           <Radio.Button value="form-data">form-data</Radio.Button>

--- a/shesha-reactjs/src/components/requestConfigModal/headersTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/headersTab.tsx
@@ -1,0 +1,107 @@
+import React, { FC } from 'react';
+import { Button, Input, Switch, Table } from 'antd';
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { IRequestHeader } from './models';
+import { ExpressionContext } from '@/components/expressionEditor';
+import { TableValueEditor } from './tableValueEditor';
+import { useStyles } from './styles';
+
+export interface IHeadersTabProps {
+  headers: IRequestHeader[];
+  onChange: (headers: IRequestHeader[]) => void;
+  expressionContext: ExpressionContext;
+}
+
+export const HeadersTab: FC<IHeadersTabProps> = ({ headers, onChange, expressionContext }) => {
+  const { styles } = useStyles();
+
+  const handleAdd = (): void => {
+    onChange([...headers, { key: '', value: '', enabled: true }]);
+  };
+
+  const handleUpdate = <K extends keyof IRequestHeader>(index: number, field: K, value: IRequestHeader[K]): void => {
+    const updated = [...headers];
+    updated[index] = { ...updated[index], [field]: value } as IRequestHeader;
+    onChange(updated);
+  };
+
+  const handleDelete = (index: number): void => {
+    onChange(headers.filter((_, i) => i !== index));
+  };
+
+  const columns = [
+    {
+      title: 'Key',
+      dataIndex: 'key',
+      key: 'key',
+      width: '35%',
+      render: (text: string, _: IRequestHeader, index: number) => (
+        <Input
+          value={text}
+          placeholder="Header name (e.g., Content-Type)"
+          onChange={(e) => handleUpdate(index, 'key', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: 'Value',
+      dataIndex: 'value',
+      key: 'value',
+      width: '45%',
+      render: (value: string, _record: IRequestHeader, index: number) => (
+        <TableValueEditor
+          value={value}
+          onChange={(v) => handleUpdate(index, 'value', v)}
+          context={expressionContext}
+          placeholder="Value or {{expression}}"
+        />
+      ),
+    },
+    {
+      title: 'Enabled',
+      dataIndex: 'enabled',
+      key: 'enabled',
+      width: '10%',
+      render: (checked: boolean, _: IRequestHeader, index: number) => (
+        <Switch
+          checked={checked}
+          onChange={(value) => handleUpdate(index, 'enabled', value)}
+        />
+      ),
+    },
+    {
+      title: '',
+      key: 'action',
+      width: '10%',
+      render: (_: unknown, __: IRequestHeader, index: number) => (
+        <Button
+          type="text"
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => handleDelete(index)}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.requestTable}>
+      <Table
+        dataSource={headers.map((header, index) => ({ ...header, rowKey: index }))}
+        columns={columns}
+        pagination={false}
+        size="small"
+        rowKey="rowKey"
+      />
+      <Button
+        type="dashed"
+        icon={<PlusOutlined />}
+        onClick={handleAdd}
+        className={styles.addRowBtn}
+        block
+      >
+        Add Header
+      </Button>
+    </div>
+  );
+};

--- a/shesha-reactjs/src/components/requestConfigModal/index.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/index.tsx
@@ -3,6 +3,7 @@ import { Modal, Tabs } from 'antd';
 import { ParamsTab } from './paramsTab';
 import { HeadersTab } from './headersTab';
 import { BodyTab } from './bodyTab';
+import { TransformationTab, DEFAULT_TRANSFORMATION_SCRIPT } from './transformationTab';
 import { IRequestConfig } from './models';
 import { useStyles } from './styles';
 import { ExpressionContext, buildExpressionContextFromPaths } from '@/components/expressionEditor';
@@ -131,9 +132,22 @@ export const RequestConfigModal: FC<IRequestConfigModalProps> = ({
                 <BodyTab
                   body={localConfig.body}
                   onChange={(body) => updateConfig({ body })}
-                  {...(localConfig.responseTransformation !== undefined ? { transformation: localConfig.responseTransformation } : {})}
-                  onTransformationChange={(responseTransformation) => updateConfig({ responseTransformation })}
                   expressionContext={expressionContext}
+                />
+              ),
+            },
+            {
+              key: 'transformation',
+              label: 'Transformation',
+              children: (
+                <TransformationTab
+                  {...(localConfig.responseTransformation !== undefined ? { value: localConfig.responseTransformation } : {})}
+                  onChange={(t) => {
+                    const seeded = t.enabled && !t.script.trim()
+                      ? { ...t, script: DEFAULT_TRANSFORMATION_SCRIPT }
+                      : t;
+                    updateConfig({ responseTransformation: seeded });
+                  }}
                 />
               ),
             },

--- a/shesha-reactjs/src/components/requestConfigModal/index.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/index.tsx
@@ -1,0 +1,148 @@
+import React, { FC, useState, useEffect, useRef, useMemo } from 'react';
+import { Modal, Tabs } from 'antd';
+import { ParamsTab } from './paramsTab';
+import { HeadersTab } from './headersTab';
+import { BodyTab } from './bodyTab';
+import { IRequestConfig } from './models';
+import { useStyles } from './styles';
+import { ExpressionContext, buildExpressionContextFromPaths } from '@/components/expressionEditor';
+import {
+  ExpressionContextTree,
+  buildExpressionContextFromMetadata,
+  mergeExpressionContexts,
+} from '@/components/expressionEditor/contextMetadata';
+import { useAsyncMemo } from '@/hooks/useAsyncMemo';
+import { useAvailableConstantsMetadata } from '@/utils/metadata/hooks';
+import { SheshaConstants } from '@/utils/metadata/standardProperties';
+import { useMetadataOrUndefined } from '@/providers/metadata';
+import { asPropertiesArray } from '@/interfaces/metadata';
+
+export interface IRequestConfigModalProps {
+  visible: boolean;
+  config: IRequestConfig;
+  onChange: (config: IRequestConfig) => void;
+  onClose: () => void;
+}
+
+const STANDARD_CONSTANTS = [SheshaConstants.application, SheshaConstants.form];
+
+export const RequestConfigModal: FC<IRequestConfigModalProps> = ({
+  visible,
+  config,
+  onChange,
+  onClose,
+}) => {
+  const { styles } = useStyles();
+  const cloneConfig = (c: IRequestConfig): IRequestConfig => ({
+    ...c,
+    params: [...c.params],
+    headers: [...c.headers],
+    body: { ...c.body },
+  });
+
+  const [localConfig, setLocalConfig] = useState<IRequestConfig>(() => cloneConfig(config));
+  const [activeTab, setActiveTab] = useState('params');
+  const wasVisible = useRef(false);
+
+  useEffect(() => {
+    if (visible && !wasVisible.current) {
+      setLocalConfig(cloneConfig(config));
+    }
+    wasVisible.current = visible;
+  }, [visible, config]);
+
+  // Build expression context once so all tabs share the same autocomplete data.
+  const availableConstants = useAvailableConstantsMetadata({ standardConstants: STANDARD_CONSTANTS });
+  const formMetadata = useMetadataOrUndefined()?.metadata;
+
+  const dataPathContext = useMemo<ExpressionContext>(() => {
+    const properties = asPropertiesArray(formMetadata?.properties, []);
+    const paths = properties.map((p) => p.path).filter(Boolean);
+    return buildExpressionContextFromPaths(paths, { additionalRoots: [] });
+  }, [formMetadata]);
+
+  const constantsContext = useAsyncMemo<ExpressionContextTree>(
+    () => buildExpressionContextFromMetadata(availableConstants),
+    [availableConstants],
+    {},
+  );
+
+  const expressionContext = useMemo<ExpressionContext>(
+    () => mergeExpressionContexts(dataPathContext, constantsContext ?? {}),
+    [dataPathContext, constantsContext],
+  );
+
+  const handleOk = (): void => {
+    onChange(localConfig);
+    onClose();
+  };
+
+  const handleCancel = (): void => {
+    setLocalConfig(cloneConfig(config));
+    onClose();
+  };
+
+  const updateConfig = (updates: Partial<IRequestConfig>): void => {
+    setLocalConfig((prev) => ({ ...prev, ...updates }));
+  };
+
+  return (
+    <Modal
+      title="Configure Request"
+      open={visible}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      width={800}
+      className={styles.requestConfigModal}
+      destroyOnClose
+      maskClosable={false}
+    >
+      <div className={styles.modalContent}>
+        <Tabs
+          activeKey={activeTab}
+          onChange={setActiveTab}
+          items={[
+            {
+              key: 'params',
+              label: 'Params',
+              children: (
+                <ParamsTab
+                  params={localConfig.params}
+                  onChange={(params) => updateConfig({ params })}
+                  expressionContext={expressionContext}
+                />
+              ),
+            },
+            {
+              key: 'headers',
+              label: 'Headers',
+              children: (
+                <HeadersTab
+                  headers={localConfig.headers}
+                  onChange={(headers) => updateConfig({ headers })}
+                  expressionContext={expressionContext}
+                />
+              ),
+            },
+            {
+              key: 'body',
+              label: 'Body',
+              children: (
+                <BodyTab
+                  body={localConfig.body}
+                  onChange={(body) => updateConfig({ body })}
+                  {...(localConfig.responseTransformation !== undefined ? { transformation: localConfig.responseTransformation } : {})}
+                  onTransformationChange={(responseTransformation) => updateConfig({ responseTransformation })}
+                  expressionContext={expressionContext}
+                />
+              ),
+            },
+          ]}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export * from './models';
+export * from './transformationRunner';

--- a/shesha-reactjs/src/components/requestConfigModal/models.ts
+++ b/shesha-reactjs/src/components/requestConfigModal/models.ts
@@ -1,0 +1,48 @@
+export type RequestValue = string;
+
+export interface IRequestParam {
+  key: string;
+  value: string;
+  description?: string;
+  enabled: boolean;
+}
+
+export interface IRequestHeader {
+  key: string;
+  value: string;
+  enabled: boolean;
+}
+
+export type BodyType = 'none' | 'json' | 'form-data' | 'x-www-form-urlencoded' | 'raw';
+
+export interface IFormDataField {
+  key: string;
+  value: string;
+  enabled: boolean;
+}
+
+export type RawBodySubType = 'text' | 'json' | 'xml' | 'html' | 'javascript';
+
+export interface IRequestBody {
+  type: BodyType;
+  content: string | Record<string, unknown> | IFormDataField[];
+  rawSubType?: RawBodySubType;
+}
+
+/**
+ * Optional transformation applied to the API response before it is displayed/consumed.
+ * The original response is left unchanged; when the transformation is disabled or fails,
+ * the original response is returned unchanged.
+ */
+export interface IResponseTransformationConfiguration {
+  enabled: boolean;
+  /** JavaScript body that receives `input` (the response) and returns the transformed value. */
+  script: string;
+}
+
+export interface IRequestConfig {
+  params: IRequestParam[];
+  headers: IRequestHeader[];
+  body: IRequestBody;
+  responseTransformation?: IResponseTransformationConfiguration;
+}

--- a/shesha-reactjs/src/components/requestConfigModal/models.ts
+++ b/shesha-reactjs/src/components/requestConfigModal/models.ts
@@ -23,11 +23,12 @@ export interface IFormDataField {
 
 export type RawBodySubType = 'text' | 'json' | 'xml' | 'html' | 'javascript';
 
-export interface IRequestBody {
-  type: BodyType;
-  content: string | Record<string, unknown> | IFormDataField[];
-  rawSubType?: RawBodySubType;
-}
+export type IRequestBody =
+  { type: 'none'; content: string } |
+  { type: 'json'; content: string } |
+  { type: 'form-data'; content: IFormDataField[] } |
+  { type: 'x-www-form-urlencoded'; content: IFormDataField[] } |
+  { type: 'raw'; content: string; rawSubType: RawBodySubType };
 
 /**
  * Optional transformation applied to the API response before it is displayed/consumed.

--- a/shesha-reactjs/src/components/requestConfigModal/paramsTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/paramsTab.tsx
@@ -1,0 +1,133 @@
+import React, { FC } from 'react';
+import { Button, Input, Switch, Table, Tooltip } from 'antd';
+import { DeleteOutlined, PlusOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { IRequestParam } from './models';
+import { ExpressionContext } from '@/components/expressionEditor';
+import { TableValueEditor } from './tableValueEditor';
+import { useStyles } from './styles';
+
+export interface IParamsTabProps {
+  params: IRequestParam[];
+  onChange: (params: IRequestParam[]) => void;
+  expressionContext: ExpressionContext;
+}
+
+export const ParamsTab: FC<IParamsTabProps> = ({ params, onChange, expressionContext }) => {
+  const { styles } = useStyles();
+
+  const handleAdd = (): void => {
+    onChange([...params, { key: '', value: '', description: '', enabled: true }]);
+  };
+
+  const handleUpdate = <K extends keyof IRequestParam>(index: number, field: K, value: IRequestParam[K]): void => {
+    const updated = [...params];
+    updated[index] = { ...updated[index], [field]: value } as IRequestParam;
+    onChange(updated);
+  };
+
+  const handleDelete = (index: number): void => {
+    onChange(params.filter((_, i) => i !== index));
+  };
+
+  const columns = [
+    {
+      title: 'Key',
+      dataIndex: 'key',
+      key: 'key',
+      width: '25%',
+      render: (text: string, _: IRequestParam, index: number) => (
+        <Input
+          value={text}
+          placeholder="Parameter name"
+          onChange={(e) => handleUpdate(index, 'key', e.target.value)}
+        />
+      ),
+    },
+    {
+      title: 'Value',
+      dataIndex: 'value',
+      key: 'value',
+      width: '30%',
+      render: (value: string, record: IRequestParam, index: number) => {
+        const isPropertiesParam = record.key.toLowerCase() === 'properties';
+        return (
+          <TableValueEditor
+            value={value}
+            onChange={(v) => handleUpdate(index, 'value', v)}
+            context={expressionContext}
+            placeholder={isPropertiesParam ? 'firstName lastName address { city }' : 'Value or {{expression}}'}
+          />
+        );
+      },
+    },
+    {
+      title: () => (
+        <span>
+          Description{' '}
+          <Tooltip title="For 'properties' parameter, use GraphQL-like syntax: firstName lastName address { addressLine1 }">
+            <InfoCircleOutlined style={{ color: '#1890ff' }} />
+          </Tooltip>
+        </span>
+      ),
+      dataIndex: 'description',
+      key: 'description',
+      width: '25%',
+      render: (text: string, record: IRequestParam, index: number) => {
+        const isPropertiesParam = record.key.toLowerCase() === 'properties';
+        return (
+          <Input
+            value={text}
+            placeholder={isPropertiesParam ? 'GraphQL-like property selection' : 'Optional description'}
+            onChange={(e) => handleUpdate(index, 'description', e.target.value)}
+          />
+        );
+      },
+    },
+    {
+      title: 'Enabled',
+      dataIndex: 'enabled',
+      key: 'enabled',
+      width: '10%',
+      render: (checked: boolean, _: IRequestParam, index: number) => (
+        <Switch
+          checked={checked}
+          onChange={(value) => handleUpdate(index, 'enabled', value)}
+        />
+      ),
+    },
+    {
+      title: '',
+      key: 'action',
+      width: '10%',
+      render: (_: unknown, __: IRequestParam, index: number) => (
+        <Button
+          type="text"
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => handleDelete(index)}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.requestTable}>
+      <Table
+        dataSource={params.map((param, index) => ({ ...param, rowKey: index }))}
+        columns={columns}
+        pagination={false}
+        size="small"
+        rowKey="rowKey"
+      />
+      <Button
+        type="dashed"
+        icon={<PlusOutlined />}
+        onClick={handleAdd}
+        className={styles.addRowBtn}
+        block
+      >
+        Add Parameter
+      </Button>
+    </div>
+  );
+};

--- a/shesha-reactjs/src/components/requestConfigModal/styles.ts
+++ b/shesha-reactjs/src/components/requestConfigModal/styles.ts
@@ -1,0 +1,121 @@
+import { createStyles } from '@/styles';
+
+export const useStyles = createStyles(({ css, cx, prefixCls }) => {
+  const requestConfigModal = cx(`${prefixCls}-request-config-modal`, css`
+    .ant-modal-body {
+      max-height: 600px;
+      overflow-y: auto;
+    }
+  `);
+
+  const modalContent = cx(`${prefixCls}-request-config-modal-content`, css`
+    .ant-tabs-nav {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background: #fff;
+      margin-bottom: 16px;
+    }
+
+    .ant-tabs-content {
+      min-height: 400px;
+    }
+  `);
+
+  const requestTable = cx(`${prefixCls}-request-table`, css`
+    margin-bottom: 16px;
+
+    .ant-table-thead > tr > th {
+      background: #fafafa;
+      font-weight: 600;
+      padding: 12px 8px;
+    }
+
+    .ant-table-tbody > tr > td {
+      padding: 8px;
+    }
+  `);
+
+  const actionCell = cx(`${prefixCls}-action-cell`, css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .ant-switch {
+      margin-right: 8px;
+    }
+  `);
+
+  const addRowBtn = cx(`${prefixCls}-add-row-btn`, css`
+    margin-top: 8px;
+  `);
+
+  const bodyTypeSelector = cx(`${prefixCls}-body-type-selector`, css`
+    margin-bottom: 16px;
+  `);
+
+  const bodyEditor = cx(`${prefixCls}-body-editor`, css`
+    .code-editor {
+      border: 1px solid #d9d9d9;
+      border-radius: 2px;
+      min-height: 300px;
+
+      textarea {
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+        font-size: 13px;
+        line-height: 1.5;
+      }
+    }
+
+    .form-data-table,
+    .urlencoded-table {
+      margin-top: 16px;
+    }
+
+    .graphql-editor {
+      .ant-tabs-nav {
+        margin-bottom: 16px;
+      }
+
+      .ant-tabs-content {
+        padding: 8px 0;
+      }
+    }
+  `);
+
+  const jsonError = cx(`${prefixCls}-json-error`, css`
+    margin-top: 8px;
+    color: #ff4d4f;
+    font-size: 12px;
+  `);
+
+  const codeEditorWrapper = cx(`${prefixCls}-code-editor-wrapper`, css`
+    border: 1px solid #d9d9d9;
+    border-radius: 2px;
+    overflow: hidden;
+  `);
+
+  // Dim form-data rows that are excluded from the payload (checkbox unticked). Only the Key and
+  // Value cells are dimmed (columns 2 and 3); the Include checkbox and delete action stay fully
+  // opaque so they remain easy to interact with. (Dimming the whole <tr> would trap children in a
+  // stacking context and prevent restoring their opacity.)
+  const disabledRow = cx(`${prefixCls}-disabled-row`, css`
+    td:nth-child(2),
+    td:nth-child(3) {
+      opacity: 0.45;
+    }
+  `);
+
+  return {
+    requestConfigModal,
+    modalContent,
+    requestTable,
+    actionCell,
+    addRowBtn,
+    bodyTypeSelector,
+    bodyEditor,
+    jsonError,
+    codeEditorWrapper,
+    disabledRow,
+  };
+});

--- a/shesha-reactjs/src/components/requestConfigModal/tableValueEditor.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/tableValueEditor.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react';
+import { ExpressionEditor, ExpressionContext } from '@/components/expressionEditor';
+
+export interface ITableValueEditorProps {
+  value: string;
+  onChange: (v: string) => void;
+  context: ExpressionContext;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export const TableValueEditor: FC<ITableValueEditorProps> = ({
+  value,
+  onChange,
+  context,
+  placeholder,
+  disabled,
+}) => (
+  <ExpressionEditor
+    value={value}
+    onChange={onChange}
+    context={context}
+    placeholder={placeholder}
+    disabled={disabled}
+    focusRows={6}
+  />
+);

--- a/shesha-reactjs/src/components/requestConfigModal/transformationRunner.ts
+++ b/shesha-reactjs/src/components/requestConfigModal/transformationRunner.ts
@@ -1,0 +1,66 @@
+/**
+ * Execution of a user-authored response-transformation script.
+ *
+ * The script is a JavaScript function body that must `return` the transformed value. It runs as a
+ * standard Shesha async script, so it has access to the same constants as every other code editor in
+ * the designer — `globalState`, `pageContext`, `http`, `moment`, `form`, `data` (form data),
+ * `selectedRow`, etc. — plus `response`, the raw API response being transformed. Because it is async,
+ * scripts may `await` (e.g. a follow-up `http` call). The available constants are supplied by the
+ * caller through the `context` argument (typically the object returned by `useAvailableConstantsData`,
+ * with `response` layered in).
+ */
+
+// The AsyncFunction constructor isn't a global binding, so derive it from an async arrow.
+const AsyncFunction = (async () => {
+  // noop
+}).constructor as FunctionConstructor;
+
+export interface ITransformationResult {
+  success: boolean;
+  output?: unknown;
+  error?: string;
+}
+
+/**
+ * Static validation of a transformation script, independent of any input.
+ * Returns an error message, or null when the script passes validation.
+ */
+export const validateTransformationScript = (script: string): string | null => {
+  if (!script || !script.trim()) {
+    return 'Transformation script cannot be empty when transformation is enabled.';
+  }
+  if (!/\breturn\b/.test(script)) {
+    return 'Transformation script must return a value.';
+  }
+  return null;
+};
+
+/**
+ * Executes the transformation script against the given execution context.
+ * Never throws — all failures are reported via the returned result so callers can never crash.
+ */
+export const executeResponseTransformation = async (script: string, context: object): Promise<ITransformationResult> => {
+  const validationError = validateTransformationScript(script);
+  if (validationError) {
+    return { success: false, error: validationError };
+  }
+
+  let output: unknown;
+  try {
+    // Mirrors Shesha's standard async `executeScript`: the context exposes the available constants
+    // (and `response`) via `with(context)`; references to anything not in the context fall through
+    // to the real global scope (JSON, Math, etc.). Inlined rather than imported so this module stays
+    // dependency-free and unit-testable (the test runner doesn't resolve the `@/` alias).
+    // eslint-disable-next-line no-new-func
+    const fn = new AsyncFunction('context', `with(context) {\n${script}\n}`) as (ctx: object) => Promise<unknown>;
+    output = await fn(context);
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (output === undefined) {
+    return { success: false, error: 'Transformation script did not return a value.' };
+  }
+
+  return { success: true, output };
+};

--- a/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
@@ -17,7 +17,7 @@ const { Text } = Typography;
 // isn't rebuilt each render.
 const RESULT_TYPE = { dataType: DataTypes.any };
 
-const DEFAULT_SCRIPT = `return {
+export const DEFAULT_TRANSFORMATION_SCRIPT = `return {
     fullName: response.firstName + " " + response.lastName,
     email: response.email
 };`;
@@ -49,8 +49,7 @@ export const TransformationTab: FC<ITransformationTabProps> = ({ value, onChange
   };
 
   const handleEnabledChange = (checked: boolean): void => {
-    // Seed an example the first time it is enabled with an empty script, for convenience.
-    update({ enabled: checked, script: checked && !script.trim() ? DEFAULT_SCRIPT : script });
+    update({ enabled: checked });
   };
 
   const handleScriptChange = (next: string): void => {
@@ -78,7 +77,7 @@ export const TransformationTab: FC<ITransformationTabProps> = ({ value, onChange
                 value={script}
                 onChange={(v) => handleScriptChange(v ?? '')}
                 language="javascript"
-                placeholder={DEFAULT_SCRIPT}
+                placeholder={DEFAULT_TRANSFORMATION_SCRIPT}
                 fileName="expression"
                 wrapInTemplate
                 templateSettings={{ useAsyncDeclaration: true, functionName: 'transformResponse' }}

--- a/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
@@ -1,0 +1,96 @@
+import React, { FC, useCallback } from 'react';
+import { Space, Switch, Tooltip, Typography } from 'antd';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { CodeEditor as BaseCodeEditor } from '@/components/codeEditor/codeEditor';
+import { IResponseTransformationConfiguration } from './models';
+import { validateTransformationScript } from './transformationRunner';
+import { useAvailableConstantsMetadata } from '@/utils/metadata/hooks';
+import { IObjectMetadataBuilder } from '@/utils/metadata/metadataBuilder';
+import { DataTypes } from '@/interfaces';
+import { useStyles } from './styles';
+
+const { Text } = Typography;
+
+// The transformation returns an arbitrary value, so the editor's wrapper should read
+// `async (): Promise<any>`. Without this it defaults to `Promise<void>`, which makes Monaco flag
+// `return { ... }` as "not assignable to type 'void'". Stable reference so the editor environment
+// isn't rebuilt each render.
+const RESULT_TYPE = { dataType: DataTypes.any };
+
+const DEFAULT_SCRIPT = `return {
+    fullName: response.firstName + " " + response.lastName,
+    email: response.email
+};`;
+
+export interface ITransformationTabProps {
+  value?: IResponseTransformationConfiguration;
+  onChange: (value: IResponseTransformationConfiguration) => void;
+}
+
+export const TransformationTab: FC<ITransformationTabProps> = ({ value, onChange }) => {
+  const { styles } = useStyles();
+
+  const enabled = value?.enabled ?? false;
+  const script = value?.script ?? '';
+
+  // Declares the variables the script editor exposes for IntelliSense. We expose the standard
+  // Shesha constants (globalState, pageContext, http, moment, form, data, selectedRow, etc. — the
+  // same set as every other code editor) plus `response`, the raw API response being transformed.
+  // These mirror what `useApiCallAction` provides at runtime via `useAvailableConstantsData`.
+  // `response` is typed `any` because its shape is dynamic. `onBuild` is memoised so the editor
+  // environment isn't rebuilt on every render.
+  const onBuildConstants = useCallback((builder: IObjectMetadataBuilder) => {
+    builder.addAny('response', 'The raw API response returned by this call');
+  }, []);
+  const availableConstants = useAvailableConstantsMetadata({ addGlobalConstants: true, onBuild: onBuildConstants });
+
+  const update = (changes: Partial<IResponseTransformationConfiguration>): void => {
+    onChange({ enabled, script, ...changes });
+  };
+
+  const handleEnabledChange = (checked: boolean): void => {
+    // Seed an example the first time it is enabled with an empty script, for convenience.
+    update({ enabled: checked, script: checked && !script.trim() ? DEFAULT_SCRIPT : script });
+  };
+
+  const handleScriptChange = (next: string): void => {
+    update({ script: next });
+  };
+
+  const scriptValidation = enabled ? validateTransformationScript(script) : null;
+
+  return (
+    <div className={styles.bodyEditor}>
+      <Space direction="vertical" size="small" style={{ width: '100%' }}>
+        <Space>
+          <Switch checked={enabled} onChange={handleEnabledChange} />
+          <Text strong>Enable Transformation</Text>
+          <Tooltip title="Reshape the API response before it's used. The response is available as `response`, plus standard constants (globalState, pageContext, http, form, data). Return the transformed value.">
+            <InfoCircleOutlined style={{ color: 'rgba(0, 0, 0, 0.45)', cursor: 'help' }} />
+          </Tooltip>
+        </Space>
+
+        {enabled && (
+          <div>
+            <Text type="secondary">Transformation script</Text>
+            <div className={styles.codeEditorWrapper}>
+              <BaseCodeEditor
+                value={script}
+                onChange={(v) => handleScriptChange(v ?? '')}
+                language="javascript"
+                placeholder={DEFAULT_SCRIPT}
+                fileName="expression"
+                wrapInTemplate
+                templateSettings={{ useAsyncDeclaration: true, functionName: 'transformResponse' }}
+                availableConstants={availableConstants}
+                resultType={RESULT_TYPE}
+                style={{ height: 280 }}
+              />
+            </div>
+            {scriptValidation && <div className={styles.jsonError}>{scriptValidation}</div>}
+          </div>
+        )}
+      </Space>
+    </div>
+  );
+};

--- a/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
@@ -17,10 +17,7 @@ const { Text } = Typography;
 // isn't rebuilt each render.
 const RESULT_TYPE = { dataType: DataTypes.any };
 
-export const DEFAULT_TRANSFORMATION_SCRIPT = `return {
-    fullName: response.firstName + " " + response.lastName,
-    email: response.email
-};`;
+export const DEFAULT_TRANSFORMATION_SCRIPT = `return response;`;
 
 export interface ITransformationTabProps {
   value?: IResponseTransformationConfiguration;

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/index.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/index.tsx
@@ -43,6 +43,7 @@ import { KeyInformationBarColumnsWrapper } from "./keyInformationBarColumns";
 import { SizableColumnsConfigWrapper } from "./sizableColumnsConfig";
 import { LayerSelectorSettingsModalWrapper } from "./layerSelectorSettingsModal";
 import { ThreeStateSwitchWrapper } from "./threeStateSwitch";
+import { RequestConfigButtonWrapper } from "./requestConfigButton";
 import { SectionSeparatorWrapper } from "./sectionSeparator";
 import { UnwrapCodeEvaluators } from "@/providers/form/models";
 
@@ -93,6 +94,7 @@ export const editorRegistry: EditorDictionary = {
   Password: PasswordWrapper,
   date: DateWrapper,
   layerSelectorSettingsModal: LayerSelectorSettingsModalWrapper,
+  requestConfigButton: RequestConfigButtonWrapper,
   // TODO: check usages and remove or implement wrapper
   // settingsInput: undefined,
   endpointsAutocomplete: EndpointsAutocompleteWrapper,

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/requestConfigButton.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/requestConfigButton.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from 'react';
+import { IRequestConfigButtonSettingsInputProps } from '@/designer-components/settingsInput/interfaces';
+import { RequestConfigButton } from '@/designer-components/requestConfigButton';
+import { IRequestConfig } from '@/components/requestConfigModal';
+
+export const RequestConfigButtonWrapper: FC<IRequestConfigButtonSettingsInputProps> = (props) => {
+  return (
+    <RequestConfigButton
+      {...(props.value !== undefined ? { value: props.value as IRequestConfig } : {})}
+      {...(props.onChange !== undefined ? { onChange: props.onChange as (value: IRequestConfig) => void } : {})}
+      {...(typeof props.readOnly === 'boolean' ? { readOnly: props.readOnly } : {})}
+    />
+  );
+};

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/requestConfigButton.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/requestConfigButton.tsx
@@ -3,11 +3,17 @@ import { IRequestConfigButtonSettingsInputProps } from '@/designer-components/se
 import { RequestConfigButton } from '@/designer-components/requestConfigButton';
 import { IRequestConfig } from '@/components/requestConfigModal';
 
+const isIRequestConfig = (v: unknown): v is IRequestConfig =>
+  typeof v === 'object' && v !== null &&
+  Array.isArray((v as IRequestConfig).params) &&
+  Array.isArray((v as IRequestConfig).headers) &&
+  typeof (v as IRequestConfig).body === 'object';
+
 export const RequestConfigButtonWrapper: FC<IRequestConfigButtonSettingsInputProps> = (props) => {
   return (
     <RequestConfigButton
-      {...(props.value !== undefined ? { value: props.value as IRequestConfig } : {})}
-      {...(props.onChange !== undefined ? { onChange: props.onChange as (value: IRequestConfig) => void } : {})}
+      {...(isIRequestConfig(props.value) ? { value: props.value } : {})}
+      onChange={(v: IRequestConfig) => props.onChange?.(v)}
       {...(typeof props.readOnly === 'boolean' ? { readOnly: props.readOnly } : {})}
     />
   );

--- a/shesha-reactjs/src/designer-components/requestConfigButton/index.tsx
+++ b/shesha-reactjs/src/designer-components/requestConfigButton/index.tsx
@@ -1,0 +1,73 @@
+import React, { FC, useState } from 'react';
+import { Button } from 'antd';
+import { SettingOutlined } from '@ant-design/icons';
+import { RequestConfigModal, IRequestConfig } from '@/components/requestConfigModal';
+
+export interface IRequestConfigButtonProps {
+  value?: IRequestConfig;
+  onChange?: (value: IRequestConfig) => void;
+  readOnly?: boolean;
+}
+
+export const RequestConfigButton: FC<IRequestConfigButtonProps> = ({
+  value,
+  onChange,
+  readOnly,
+}) => {
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const currentConfig: IRequestConfig = value || {
+    params: [],
+    headers: [],
+    body: { type: 'none', content: '' },
+  };
+
+  const handleOpenModal = (): void => {
+    setModalVisible(true);
+  };
+
+  const handleModalChange = (config: IRequestConfig): void => {
+    onChange?.(config);
+  };
+
+  const handleModalClose = (): void => {
+    setModalVisible(false);
+  };
+
+  const getConfigSummary = (): string => {
+    const paramsCount = currentConfig.params.filter((p) => p.enabled).length || 0;
+    const headersCount = currentConfig.headers.filter((h) => h.enabled).length || 0;
+    const hasBody = currentConfig.body.type !== 'none';
+
+    const parts = [];
+    if (paramsCount > 0) parts.push(`${paramsCount} param${paramsCount > 1 ? 's' : ''}`);
+    if (headersCount > 0) parts.push(`${headersCount} header${headersCount > 1 ? 's' : ''}`);
+    if (hasBody) parts.push(`body: ${currentConfig.body.type}`);
+
+    return parts.length > 0 ? parts.join(', ') : 'Not configured';
+  };
+
+  return (
+    <>
+      <Button
+        icon={<SettingOutlined />}
+        onClick={handleOpenModal}
+        disabled={readOnly ?? false}
+        block
+      >
+        Configure Request
+      </Button>
+      <div style={{ marginTop: 8, fontSize: 12, color: '#8c8c8c' }}>
+        {getConfigSummary()}
+      </div>
+      <RequestConfigModal
+        visible={modalVisible}
+        config={currentConfig}
+        onChange={handleModalChange}
+        onClose={handleModalClose}
+      />
+    </>
+  );
+};
+
+export default RequestConfigButton;

--- a/shesha-reactjs/src/designer-components/settingsInput/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/settingsInput/interfaces.ts
@@ -460,6 +460,12 @@ export interface ILayerSelectorSettingsInputProps extends ISettingsInputBase<ILa
   settings?: FormMarkup | undefined;
 }
 
+// Request Config Button
+export interface IRequestConfigButtonSettingsInputProps extends ISettingsInputBase {
+  type: 'requestConfigButton';
+}
+export const isRequestConfigButtonProps = (value: ISettingsInputBase): value is IRequestConfigButtonSettingsInputProps => value.type === 'requestConfigButton';
+
 // Common styling props that can be applied to multiple components
 export interface ICommonStylingProps {
   variant?: 'borderless' | 'filled' | 'outlined' | undefined;
@@ -513,6 +519,7 @@ export type BaseInputProps =
   ISizableColumnsConfigSettingsInputProps |
   ILayerSelectorSettingsInputProps |
   IThreeStateSwitchSettingsInputProps |
+  IRequestConfigButtonSettingsInputProps |
   ISectionSeparatorSettingsInputProps
 ;
 

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -19,7 +19,7 @@ import { IDictionary } from '@/interfaces';
 // already resolved them before the executer runs. Legacy configs may still store an IPropertySetting
 // object — handle that transparently so old configurations keep working.
 const resolveRequestValue = (raw: unknown): string => {
-  if (!raw) return '';
+  if (raw === null || raw === undefined || raw === '') return '';
   if (typeof raw === 'object') {
     const obj = raw as Record<string, unknown>;
     return obj['_mode'] === 'code' ? String(obj['_code'] ?? '') : String(obj['_value'] ?? '');
@@ -116,6 +116,13 @@ const applyResponseTransformation = async (
 
 const isGlobalUrl = (url: string): boolean => {
   return !isNullOrWhiteSpace(url) && Boolean(url.match(/^(http|ftp|https):\/\//gi));
+};
+
+const hasHeader = (headers: Record<string, string>, name: string): boolean =>
+  Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
+
+const setHeaderIfMissing = (headers: Record<string, string>, name: string, value: string): void => {
+  if (!hasHeader(headers, name)) headers[name] = value;
 };
 
 const prepareUrlAndData = (url: string, verb: string, parameters: IDictionary<string>): { url: string; data: IDictionary<string> | undefined } => {
@@ -225,9 +232,7 @@ export const useApiCallAction = (): void => {
               } catch {
                 requestBody = requestConfig.body.content;
               }
-              if (!finalHeaders['Content-Type']) {
-                finalHeaders['Content-Type'] = 'application/json';
-              }
+              setHeaderIfMissing(finalHeaders, 'Content-Type', 'application/json');
               break;
             case 'form-data':
             case 'x-www-form-urlencoded':
@@ -249,15 +254,15 @@ export const useApiCallAction = (): void => {
                   }
                   return acc;
                 }, {});
-                if (requestConfig.body.type === 'x-www-form-urlencoded' && !finalHeaders['Content-Type']) {
-                  finalHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+                if (requestConfig.body.type === 'x-www-form-urlencoded') {
+                  setHeaderIfMissing(finalHeaders, 'Content-Type', 'application/x-www-form-urlencoded');
                 }
               } catch {
                 requestBody = requestConfig.body.content;
               }
               break;
             case 'raw': {
-              const rawSubType = requestConfig.body.rawSubType ?? 'text';
+              const rawSubType = requestConfig.body.rawSubType;
               if (rawSubType === 'javascript') {
                 // Executable JS body: run the script against the live execution context (data,
                 // globalState, http, …); its returned value becomes the payload.
@@ -270,8 +275,8 @@ export const useApiCallAction = (): void => {
                   requestBody = undefined;
                 }
                 // Object results are sent as JSON; strings/primitives are sent as-is.
-                if (!finalHeaders['Content-Type'] && requestBody !== null && typeof requestBody === 'object') {
-                  finalHeaders['Content-Type'] = 'application/json';
+                if (requestBody !== null && typeof requestBody === 'object') {
+                  setHeaderIfMissing(finalHeaders, 'Content-Type', 'application/json');
                 }
               } else {
                 // Other raw sub-types are sent as text, with Mustache resolved against the context.
@@ -284,9 +289,7 @@ export const useApiCallAction = (): void => {
                   xml: 'application/xml',
                   html: 'text/html',
                 };
-                if (!finalHeaders['Content-Type']) {
-                  finalHeaders['Content-Type'] = rawContentTypeMap[rawSubType] ?? 'text/plain';
-                }
+                setHeaderIfMissing(finalHeaders, 'Content-Type', rawContentTypeMap[rawSubType] ?? 'text/plain');
               }
               break;
             }

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -1,5 +1,7 @@
+import { useRef } from 'react';
 import { nanoid } from '@/utils/uuid';
 import { useSheshaApplication } from "@/providers";
+import { useAvailableConstantsData, evaluateString, executeScript, genericActionArgumentsEvaluator } from '@/providers/form/utils';
 import { SheshaActionOwners } from "../../configurableActionsDispatcher/models";
 import axios, { Method } from 'axios';
 import { IKeyValue } from "@/interfaces/keyValue";
@@ -10,7 +12,20 @@ import { mapKeyValueToDictionary } from "@/utils/dictionary";
 import { getQueryParams } from "@/utils/url";
 import { isNullOrWhiteSpace } from '@/utils/nullables';
 import { FormMarkupFactory } from '@/interfaces/configurableAction';
+import { IRequestParam, IRequestHeader, IRequestBody, IFormDataField, IResponseTransformationConfiguration, executeResponseTransformation } from '@/components/requestConfigModal';
 import { IDictionary } from '@/interfaces';
+
+// Values are now plain strings (possibly containing {{ }} mustache). The generic evaluator has
+// already resolved them before the executer runs. Legacy configs may still store an IPropertySetting
+// object — handle that transparently so old configurations keep working.
+const resolveRequestValue = (raw: unknown): string => {
+  if (!raw) return '';
+  if (typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    return obj['_mode'] === 'code' ? String(obj['_code'] ?? '') : String(obj['_value'] ?? '');
+  }
+  return String(raw);
+};
 
 export interface IApiCallArguments {
   url: string;
@@ -18,6 +33,13 @@ export interface IApiCallArguments {
   parameters: IKeyValue[];
   headers: IKeyValue[];
   sendStandardHeaders: boolean;
+  // New structure for enhanced configuration
+  requestConfig?: {
+    params?: IRequestParam[];
+    headers?: IRequestHeader[];
+    body?: IRequestBody;
+    responseTransformation?: IResponseTransformationConfiguration;
+  };
 }
 
 const HttpVerbs: Method[] = ['get',
@@ -52,40 +74,44 @@ const getApiCallArgumentsForm: FormMarkupFactory = ({ fbf }) => {
       },
     ],
   })
-    .addSettingsInputRow({
-      id: "parameters-standard-header-row",
-      inputs: [
-        {
-          id: nanoid(),
-          type: 'labelValueEditor',
-          propertyName: 'parameters',
-          label: 'Parameters',
-          description: 'Request parameters. They will be included into the request as query string or body depending on the selected verb.',
-          labelName: 'key',
-          labelTitle: 'Key',
-          valueName: 'value',
-          valueTitle: 'Value',
-        },
-        {
-          id: nanoid(),
-          type: 'switch',
-          propertyName: 'sendStandardHeaders',
-          label: 'Send Standard Headers',
-          description: 'Allow to send standard application headers including authentication. Note: it may be unsafe to send these headers to external applications.',
-        },
-      ],
+    .addSettingsInput({
+      id: nanoid(),
+      inputType: 'requestConfigButton',
+      propertyName: 'requestConfig',
+      label: 'Request Configuration',
+      description: 'Configure request parameters, headers, and body',
     })
     .addSettingsInput({
       id: nanoid(),
-      inputType: 'labelValueEditor',
-      propertyName: 'headers',
-      label: 'Headers',
-      labelName: 'key',
-      labelTitle: 'Key',
-      valueName: 'value',
-      valueTitle: 'Value',
+      inputType: 'switch',
+      propertyName: 'sendStandardHeaders',
+      label: 'Send Standard Headers',
+      description: 'Allow to send standard application headers including authentication. Note: it may be unsafe to send these headers to external applications.',
     })
     .toJson();
+};
+
+// Applies the optional response transformation. The original response is never mutated; when the
+// transformation is disabled or fails, the original response is returned unchanged so a bad script
+// can never break the action. `context` is the standard Shesha constants object (globalState,
+// pageContext, http, form, data, …) with `response` layered in — the same scope every other code
+// editor exposes.
+const applyResponseTransformation = async (
+  original: unknown,
+  context: object,
+  transformation?: IResponseTransformationConfiguration,
+): Promise<unknown> => {
+  if (!transformation?.enabled || !transformation.script.trim()) {
+    return original;
+  }
+
+  const result = await executeResponseTransformation(transformation.script, context);
+  if (result.success) {
+    return result.output;
+  }
+
+  console.error('Response transformation failed, returning original response:', result.error);
+  return original;
 };
 
 const isGlobalUrl = (url: string): boolean => {
@@ -111,6 +137,14 @@ const prepareUrlAndData = (url: string, verb: string, parameters: IDictionary<st
 export const useApiCallAction = (): void => {
   const { backendUrl, httpHeaders } = useSheshaApplication();
 
+  // The response transformation runs as a standard Shesha script, so it needs the same constants
+  // (globalState, pageContext, http, form, data, …) as every other code editor. `responseHolder`
+  // is a stable object whose `response` key is registered as an available constant; we write the
+  // actual response into it just before executing the transformation. The accessor reads it lazily,
+  // so the live value is picked up without rebuilding the constants on every API response.
+  const responseHolder = useRef<{ response: unknown }>({ response: undefined });
+  const allData = useAvailableConstantsData({}, responseHolder.current);
+
   useConfigurableAction<IApiCallArguments>({
     isPermament: true,
     owner: 'Common',
@@ -120,20 +154,152 @@ export const useApiCallAction = (): void => {
     sortOrder: 5,
     hasArguments: true,
     argumentsFormMarkup: getApiCallArgumentsForm,
-    executer: (actionArgs, _context) => {
+    // Evaluate arguments normally (params/headers/url get their Mustache resolved), but keep the
+    // JSON/raw body template raw. A JSON body is one big string, and letting the generic pass run
+    // Mustache over it can blank tags before the body data is available; instead the executer
+    // evaluates it against the live execution context (same data params use). form-data field
+    // values stay evaluated here and are read via resolveRequestValue.
+    evaluateArguments: async (args, context) => {
+      const evaluated = await genericActionArgumentsEvaluator<IApiCallArguments>(args, context);
+      const srcBody = args.requestConfig?.body;
+      const dstBody = evaluated?.requestConfig?.body;
+      if (dstBody && srcBody && (srcBody.type === 'json' || srcBody.type === 'raw') && typeof srcBody.content === 'string') {
+        dstBody.content = srcBody.content;
+      }
+      return evaluated;
+    },
+    executer: async (actionArgs, context) => {
       const {
         url,
         verb,
         sendStandardHeaders,
+        requestConfig,
       } = actionArgs;
 
-      const headers = mapKeyValueToDictionary(actionArgs.headers) ?? {};
-      const standardHeaders = sendStandardHeaders
-        ? httpHeaders
-        : {};
-      const allHeaders = { ...standardHeaders, ...headers };
+      // Backward compatibility: use legacy parameters/headers if requestConfig is not set
+      let finalParams: Record<string, string> = {};
+      let finalHeaders: Record<string, string> = {};
+      let requestBody: unknown;
 
-      const parameters = mapKeyValueToDictionary(actionArgs.parameters);
+      if (requestConfig) {
+        // New structure: use requestConfig
+        const enabledParams = requestConfig.params?.filter((p) => p.enabled) || [];
+        finalParams = enabledParams.reduce((acc, param) => {
+          if (param.key) {
+            let value = resolveRequestValue(param.value);
+
+            // Special handling for 'properties' parameter - normalize GraphQL-like syntax
+            // Convert multi-line format to single line with spaces
+            if (param.key.toLowerCase() === 'properties' && typeof value === 'string') {
+              value = value
+                .split('\n') // Split by newlines
+                .map((line) => line.trim()) // Trim each line
+                .filter((line) => line) // Remove empty lines
+                .join(' '); // Join with spaces
+            }
+
+            acc[param.key] = value;
+          }
+          return acc;
+        }, {} as Record<string, string>);
+
+        const enabledHeaders = requestConfig.headers?.filter((h) => h.enabled) || [];
+        finalHeaders = enabledHeaders.reduce((acc, header) => {
+          if (header.key) acc[header.key] = resolveRequestValue(header.value);
+          return acc;
+        }, {} as Record<string, string>);
+
+        // Handle request body based on type
+        if (requestConfig.body && requestConfig.body.type !== 'none') {
+          switch (requestConfig.body.type) {
+            case 'json':
+              try {
+                // Resolve Mustache in the JSON body against the live execution context (data,
+                // globalState, etc.) before parsing, so e.g. {"name":"{{data.firstName}}"} works.
+                const evaluatedJson = typeof requestConfig.body.content === 'string'
+                  ? evaluateString(requestConfig.body.content, context as object)
+                  : requestConfig.body.content;
+                requestBody = typeof evaluatedJson === 'string'
+                  ? JSON.parse(evaluatedJson) as unknown
+                  : evaluatedJson;
+              } catch {
+                requestBody = requestConfig.body.content;
+              }
+              if (!finalHeaders['Content-Type']) {
+                finalHeaders['Content-Type'] = 'application/json';
+              }
+              break;
+            case 'form-data':
+            case 'x-www-form-urlencoded':
+              try {
+                // New storage: typed array of fields. Legacy storage: JSON-stringified array.
+                const rawContent = requestConfig.body.content;
+                const toFormFields = (content: IRequestBody['content']): IFormDataField[] => {
+                  if (Array.isArray(content)) return content as IFormDataField[];
+                  if (typeof content === 'string') {
+                    const parsed: unknown = JSON.parse(content);
+                    return Array.isArray(parsed) ? (parsed as IFormDataField[]) : [];
+                  }
+                  return [];
+                };
+                const formFields = toFormFields(rawContent);
+                requestBody = formFields.reduce((acc: Record<string, string>, field: IFormDataField) => {
+                  if (field.key && field.enabled !== false) {
+                    acc[field.key] = resolveRequestValue(field.value);
+                  }
+                  return acc;
+                }, {});
+                if (requestConfig.body.type === 'x-www-form-urlencoded' && !finalHeaders['Content-Type']) {
+                  finalHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+                }
+              } catch {
+                requestBody = requestConfig.body.content;
+              }
+              break;
+            case 'raw': {
+              const rawSubType = requestConfig.body.rawSubType ?? 'text';
+              if (rawSubType === 'javascript') {
+                // Executable JS body: run the script against the live execution context (data,
+                // globalState, http, …); its returned value becomes the payload.
+                try {
+                  requestBody = typeof requestConfig.body.content === 'string' && requestConfig.body.content.trim()
+                    ? await executeScript<unknown>(requestConfig.body.content, context as object)
+                    : undefined;
+                } catch (e) {
+                  console.error('API Call: JavaScript body execution failed:', e);
+                  requestBody = undefined;
+                }
+                // Object results are sent as JSON; strings/primitives are sent as-is.
+                if (!finalHeaders['Content-Type'] && requestBody !== null && typeof requestBody === 'object') {
+                  finalHeaders['Content-Type'] = 'application/json';
+                }
+              } else {
+                // Other raw sub-types are sent as text, with Mustache resolved against the context.
+                requestBody = typeof requestConfig.body.content === 'string'
+                  ? evaluateString(requestConfig.body.content, context as object)
+                  : requestConfig.body.content;
+                const rawContentTypeMap: Record<string, string> = {
+                  text: 'text/plain',
+                  json: 'application/json',
+                  xml: 'application/xml',
+                  html: 'text/html',
+                };
+                if (!finalHeaders['Content-Type']) {
+                  finalHeaders['Content-Type'] = rawContentTypeMap[rawSubType] ?? 'text/plain';
+                }
+              }
+              break;
+            }
+          }
+        }
+      } else {
+        // Legacy structure: use old parameters/headers
+        finalParams = mapKeyValueToDictionary(actionArgs.parameters) || {};
+        finalHeaders = mapKeyValueToDictionary(actionArgs.headers) || {};
+      }
+
+      const standardHeaders = sendStandardHeaders ? httpHeaders : {};
+      const allHeaders = { ...standardHeaders, ...finalHeaders };
 
       // validate arguments
       if (!url)
@@ -145,7 +311,20 @@ export const useApiCallAction = (): void => {
         ? undefined
         : backendUrl;
 
-      const { url: preparedUrl, data: preparedData } = prepareUrlAndData(url, verb, { ...parameters });
+      // When an explicit body is configured on a non-GET verb, encode params as URL query string so
+      // they are not silently dropped (without this, prepareUrlAndData would put them in the body).
+      const hasParams = Object.keys(finalParams).length > 0;
+      const bodyOverridesParams = requestBody !== undefined && hasParams;
+      const effectiveUrl = bodyOverridesParams
+        ? `${url.split('?')[0]}?${qs.stringify({ ...getQueryParams(url), ...finalParams }, { allowDots: true })}`
+        : url;
+
+      const { url: preparedUrl, data: paramsData } = prepareUrlAndData(
+        effectiveUrl,
+        verb,
+        bodyOverridesParams ? {} : { ...finalParams },
+      );
+      const preparedData = requestBody !== undefined ? requestBody : paramsData;
 
       return axios({
         url: preparedUrl,
@@ -153,7 +332,12 @@ export const useApiCallAction = (): void => {
         method: verb as Method,
         headers: allHeaders,
         ...(baseUrl && { baseURL: baseUrl }),
-      }).then((response) => unwrapAbpResponse(response.data));
+      }).then((response) => {
+        const original: unknown = unwrapAbpResponse(response.data) as unknown;
+        // Expose the freshly-received response to the transformation script as `response`.
+        responseHolder.current.response = original;
+        return applyResponseTransformation(original, allData, requestConfig?.responseTransformation);
+      });
     },
-  }, [backendUrl, httpHeaders]);
+  }, [backendUrl, httpHeaders, allData]);
 };


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Request Configuration modal with tabs for Params, Headers, Body (none/JSON/form-data/x-www-form-urlencoded/raw), and an optional Transformation step.
  * Introduced a “Configure Request” button with a compact summary of enabled settings.
* **Bug Fixes**
  * Updated API Call execution to use the new request configuration, correctly include enabled params for non-GET requests, and apply response transformations safely.
* **Tests**
  * Added Jest coverage for response-transformation script validation and execution, including common error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->