### PR TITLE
fix: fixed dropdown in tags display mode

### DIFF
--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/index.tsx
@@ -109,7 +109,7 @@ export const ReadOnlyDisplayFormItem: FC<IReadOnlyDisplayFormItemProps> = <TValu
 
       case 'dropdownMultiple': {
         const typedValue = Array.isArray(value) && (!isNonEmptyArray(value) || typeof (value[0]) === "object")
-          ? value as ISelectOption[]
+          ? (value as ISelectOption[]).filter(isDefined)
           : undefined;
         if (typedValue) {
           const values = typedValue.map(({ label }) => label);

--- a/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
+++ b/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
@@ -7,7 +7,7 @@ import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
 import { CustomLabeledValue, IGenericRefListDropDownProps, ISelectOption } from './models';
 import ReflistTag from './reflistTag';
 import { isNonEmptyArray } from '@/utils/array';
-import { isDefined } from '@/utils/nullables';
+import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 
 const parseDisabledValues = (input: number[] | string | undefined): number[] => {
   if (!isDefined(input))
@@ -29,7 +29,7 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
     disabledValues,
     mode,
     onChange,
-    readOnly,
+    readOnly = false,
     disabled,
     style,
     allowClear = true,
@@ -137,7 +137,7 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
     ) : (
       <Empty
         image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description={refListError ? <ValidationErrors renderMode="raw" error={refListError} /> : 'No matches'}
+        description={isDefined(refListError) ? <ValidationErrors renderMode="raw" error={refListError} /> : 'No matches'}
       />
     ),
     allowClear,
@@ -146,7 +146,7 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
     filterOption: filterOption,
     size: size,
     ...(variant ? { variant } : {}),
-    ...(className ? { className } : {}),
+    ...(!isNullOrWhiteSpace(className) ? { className } : {}),
     onChange: handleChange,
     value: wrapValue(value, options),
   };

--- a/shesha-reactjs/src/components/refListDropDown/reflistTag.tsx
+++ b/shesha-reactjs/src/components/refListDropDown/reflistTag.tsx
@@ -3,6 +3,7 @@ import convert from 'color-convert';
 import { Tag, Tooltip, TooltipProps } from 'antd';
 import React, { CSSProperties } from 'react';
 import { ShaIcon, IconType } from '../shaIcon';
+import { isNullOrWhiteSpace } from '@/utils/nullables';
 
 interface IReflistTagProps {
   value?: string | number | undefined;
@@ -16,10 +17,22 @@ interface IReflistTagProps {
   label?: string | React.ReactNode | undefined;
   placement?: TooltipProps['placement'] | undefined;
 }
-function ReflistTag({ value, description, color = "", icon, showIcon, tagStyle, solidColor = false, showItemName, label, placement = 'right' }: IReflistTagProps): React.JSX.Element {
+
+const tryConvertToHex = (value: string): string => {
+  try {
+    return value.startsWith('#')
+      ? value
+      : convert.keyword.hex(value);
+  } catch {
+    console.warn(`Failed to convert ${value} to hex`);
+    return value;
+  }
+};
+
+function ReflistTag({ value, description, color = "", icon, showIcon = false, tagStyle, solidColor = false, showItemName = false, label, placement = 'right' }: IReflistTagProps): React.JSX.Element {
   const memoizedColor = !solidColor
     ? color.toLowerCase()
-    : convert.keyword.hex(color);
+    : tryConvertToHex(color.toLowerCase());
 
   const labelToRender = typeof label === 'string' ? label.toUpperCase() : label;
 
@@ -33,7 +46,7 @@ function ReflistTag({ value, description, color = "", icon, showIcon, tagStyle, 
       <Tag
         key={value}
         color={memoizedColor}
-        icon={(icon && showIcon) && <ShaIcon iconName={icon as IconType} />}
+        icon={(!isNullOrWhiteSpace(icon) && showIcon) && <ShaIcon iconName={icon as IconType} />}
         style={getTagStyle(tagStyle, !!color)}
       >{showItemName && labelToRender}
       </Tag>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-only dropdown displays so multi-select values no longer include empty entries.
  * Made reference list dropdowns handle missing or invalid states more consistently, including better empty-state behavior and cleaner styling when a label is blank.
  * Fixed tag rendering for reference lists by avoiding color conversion errors and falling back gracefully when a color can’t be converted.
  * Updated default tag behavior so icons and item names are hidden unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->