### PR TITLE
fix: update QueryBuilderExpressionViewer to use TypeScript and include available constants

### DIFF
--- a/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/filters/filterItemSettingsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/filters/filterItemSettingsEditor.tsx
@@ -1,6 +1,6 @@
 import { CodeVariablesTables } from '@/components/codeVariablesTable';
 import { ListEditorRenderer } from '@/components/listEditorRenderer';
-import QueryBuilderExpressionViewer from '@/designer-components/queryBuilder/queryBuilderExpressionViewer';
+import QueryBuilderExpressionViewer, { JsonValue } from '@/designer-components/queryBuilder/queryBuilderExpressionViewer';
 import { QueryBuilderPlainRenderer } from '@/designer-components/queryBuilder/queryBuilderFieldPlain';
 import { QueryBuilderProvider, useMetadata } from '@/providers';
 import { Tabs } from 'antd';
@@ -64,7 +64,7 @@ export const FilterItemSettingsEditor: FC<IFilterItemSettingsEditorProps> = ({ v
           {
             key: 'expressionViewerTab',
             label: 'Query expression viewer',
-            children: <QueryBuilderExpressionViewer value={expressionObject} />,
+            children: <QueryBuilderExpressionViewer value={expressionObject as JsonValue | undefined} />,
           },
           {
             key: 'exposedVariables',

--- a/shesha-reactjs/src/designer-components/queryBuilder/queryBuilderExpressionViewer.tsx
+++ b/shesha-reactjs/src/designer-components/queryBuilder/queryBuilderExpressionViewer.tsx
@@ -1,4 +1,5 @@
 import { CodeEditor } from '@/components/codeEditor/codeEditor';
+import { useAvailableStandardConstantsMetadata } from '@/utils/metadata/hooks';
 import React, { FC } from 'react';
 
 export interface IQueryBuilderExpressionViewerProps {
@@ -6,11 +7,20 @@ export interface IQueryBuilderExpressionViewerProps {
 }
 
 export const QueryBuilderExpressionViewer: FC<IQueryBuilderExpressionViewerProps> = (props) => {
+  const availableConstants = useAvailableStandardConstantsMetadata();
+
   return (
     <CodeEditor
       readOnly={true}
       value={props.value ? JSON.stringify(props.value, null, 2) : ''}
-      language="javascript"
+      language="typescript"
+      fileName="queryExpression"
+      wrapInTemplate={true}
+      templateSettings={{
+        functionName: 'executeScriptAsync',
+        useAsyncDeclaration: true,
+      }}
+      availableConstants={availableConstants}
     />
   );
 };

--- a/shesha-reactjs/src/designer-components/queryBuilder/queryBuilderExpressionViewer.tsx
+++ b/shesha-reactjs/src/designer-components/queryBuilder/queryBuilderExpressionViewer.tsx
@@ -2,8 +2,11 @@ import { CodeEditor } from '@/components/codeEditor/codeEditor';
 import { useAvailableStandardConstantsMetadata } from '@/utils/metadata/hooks';
 import React, { FC } from 'react';
 
+type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
 export interface IQueryBuilderExpressionViewerProps {
-  value?: object | undefined;
+  value?: JsonValue | undefined;
 }
 
 export const QueryBuilderExpressionViewer: FC<IQueryBuilderExpressionViewerProps> = (props) => {
@@ -12,7 +15,7 @@ export const QueryBuilderExpressionViewer: FC<IQueryBuilderExpressionViewerProps
   return (
     <CodeEditor
       readOnly={true}
-      value={props.value ? JSON.stringify(props.value, null, 2) : ''}
+      value={props.value === undefined ? '' : JSON.stringify(props.value, null, 2)}
       language="typescript"
       fileName="queryExpression"
       wrapInTemplate={true}


### PR DESCRIPTION
This pull request updates the `QueryBuilderExpressionViewer` component to enhance its integration with the code editor and improve the developer experience. The main changes involve configuring the code editor for TypeScript, enabling template wrapping, and providing metadata for available constants.

Enhancements to code editor integration:

* Changed the `language` prop from `"javascript"` to `"typescript"` for better syntax highlighting and type support in `CodeEditor`.
* Added `fileName`, `wrapInTemplate`, and `templateSettings` props to enable code wrapping in an async function template, improving code execution context and clarity.
* Introduced the `useAvailableStandardConstantsMetadata` hook to supply `availableConstants` metadata to the code editor, making standard constants accessible within the editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the query builder’s expression viewer with richer, async-ready code editing and improved suggestions.
  * Updated the editor to display code with TypeScript-style syntax highlighting and improved formatting via async template wrapping.
* **Improved Type Safety**
  * Strengthened the expression value typing used across the viewer and its settings editor for more reliable, consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

related to issue #5080