### PR TITLE
fix: enhance file upload thumbnail handling and styling

### DIFF
--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -15,7 +15,7 @@ import { ListType } from '@/designer-components/attachmentsEditor/attachmentsEdi
 import { getFileIcon, isImageType } from '@/icons/fileIcons';
 import { useFileUploadState, useFileUpload, useTheme } from '@/providers';
 import { useHttpClient } from '@/providers/sheshaApplication/publicApi/http/hooks';
-import { fetchStoredFile } from '@/components/storedFilesRendererBase/utils';
+import { fetchStoredFile, resolveThumbnailSize } from '@/components/storedFilesRendererBase/utils';
 import { isFileTypeAllowed } from '@/utils/fileValidation';
 import FileVersionsPopup from './fileVersionsPopup';
 import { DraggerStub } from './stubs';
@@ -94,15 +94,14 @@ export const FileUpload: FC<IFileUploadProps> = ({
   // of the same file reuse the already-downloaded image instead of hitting the server again.
   const previewImageCache = useRef<Map<string, string>>(new Map());
   const downloadUrl = buildUrl(fileInfo?.url ?? '');
-  const thumbnailQueryParams = {
+  // The backend returns a degenerate 1x1 thumbnail when width/height are omitted, so always send
+  // concrete dimensions derived from the configured thumbnail size (with a safe default).
+  const thumbnailUrl = buildUrl(STORED_FILE_URLS.DOWNLOAD_THUMBNAIL, {
     id: fileInfo?.id ?? '',
-    width: isDefined(thumbnailWidth) ? parseFloat(thumbnailWidth) : undefined,
-    height: isDefined(thumbnailHeight) ? parseFloat(thumbnailHeight) : undefined,
-  };
-  const thumbnailUrl = buildUrl(
-    STORED_FILE_URLS.DOWNLOAD_THUMBNAIL,
-    Object.fromEntries(Object.entries(thumbnailQueryParams).filter(([_, v]) => v !== undefined && !Number.isNaN(v))),
-  );
+    width: resolveThumbnailSize(thumbnailWidth),
+    height: resolveThumbnailSize(thumbnailHeight),
+    fitOption: 1, // 1: FitToHeight
+  });
 
   // Clean up blob URLs on unmount
   useEffect(() => {
@@ -435,7 +434,7 @@ export const FileUpload: FC<IFileUploadProps> = ({
     multiple: false,
     fileList: isDefined(uploadFileModel) && fileInfo?.status !== 'error' ? [uploadFileModel] : [],
     maxCount: 1,
-    ...(!isDragger && listType !== 'thumbnail' && isDefined(stylesProp) ? { style: stylesProp } : {}),
+    // ...(!isDragger && listType !== 'thumbnail' && isDefined(stylesProp) ? { style: stylesProp } : {}),
     customRequest: onCustomRequest,
     beforeUpload: (file) => {
       if (!isFileTypeAllowed(file.name, allowedFileTypes)) {
@@ -509,6 +508,12 @@ export const FileUpload: FC<IFileUploadProps> = ({
       </div>
     );
   };
+
+  // When read-only with no file (and not in the designer stub), render nothing at all so the
+  // configured border/background/placeholder of an empty component isn't shown on read-only views.
+  const isEmptyReadonly = !isStub && !allowUpload && (!fileInfo || fileInfo.status === 'error');
+  if (isEmptyReadonly)
+    return null;
 
   return (
     <>

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -28,7 +28,6 @@ export type FileUploadStylesResponse = {
   antUploadText?: string;
   antUploadHint?: string;
   styledFileControls?: string;
-  thumbnailReadOnly?: string;
 };
 
 export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesResponse>(({ token, css, cx, prefixCls }, { style, model }) => {
@@ -76,11 +75,15 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     textAlign = 'left',
   } = style || {};
 
+  const { layout, isDragger, hideFileName, listType } = model;
+
+  // The configured component styles (background, border, shadow, dimensions) describe the
+  // thumbnail tile, so they must only be applied in thumbnail mode. In text mode the file is
+  // shown as a plain filename and must not pick up the thumbnail's shadow/border/box styling.
+  const isThumbnail = listType === 'thumbnail';
   // React.CSSProperties is not directly assignable to Emotion's CSSInterpolation;
   // spreading it into a CSSObject-shaped value is safe at runtime.
-  const extraStyles = { ...style } as CSSInterpolation;
-
-  const { layout, isDragger, hideFileName, listType } = model;
+  const extraStyles = (isThumbnail ? { ...style } : {}) as CSSInterpolation;
 
   const justifyContentMap: Record<TextAlignType, string> = {
     left: 'flex-start',
@@ -115,7 +118,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
   `;
 
   const commonBorderStyles = css`
-    border: ${borderWidth} ${borderStyle} ${borderColor};
     border-top: ${borderTopWidth || borderWidth} ${borderTopStyle || borderStyle} ${borderTopColor || borderColor};
     border-right: ${borderRightWidth || borderWidth} ${borderRightStyle || borderStyle}
       ${borderRightColor || borderColor};
@@ -149,34 +151,22 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       min-height: ${layout ? (minHeight) : '100%'} !important;
       max-width: ${layout ? (maxWidth) : '100%'} !important;
       min-width: ${layout ? (minWidth) : '100%'} !important;
+      ${isThumbnail ? `
       background: ${backgroundImage ?? backgroundColor ?? background};
       ${backgroundPosition ? `background-position: ${backgroundPosition};` : ''}
       ${backgroundRepeat ? `background-repeat: ${backgroundRepeat};` : ''}
       ${backgroundSize ? `background-size: ${backgroundSize};` : ''}
+      ` : ''}
 
-      .ant-upload-select-picture-card,
-      .ant-upload-list-picture-card .ant-upload-select,
-      .ant-upload-list-picture-card .ant-upload.ant-upload-select {
-        width: var(--thumbnail-width) !important;
-        height: var(--thumbnail-height) !important;
-        background-position: ${backgroundPosition} !important;
-        background-repeat: ${backgroundRepeat} !important;
-        background-size: ${backgroundSize} !important;
-        ${borderRadiusCss}
-        border: ${borderWidth} ${borderStyle} ${borderColor} !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-      }
+      // /* Hide the upload trigger once a file is present (single-file upload). antd's
+      //    maxCount=1 isn't auto-hiding the trigger in this version, so suppress it via
+      //    a sibling-combinator rule: any .ant-upload-select that follows a file item is hidden. */
+      // .ant-upload-list-picture-card .ant-upload-list-item-container ~ .ant-upload-select,
+      // .ant-upload-list-picture-card .ant-upload-list-item-container ~ .ant-upload.ant-upload-select {
+      //   display: none !important;
+      // }
 
-      /* Hide the upload trigger once a file is present (single-file upload). antd's
-         maxCount=1 isn't auto-hiding the trigger in this version, so suppress it via
-         a sibling-combinator rule: any .ant-upload-select that follows a file item is hidden. */
-      .ant-upload-list-picture-card .ant-upload-list-item-container ~ .ant-upload-select,
-      .ant-upload-list-picture-card .ant-upload-list-item-container ~ .ant-upload.ant-upload-select {
-        display: none !important;
-      }
-
+      ${isThumbnail ? `
       .ant-upload-list-item {
         width: var(--thumbnail-width) !important;
         height: ${hideFileName ? 'var(--thumbnail-height)' : 'calc(var(--thumbnail-height) + 32px)'} !important;
@@ -184,16 +174,8 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         border-bottom: ${borderBottom} !important;
         border-right: ${borderRight} !important;
       }
+      ` : ''}
 
-      .ant-upload-list-picture-card {
-        height: ${hideFileName
-          ? 'var(--thumbnail-height)'
-          : `calc(var(--thumbnail-height) + ${fontSize} * 2 + 32px)`} !important;
-        min-height: ${hideFileName
-          ? 'var(--thumbnail-height)'
-          : `calc(var(--thumbnail-height) + ${fontSize} * 2 + 32px)`} !important;
-        padding-bottom: 1rem;
-      }
 
       .ant-upload-list-item-image {
         object-fit: contain !important;
@@ -212,9 +194,10 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         --ant-padding-xs: 0px !important;
         --font-size: ${fontSize} !important;
         --ant-font-size: ${fontSize} !important;
+        display: flex;
+        ${isThumbnail ? `
         ${borderRadiusCss}
         border: ${borderWidth} ${borderStyle} ${borderColor} !important;
-        display: flex;
 
         :before {
           top: 0;
@@ -223,13 +206,14 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
           border: ${borderWidth} ${borderStyle} ${borderColor} !important;
           height: 100% !important;
         }
+        ` : ''}
       }
 
       .ant-upload-list-item-thumbnail {
+        ${extraStyles}
         ${borderRadiusCss}
         padding: 0 !important;
         ${commonBorderStyles}
-        ${extraStyles}
       }
 
       .thumbnail-item-name {
@@ -245,13 +229,15 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       }
 
       .thumbnail-stub {
+        ${extraStyles}
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
         ${borderRadiusCss}
-        border: ${borderWidth} ${borderStyle} ${borderColor} !important;
-        ${extraStyles}
+        ${commonBorderStyles}
+        ${commonTextStyles}
+        ${borderRadiusCss}
       }
 
       .ant-upload-list-text {
@@ -268,9 +254,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       }
 
       .${prefixCls}-upload {
-
-        width: ${layout && !isDragger ? 'var(--thumbnail-width)' : isDragger ? (width ?? height ?? '120px') : 'auto'} !important;
-        height: ${layout && !isDragger ? 'var(--thumbnail-height)' : isDragger ? (height ?? width ?? '120px') : (height ?? width ?? '54px')} !important;
+        ${isDragger ? `min-height: ${minHeight ?? '120px'} !important;` : ''}
         ${borderRadiusCss}
         align-items: center;
 
@@ -300,7 +284,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         * {
           ${commonTextStyles}
         }
-        ${extraStyles}
         width: 100% !important;
         height: 100% !important;
         border: none !important;
@@ -308,14 +291,11 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       }
 
       .ant-upload-list-item-container {
-        background: ${backgroundImage ?? backgroundColor} !important;
-        width: var(--thumbnail-width) !important;
-        height: var(--thumbnail-height) !important;
-        ${borderRadiusCss}
-        border: ${borderWidth} ${borderStyle} transparent !important;
-        /* antd's default margin-block on this container shifts the file tile down after upload;
-           the trigger has no such margin, so reset both margin and padding to keep the file
-           tile in the same spot the trigger occupied. */
+        max-height: calc(var(--container-max-height) - calc(${fontSize} * 4)) !important;
+        min-height: calc(var(--container-min-height) - 32px) !important;
+        width: calc(var(--container-width) - 32px) !important;
+        max-width: calc(var(--container-max-width) - 32px) !important;
+        min-width: calc(var(--container-min-width) - 32px) !important;
         margin: 0 !important;
         padding: 0 !important;
         &.ant-upload-animate-inline-appear,
@@ -325,7 +305,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
           animation: none !important;
           transition: none !important;
         }
-        ${extraStyles}
       }
     `,
   );
@@ -392,7 +371,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       ${commonTextStyles}
       ${borderRadiusCss}
       padding: 0 !important;
-      background: ${background} !important;
+      background: ${backgroundImage ?? backgroundColor ?? background};
       width: ${width || '54px'} !important;
       height: ${height || '54px'} !important;
       display: flex !important;
@@ -409,15 +388,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     `,
   );
 
-  const thumbnailReadOnly = cx("ant-upload-list-item thumbnail-readonly", css`
-      text-align: center;
-      align-items: center;
-      justify-content: center;
-      background-color: #00000005 !important;
-      border: 1px dashed #d9d9d9 !important;
-      border-radius: 8px !important;
-  `);
-
   return {
     shaStoredFilesRenderer,
     storedFilesRendererBtnContainer,
@@ -429,6 +399,5 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     antUploadText,
     antUploadHint,
     styledFileControls,
-    thumbnailReadOnly,
   };
 });

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -17,6 +17,16 @@ interface FileUploadStylesParams {
 
 type TextAlignType = 'left' | 'right' | 'center' | 'justify';
 
+/**
+ * Converts React CSSProperties to Emotion CSSInterpolation.
+ * Spreading CSSProperties into a new object is safe at runtime and produces
+ * a shape compatible with Emotion's CSSObject. The type assertion is necessary
+ * because CSSInterpolation is a union type that doesn't directly accept the spread.
+ */
+const toCssInterpolation = (style: CSSProperties | undefined): CSSInterpolation => {
+  return (style ? { ...style } : {}) as CSSInterpolation;
+};
+
 export type FileUploadStylesResponse = {
   shaStoredFilesRenderer?: string;
   storedFilesRendererBtnContainer?: string;
@@ -81,9 +91,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
   // thumbnail tile, so they must only be applied in thumbnail mode. In text mode the file is
   // shown as a plain filename and must not pick up the thumbnail's shadow/border/box styling.
   const isThumbnail = listType === 'thumbnail';
-  // React.CSSProperties is not directly assignable to Emotion's CSSInterpolation;
-  // spreading it into a CSSObject-shaped value is safe at runtime.
-  const extraStyles = (isThumbnail ? { ...style } : {}) as CSSInterpolation;
+  const extraStyles = isThumbnail ? toCssInterpolation(style) : {};
 
   const justifyContentMap: Record<TextAlignType, string> = {
     left: 'flex-start',
@@ -158,14 +166,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       ${backgroundSize ? `background-size: ${backgroundSize};` : ''}
       ` : ''}
 
-      // /* Hide the upload trigger once a file is present (single-file upload). antd's
-      //    maxCount=1 isn't auto-hiding the trigger in this version, so suppress it via
-      //    a sibling-combinator rule: any .ant-upload-select that follows a file item is hidden. */
-      // .ant-upload-list-picture-card .ant-upload-list-item-container ~ .ant-upload-select,
-      // .ant-upload-list-picture-card .ant-upload-list-item-container ~ .ant-upload.ant-upload-select {
-      //   display: none !important;
-      // }
-
       ${isThumbnail ? `
       .ant-upload-list-item {
         width: var(--thumbnail-width) !important;
@@ -237,7 +237,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         ${borderRadiusCss}
         ${commonBorderStyles}
         ${commonTextStyles}
-        ${borderRadiusCss}
       }
 
       .ant-upload-list-text {
@@ -291,6 +290,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       }
 
       .ant-upload-list-item-container {
+        height: calc(var(--container-height) - 32px) !important;
         max-height: calc(var(--container-max-height) - calc(${fontSize} * 4)) !important;
         min-height: calc(var(--container-min-height) - 32px) !important;
         width: calc(var(--container-width) - 32px) !important;

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -30,7 +30,7 @@ import { ButtonGroupItemProps } from '@/providers/buttonGroupConfigurator/models
 import { ButtonGroup } from '@/designer-components/button/buttonGroup/buttonGroup';
 import { FormIdentifier } from '@/providers/form/models';
 import { DataContextProvider } from '@/providers/dataContextProvider';
-import { FileVersionsButton, ExtraContent, PLACEHOLDER_FILE, getListTypeAndLayout, fetchStoredFile, FileNameDisplay } from './utils';
+import { FileVersionsButton, ExtraContent, PLACEHOLDER_FILE, getListTypeAndLayout, fetchStoredFile, FileNameDisplay, resolveThumbnailSize } from './utils';
 import classNames from 'classnames';
 import { isFileTypeAllowed } from '@/utils/fileValidation';
 import { ShaIcon, IconType } from '@/components/shaIcon';
@@ -303,18 +303,14 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
             if (isNullOrWhiteSpace(file.id)) {
               continue;
             }
-            const queryParams = {
+            // The backend returns a degenerate 1x1 thumbnail when width/height are omitted, so always
+            // send concrete dimensions derived from the configured thumbnail size (with a safe default).
+            const thumbnailUrl = buildUrl(STORED_FILE_URLS.DOWNLOAD_THUMBNAIL, {
               id: file.id,
-              width: isDefined(model.dimensions?.width) ? parseFloat(`${model.dimensions.width}`) : undefined,
-              height: isDefined(model.dimensions?.height) ? parseFloat(`${model.dimensions.height}`) : undefined,
-            };
-
-            // Filter out undefined/NaN values
-            const cleanedParams = Object.fromEntries(
-              Object.entries(queryParams).filter(([_, v]) => v !== undefined && !Number.isNaN(v)),
-            );
-
-            const thumbnailUrl = buildUrl(STORED_FILE_URLS.DOWNLOAD_THUMBNAIL, cleanedParams);
+              width: resolveThumbnailSize(model.thumbnailWidth ?? `${model.allStyles?.dimensionsStyles.width ?? ''}`),
+              height: resolveThumbnailSize(model.thumbnailHeight ?? `${model.allStyles?.dimensionsStyles.height ?? ''}`),
+              fitOption: 1, // 1: FitToHeight
+            });
 
             const { url: imageUrl, revoke } = await fetchStoredFile(httpClient, thumbnailUrl);
             if (isCancelled) {
@@ -363,7 +359,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       // Call all revoke functions to clean up blob URLs
       revokeCallbacks.forEach((revoke) => revoke());
     };
-  }, [fileList, httpClient, model.dimensions?.width, model.dimensions?.height, listType]);
+  }, [fileList, httpClient, model.thumbnailWidth, model.thumbnailHeight, model.allStyles?.dimensionsStyles.width, model.allStyles?.dimensionsStyles.height, listType]);
 
   // Clean up uploaded blob URLs on component unmount to prevent memory leaks
   useEffect(() => {

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -798,10 +798,18 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
                       {fileList.length === 0 ? (
                         <DraggerStub styles={styles} />
                       ) : (
-                        <div>
-                          {renderUploadContent()}
+                        <div style={{ pointerEvents: 'none' }}>
+                          <Button
+                            type="link"
+                            icon={<UploadOutlined />}
+                            disabled={disabled ?? false}
+                            className={styles.uploadButton}
+                            style={{ pointerEvents: 'auto', marginBottom: '8px' }}
+                          >
+                            (Click or drag to upload)
+                          </Button>
                           {fileList.map((file) => (
-                            <div key={file.uid}>
+                            <div key={file.uid} style={{ pointerEvents: 'auto' }}>
                               {itemRenderFunction(<></>, file as UploadFile)}
                             </div>
                           ))}

--- a/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
@@ -181,6 +181,9 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style = 
 
     .ant-upload-wrapper {
       flex: 1 !important;
+      .ant-upload-list-picture-card {
+       min-height: 0px !important;
+      }
     }
 
     .ant-upload:not(.ant-upload-disabled) {

--- a/shesha-reactjs/src/components/storedFilesRendererBase/utils.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/utils.tsx
@@ -53,6 +53,19 @@ export const getListTypeAndLayout = (
   return type === 'text' || !type || isDragger ? 'text' : 'picture-card';
 };
 
+/** Default thumbnail dimension (px) used when no concrete size is configured. */
+export const DEFAULT_THUMBNAIL_SIZE = 160;
+
+/**
+ * Parses a CSS size value (e.g. "54px", "160", 54) into a positive integer pixel value for the
+ * DownloadThumbnail endpoint. The backend returns a 1x1 placeholder when width/height are missing
+ * or non-positive, so this always resolves to a usable size, falling back to DEFAULT_THUMBNAIL_SIZE.
+ */
+export const resolveThumbnailSize = (value: string | number | undefined): number => {
+  const parsed = typeof value === 'number' ? value : parseFloat(`${value ?? ''}`);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : DEFAULT_THUMBNAIL_SIZE;
+};
+
 
 /**
  * Result object returned by fetchStoredFile containing the object URL and cleanup function.

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -221,19 +221,6 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                             },
                           ],
                         })
-                        .addSettingsInput({
-                          id: nanoid(),
-                          inputType: "dropdown",
-                          propertyName: "extraFormSelectionMode",
-                          parentId: customActionsPnId,
-                          label: "Form Selection Mode",
-                          tooltip: "Choose how to select the form for custom content",
-                          dropdownOptions: [
-                            { label: "Name", value: "name" },
-                            { label: "Dynamic", value: "dynamic" },
-                          ],
-                          hidden: { _code: 'return !getSettingValue(data?.customContent);', _mode: 'code', _value: false },
-                        })
                         .addSettingsInputRow({
                           id: nanoid(),
                           parentId: customActionsPnId,
@@ -247,20 +234,6 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                             },
                           ],
                           hidden: { _code: 'return !getSettingValue(data?.customContent) || getSettingValue(data?.extraFormSelectionMode) !== "dynamic";', _mode: 'code', _value: false },
-                        })
-                        .addSettingsInputRow({
-                          id: nanoid(),
-                          parentId: customActionsPnId,
-                          inputs: [
-                            {
-                              id: nanoid(),
-                              type: "formAutocomplete",
-                              propertyName: "extraFormId",
-                              label: "Form",
-                              jsSetting: true,
-                            },
-                          ],
-                          hidden: { _code: 'return !getSettingValue(data?.customContent) || getSettingValue(data?.extraFormSelectionMode) === "dynamic";', _mode: 'code', _value: false },
                         })
                         .toJson(),
                     ],

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -49,7 +49,7 @@ const FileUploadComponent: FileUploadComponentDefinition = {
     const enabled = !model.readOnly;
 
     return (
-      <ConfigurableFormItem<FileUploadValue> model={model}>
+      <ConfigurableFormItem<FileUploadValue> model={model} autoAlignLabel={false}>
         {(value, onChange) => {
           return (
             <FileUploadProvider

--- a/shesha-reactjs/src/providers/notes/contexts.ts
+++ b/shesha-reactjs/src/providers/notes/contexts.ts
@@ -3,6 +3,7 @@ import { CreateNoteArgs, DeleteNoteArgs, NoteModel, NotesReference, UpdateNoteAr
 
 export type INotesEditorActions = {
   init: (notesReference: NotesReference) => void;
+  setDesignerMode: (isDesignerMode: boolean) => void;
   createNoteAsync: (args: CreateNoteArgs) => Promise<void>;
   updateNoteAsync: (args: UpdateNoteArgs) => Promise<void>;
   deleteNoteAsync: (args: DeleteNoteArgs) => Promise<void>;

--- a/shesha-reactjs/src/providers/notes/hooks.ts
+++ b/shesha-reactjs/src/providers/notes/hooks.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo } from "react";
 import { useHttpClient } from "../sheshaApplication/publicApi";
 import { NotesEditorInstance } from "./instance";
 import { INotesEditorInstance } from "./contexts";
@@ -9,12 +9,12 @@ export const useNotesEditorInstance = (): INotesEditorInstance => {
   const form = useFormOrUndefined();
   const isDesignerMode = form?.formMode === 'designer';
 
-  const [instance] = useState<INotesEditorInstance>(() => {
+  const instance = useMemo<INotesEditorInstance>(() => {
     return new NotesEditorInstance({
       httpClient,
       isDesignerMode,
     });
-  });
+  }, [httpClient, isDesignerMode]);
 
   return instance;
 };

--- a/shesha-reactjs/src/providers/notes/hooks.ts
+++ b/shesha-reactjs/src/providers/notes/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useRef } from "react";
 import { useHttpClient } from "../sheshaApplication/publicApi";
 import { NotesEditorInstance } from "./instance";
 import { INotesEditorInstance } from "./contexts";
@@ -9,12 +9,22 @@ export const useNotesEditorInstance = (): INotesEditorInstance => {
   const form = useFormOrUndefined();
   const isDesignerMode = form?.formMode === 'designer';
 
-  const instance = useMemo<INotesEditorInstance>(() => {
-    return new NotesEditorInstance({
+  // Use ref to maintain stable instance across renders, preserving mutable state (#notes, #notesReference)
+  const instanceRef = useRef<INotesEditorInstance | null>(null);
+
+  if (instanceRef.current === null) {
+    instanceRef.current = new NotesEditorInstance({
       httpClient,
       isDesignerMode,
     });
-  }, [httpClient, isDesignerMode]);
+  }
 
-  return instance;
+  // Update designer mode on the existing instance without recreation
+  useEffect(() => {
+    if (instanceRef.current) {
+      instanceRef.current.setDesignerMode(isDesignerMode);
+    }
+  }, [isDesignerMode]);
+
+  return instanceRef.current;
 };

--- a/shesha-reactjs/src/providers/notes/hooks.ts
+++ b/shesha-reactjs/src/providers/notes/hooks.ts
@@ -2,13 +2,17 @@ import { useState } from "react";
 import { useHttpClient } from "../sheshaApplication/publicApi";
 import { NotesEditorInstance } from "./instance";
 import { INotesEditorInstance } from "./contexts";
+import { useFormOrUndefined } from "../form";
 
 export const useNotesEditorInstance = (): INotesEditorInstance => {
   const httpClient = useHttpClient();
+  const form = useFormOrUndefined();
+  const isDesignerMode = form?.formMode === 'designer';
 
   const [instance] = useState<INotesEditorInstance>(() => {
     return new NotesEditorInstance({
       httpClient,
+      isDesignerMode,
     });
   });
 

--- a/shesha-reactjs/src/providers/notes/instance.ts
+++ b/shesha-reactjs/src/providers/notes/instance.ts
@@ -28,6 +28,10 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
     this.#isDesignerMode = args.isDesignerMode ?? false;
   }
 
+  setDesignerMode = (isDesignerMode: boolean): void => {
+    this.#isDesignerMode = isDesignerMode;
+  };
+
   init = (notesReference: NotesReference): void => {
     if (isDefined(this.#notesReference) && notesReferenceEqual(this.#notesReference, notesReference))
       return;

--- a/shesha-reactjs/src/providers/notes/instance.ts
+++ b/shesha-reactjs/src/providers/notes/instance.ts
@@ -11,6 +11,7 @@ import { INotesEditorActions, INotesEditorState } from "./contexts";
 
 export type NotesEditorInstanceArgs = {
   httpClient: HttpClientApi;
+  isDesignerMode?: boolean;
 };
 
 export class NotesEditorInstance implements INotesEditorActions, INotesEditorState {
@@ -20,8 +21,11 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
 
   #notesReference: NotesReference | undefined;
 
+  #isDesignerMode: boolean;
+
   constructor(args: NotesEditorInstanceArgs) {
     this.#httpClient = args.httpClient;
+    this.#isDesignerMode = args.isDesignerMode ?? false;
   }
 
   init = (notesReference: NotesReference): void => {
@@ -29,7 +33,8 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
       return;
 
     this.#notesReference = notesReference;
-    if (isOwnerReferenceValid(this.#notesReference))
+    // Skip API calls in designer/config mode to prevent errors from incomplete data
+    if (!this.#isDesignerMode && isOwnerReferenceValid(this.#notesReference))
       this.fetchNotesAsync()
         .catch((error) => {
           console.error('Failed to fetch notes', error);

--- a/shesha-reactjs/src/providers/storedFile/instance.ts
+++ b/shesha-reactjs/src/providers/storedFile/instance.ts
@@ -180,6 +180,8 @@ export class FileUploadInstance implements IFileUpload {
     }
 
     this.clearFileInfo();
+    // Clear the bound form value so required validation re-triggers and stale ids aren't kept.
+    this.#onChange?.(null);
   };
 
   init = (args: FileUploadInitArgs): void => {

--- a/shesha-reactjs/src/providers/storedFiles/hooks.ts
+++ b/shesha-reactjs/src/providers/storedFiles/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { AttachmentsEditorInstance } from "./instance";
 import { useHttpClient } from "../sheshaApplication/publicApi";
 import { App } from "antd";
@@ -13,14 +13,20 @@ export const useAttachmentsEditorInstance = (): IAttachmentsEditorInstance => {
   const form = useFormOrUndefined();
   const isDesignerMode = form?.formMode === 'designer';
 
+  // Store delayedUpdateClient in a ref to avoid recreating instance when it changes identity
+  const delayedUpdateClientRef = useRef(delayedUpdateClient);
+  delayedUpdateClientRef.current = delayedUpdateClient;
+
+  // Only recreate instance when isDesignerMode changes (which should trigger state reset)
+  // httpClient and message are stable, delayedUpdateClient is accessed via ref
   const instance = useMemo<IAttachmentsEditorInstance>(() => {
     return new AttachmentsEditorInstance({
       httpClient,
       message,
-      delayedUpdateClient,
+      delayedUpdateClient: delayedUpdateClientRef.current,
       isDesignerMode,
     });
-  }, [httpClient, message, delayedUpdateClient, isDesignerMode]);
+  }, [httpClient, message, isDesignerMode]);
 
   return instance;
 };

--- a/shesha-reactjs/src/providers/storedFiles/hooks.ts
+++ b/shesha-reactjs/src/providers/storedFiles/hooks.ts
@@ -4,17 +4,21 @@ import { useHttpClient } from "../sheshaApplication/publicApi";
 import { App } from "antd";
 import { useDelayedUpdateOrUndefined } from "../delayedUpdateProvider";
 import { IAttachmentsEditorInstance } from "./contexts";
+import { useFormOrUndefined } from "../form";
 
 export const useAttachmentsEditorInstance = (): IAttachmentsEditorInstance => {
   const httpClient = useHttpClient();
   const { message } = App.useApp();
   const delayedUpdateClient = useDelayedUpdateOrUndefined();
+  const form = useFormOrUndefined();
+  const isDesignerMode = form?.formMode === 'designer';
 
   const [instance] = useState<IAttachmentsEditorInstance>(() => {
     return new AttachmentsEditorInstance({
       httpClient,
       message,
       delayedUpdateClient,
+      isDesignerMode,
     });
   });
 

--- a/shesha-reactjs/src/providers/storedFiles/hooks.ts
+++ b/shesha-reactjs/src/providers/storedFiles/hooks.ts
@@ -13,17 +13,17 @@ export const useAttachmentsEditorInstance = (): IAttachmentsEditorInstance => {
   const form = useFormOrUndefined();
   const isDesignerMode = form?.formMode === 'designer';
 
-  // Store delayedUpdateClient in a ref to avoid recreating instance when it changes identity
+  // Store delayedUpdateClient in a ref so instance can access latest value without recreation
   const delayedUpdateClientRef = useRef(delayedUpdateClient);
   delayedUpdateClientRef.current = delayedUpdateClient;
 
   // Only recreate instance when isDesignerMode changes (which should trigger state reset)
-  // httpClient and message are stable, delayedUpdateClient is accessed via ref
+  // httpClient and message are stable, delayedUpdateClient ref is passed and dereferenced inside instance
   const instance = useMemo<IAttachmentsEditorInstance>(() => {
     return new AttachmentsEditorInstance({
       httpClient,
       message,
-      delayedUpdateClient: delayedUpdateClientRef.current,
+      delayedUpdateClientRef,
       isDesignerMode,
     });
   }, [httpClient, message, isDesignerMode]);

--- a/shesha-reactjs/src/providers/storedFiles/hooks.ts
+++ b/shesha-reactjs/src/providers/storedFiles/hooks.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo } from "react";
 import { AttachmentsEditorInstance } from "./instance";
 import { useHttpClient } from "../sheshaApplication/publicApi";
 import { App } from "antd";
@@ -13,14 +13,14 @@ export const useAttachmentsEditorInstance = (): IAttachmentsEditorInstance => {
   const form = useFormOrUndefined();
   const isDesignerMode = form?.formMode === 'designer';
 
-  const [instance] = useState<IAttachmentsEditorInstance>(() => {
+  const instance = useMemo<IAttachmentsEditorInstance>(() => {
     return new AttachmentsEditorInstance({
       httpClient,
       message,
       delayedUpdateClient,
       isDesignerMode,
     });
-  });
+  }, [httpClient, message, delayedUpdateClient, isDesignerMode]);
 
   return instance;
 };

--- a/shesha-reactjs/src/providers/storedFiles/instance.ts
+++ b/shesha-reactjs/src/providers/storedFiles/instance.ts
@@ -13,11 +13,12 @@ import { fileListReferenceEqual, getFileExtension, storedFileDtoToModel } from "
 import { OnFileDownloaded, OnFileListChanged } from "./models";
 import { isOwnerReferenceValid } from "@/utils/entity";
 import { isFile } from "@/utils/fileValidation";
+import { RefObject } from "react";
 
 export type StoredFilesProcessorArgs = {
   httpClient: HttpClientApi;
   message: MessageInstance;
-  delayedUpdateClient: DelayedUpdateClient | undefined;
+  delayedUpdateClientRef: RefObject<DelayedUpdateClient | undefined>;
   isDesignerMode?: boolean;
 };
 
@@ -30,7 +31,7 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
 
   #fileHelper: IStoredFileHelper;
 
-  #delayedUpdateClient: DelayedUpdateClient | undefined;
+  #delayedUpdateClientRef: RefObject<DelayedUpdateClient | undefined>;
 
   #onChange: OnFileListChanged | undefined;
 
@@ -42,7 +43,7 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
 
   constructor(args: StoredFilesProcessorArgs) {
     this.#message = args.message;
-    this.#delayedUpdateClient = args.delayedUpdateClient;
+    this.#delayedUpdateClientRef = args.delayedUpdateClientRef;
     this.#fileHelper = new StoredFileHelper(args.httpClient);
     this.#subscriptionManager = new SubscriptionManager<AttachmentsEditorEvents, IAttachmentsEditorInstance>();
     this.#isDesignerMode = args.isDesignerMode ?? false;
@@ -139,7 +140,7 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
       if (!isFile(file))
         throw new Error('File is not a file');
 
-      if (isNullOrWhiteSpace(ownerId) && !this.#delayedUpdateClient)
+      if (isNullOrWhiteSpace(ownerId) && !this.#delayedUpdateClientRef.current)
         throw new Error("Delayed update client is mandatory if owner id is not defined");
 
       const newFile: StoredFileModel = {
@@ -159,8 +160,8 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
 
       this.updateFileByUid(fileUid, () => storedFileDtoToModel(responseFile));
 
-      if (responseFile.temporary && this.#delayedUpdateClient)
-        this.#delayedUpdateClient.addItem(STORED_FILES_DELAYED_UPDATE, responseFile.id, {
+      if (responseFile.temporary && this.#delayedUpdateClientRef.current)
+        this.#delayedUpdateClientRef.current.addItem(STORED_FILES_DELAYED_UPDATE, responseFile.id, {
           ownerName: uploadArgs.ownerName,
         });
 
@@ -227,8 +228,8 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
       // Remove using the original fileId to handle both id and uid lookups
       this.updateFileList((files) => files.filter((f) => f.id !== fileId && f.uid !== fileId));
 
-      if (this.#delayedUpdateClient)
-        this.#delayedUpdateClient.removeItem(STORED_FILES_DELAYED_UPDATE, persistedId);
+      if (this.#delayedUpdateClientRef.current)
+        this.#delayedUpdateClientRef.current.removeItem(STORED_FILES_DELAYED_UPDATE, persistedId);
 
       this.#onChange?.(this.#fileList, true);
     } catch (error) {

--- a/shesha-reactjs/src/providers/storedFiles/instance.ts
+++ b/shesha-reactjs/src/providers/storedFiles/instance.ts
@@ -18,6 +18,7 @@ export type StoredFilesProcessorArgs = {
   httpClient: HttpClientApi;
   message: MessageInstance;
   delayedUpdateClient: DelayedUpdateClient | undefined;
+  isDesignerMode?: boolean;
 };
 
 export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
@@ -37,11 +38,14 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
 
   #subscriptionManager: SubscriptionManager<AttachmentsEditorEvents, IAttachmentsEditorInstance>;
 
+  #isDesignerMode: boolean;
+
   constructor(args: StoredFilesProcessorArgs) {
     this.#message = args.message;
     this.#delayedUpdateClient = args.delayedUpdateClient;
     this.#fileHelper = new StoredFileHelper(args.httpClient);
     this.#subscriptionManager = new SubscriptionManager<AttachmentsEditorEvents, IAttachmentsEditorInstance>();
+    this.#isDesignerMode = args.isDesignerMode ?? false;
   }
 
   subscribe: SubscribeFunc<AttachmentsEditorEvents, IAttachmentsEditorInstance> = (type, callback) => {
@@ -73,7 +77,8 @@ export class AttachmentsEditorInstance implements IAttachmentsEditorInstance {
       return;
 
     this.#fileListReference = fileListReference;
-    if (isOwnerReferenceValid(this.#fileListReference))
+    // Skip API calls in designer/config mode to prevent errors from incomplete data
+    if (!this.#isDesignerMode && isOwnerReferenceValid(this.#fileListReference))
       void this.fetchFilesList();
   };
 

--- a/shesha-reactjs/src/utils/storedFile/utils.ts
+++ b/shesha-reactjs/src/utils/storedFile/utils.ts
@@ -5,9 +5,16 @@ import { StoredFileDto } from "./api-models";
 import { ownerTypeToString } from "../entity";
 import { UploadFile } from "antd";
 
+const GUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 export const validateFileReference = (fileReference: FileReference): void => {
   if (isNullOrWhiteSpace(fileReference.ownerId))
     throw new Error('ownerId is required');
+  // ownerId must be a well-formed GUID before it is sent to the back-end. A partially typed or
+  // malformed value would otherwise reach api/StoredFile/EntityProperty and fail server-side with
+  // "Unrecognized Guid format".
+  if (!GUID_REGEX.test(fileReference.ownerId))
+    throw new Error('ownerId is not a valid GUID');
   if (isEntityTypeIdEmpty(fileReference.ownerType))
     throw new Error('ownerType is required');
   if (isNullOrWhiteSpace(fileReference.propertyName))


### PR DESCRIPTION
#5106
#5120

- Introduced `resolveThumbnailSize` utility to ensure valid thumbnail dimensions are always sent to the backend, preventing 1x1 placeholder images.
- Updated `FileUpload` and `StoredFilesRendererBase` components to utilize the new thumbnail resolution logic.
- Improved styling logic in `FileUpload` to conditionally apply styles based on the list type.
- Cleaned up unused styles and comments in `styles.ts` for better maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thumbnail previews now use consistent, concrete sizing and support an additional fit option for better image rendering.
  * File uploads now clear the selected value properly after deletion.

* **Bug Fixes**
  * Read-only file upload views now render nothing when no file is available, avoiding empty placeholder UI.
  * File references are now validated more strictly to reject invalid identifiers.

* **Style**
  * File upload layout and thumbnail styling were refined for more consistent appearance across display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->