### PR TITLE
fix: clip Configuration Studio sidebar tree labels to a single line (#5007)

### DIFF
--- a/shesha-reactjs/src/configuration-studio/styles.ts
+++ b/shesha-reactjs/src/configuration-studio/styles.ts
@@ -124,8 +124,32 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls, iconPrefixCl
                         height:100%;
                     }
                     .${prefixCls}-tree-treenode {
+                      width: 100%;
+                      max-width: 100%;
                       .${prefixCls}-tree-draggable-icon {
                         display: none;
+                      }
+                      /* Keep long labels on a single line, clipped at the panel
+                         edge instead of wrapping (File Explorer behaviour).
+                         The content wrapper becomes a flex row so the type icon
+                         stays inline and only the title truncates; min-width: 0
+                         lets the title shrink below its content width so the
+                         ellipsis actually triggers. */
+                      .${prefixCls}-tree-node-content-wrapper {
+                        display: flex;
+                        align-items: center;
+                        min-width: 0;
+                        overflow: hidden;
+                        .${prefixCls}-tree-iconEle {
+                          flex: none;
+                        }
+                        .${prefixCls}-tree-title {
+                          flex: 1 1 auto;
+                          min-width: 0;
+                          overflow: hidden;
+                          white-space: nowrap;
+                          text-overflow: ellipsis;
+                        }
                       }
                     }
                 }


### PR DESCRIPTION

Related to issue (#5007))
This pull request updates the tree node styling in the `configuration-studio` to improve the display of long labels, ensuring they are truncated with ellipsis instead of wrapping, similar to file explorer behavior. The most important changes are listed below.

**UI/UX improvements for tree nodes:**

* Modified the `.tree-treenode` class to set `width` and `max-width` to 100%, ensuring nodes use the full available space.
* Updated `.tree-node-content-wrapper` to use flex layout, keeping the type icon and title inline and preventing the title from wrapping. Added styles to allow the title to shrink and truncate with ellipsis when necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated navigation tree item layout so long labels stay on one line and truncate with ellipsis.
  * Improved alignment of tree icons and text for a cleaner, more file-explorer-like appearance.
  * Prevented tree node content from wrapping awkwardly in the configuration studio panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->