### PR TITLE
fix: fixed rendering of nested modals

### DIFF
--- a/shesha-reactjs/src/providers/dynamicModal/renderer.tsx
+++ b/shesha-reactjs/src/providers/dynamicModal/renderer.tsx
@@ -67,9 +67,12 @@ const DynamicModalRenderer: FC<PropsWithChildren<IDynamicModalRendererProps>> = 
 
   const context = { registerChildren, unregisterChildren };
 
+  // eslint-disable-next-line react-hooks/refs
+  const isDeepest = children.current.length === 0;
+
   return (
     <DynamicModalRendererContext.Provider value={context}>
-      {renderInstances()}
+      {isDeepest && renderInstances()}
       {props.children}
     </DynamicModalRendererContext.Provider>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic modals now display only in the correct context, preventing instances from rendering too early when nested modal renderers are present.
  * Improved modal visibility behavior so only the deepest eligible renderer shows dynamic modal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->