### PR TITLE
fix: prevent credential autofill in search input by managing read-onl…

### DIFF
--- a/shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx
+++ b/shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx
@@ -19,6 +19,11 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
   const { tabs } = model;
   const formDesigner = useFormDesignerOrUndefined();
   const [searchQuery, setSearchQuery] = useState('');
+  // Chrome skips its load-time credential autofill for read-only fields, so keep the
+  // search box read-only until the user focuses it. This prevents the saved username
+  // (e.g. "admin") being injected, which would filter out every property and collapse
+  // the settings panel.
+  const [autofillGuard, setAutofillGuard] = useState(true);
   const [localActiveTabKey, setLocalActiveTabKey] = useState<string>(formDesigner?.activeSettingsTabKey ?? '1');
   const { styles } = useStyles();
 
@@ -48,6 +53,9 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
         placeholder="Search properties"
         value={searchQuery}
         onChange={handleSearchChange}
+        readOnly={autofillGuard}
+        onFocus={() => setAutofillGuard(false)}
+        autoComplete="new-password"
         suffix={<SearchOutlined style={{ color: 'rgba(0,0,0,.45)' }} />}
         ref={options?.ref}
         className={options?.className}


### PR DESCRIPTION
This pull request addresses an issue where Chrome's autofill feature was injecting saved credentials (like "admin") into the search box of the settings panel, causing unwanted filtering and collapsing of properties. The solution involves adding a guard to keep the search box read-only until the user focuses it, which prevents Chrome from autofilling the field.

**Improvements to user experience and autofill prevention:**

* Added an `autofillGuard` state to keep the search box read-only until focused, preventing Chrome from autofilling credentials and disrupting the property filter. (`shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx`)
* Set the `readOnly` and `autoComplete="new-password"` attributes on the search input, and removed the read-only state on focus, further preventing Chrome autofill issues. (`shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx`) (#5047)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the search input in tab navigation to avoid unwanted browser autofill on page load.
  * The search field now stays protected until it’s focused, then becomes editable normally for typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->