### PR TITLE
feat: Implement step persistence in wizard component

### DIFF
--- a/shesha-reactjs/src/designer-components/wizard/hooks.ts
+++ b/shesha-reactjs/src/designer-components/wizard/hooks.ts
@@ -1,12 +1,12 @@
 import { componentsTreeToFlatStructure, executeScriptSync, useAvailableConstantsData } from '@/providers/form/utils';
 import { getStepDescritpion, getWizardStep } from './utils';
+import { getInitialStepIndex, getDefaultStepIndex, isValidStepIndex, shouldPersistStep } from './stepSelection';
 import { IActionExecutionContext, IConfigurableActionConfiguration } from '@/interfaces/configurableAction';
 import { IConfigurableFormComponent, isConfigurableFormComponent, useForm, useSheshaApplication, ShaForm } from '@/providers';
 import { IWizardComponentProps, IWizardStepProps } from './models';
 import { useConfigurableAction } from '@/providers/configurableActionsDispatcher';
 import { useEffect, useMemo, useState } from 'react';
-import { useDeepCompareMemo } from '@/hooks';
-import { useFormExpression } from '@/hooks';
+import { useDeepCompareMemo, useFormExpression, useSessionStorage } from '@/hooks';
 import { useFormDesignerComponents } from '@/providers/form/hooks';
 import { useValidator } from '@/providers/validateProvider';
 import { useClosestModal } from '@/providers/dynamicModal';
@@ -32,19 +32,6 @@ interface IWizardComponent {
 
 type IValidatable = IActionExecutionContext & { validate: (() => Promise<void>) | undefined };
 
-const getDefaultStepIndex = (tabs: IWizardStepProps[], i: number | string | undefined): number => {
-  if (typeof (i) === 'number' && i >= 0 && tabs.length > i)
-    return i;
-
-  if (typeof (i) === 'string') {
-    const index = tabs.findIndex((item) => item.id === i);
-    if (index > -1)
-      return index;
-  }
-
-  return 0;
-};
-
 export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
   const { anyOfPermissionsGranted } = useSheshaApplication();
   const allData = useAvailableConstantsData({ topContextId: 'ctx_' + model.id });
@@ -69,12 +56,18 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
     defaultActiveStep = 0,
     showStepStatus = false,
     sequence,
+    persistCurrentStep = true,
   } = model;
   const actionOwnerName = componentName ?? "";
 
-  const [current, setCurrent] = useState(() => {
-    return getDefaultStepIndex(tabs, defaultActiveStep);
-  });
+  // Persist the active step across page refresh (opt-in). Disabled in the designer and inside
+  // modals, since a modal won't reopen on refresh and its stored step would apply out of context.
+  // NOTE: useClosestModal() has a non-undefined default, so check `instance` to detect a real modal.
+  const canPersist = shouldPersistStep(persistCurrentStep, formMode, !!closestModal?.instance);
+  const stepStorageKey = `wizard-step:${actionsOwnerId}`;
+  const [storedStep, setStoredStep] = useSessionStorage<number | undefined>(stepStorageKey);
+
+  const [current, setCurrent] = useState(() => getInitialStepIndex(canPersist, storedStep, tabs, defaultActiveStep));
 
   const { componentRelations, allComponents } = ShaForm.useMarkup();
 
@@ -149,7 +142,11 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
   const argumentsEvaluationContext = { ...allData, fieldsToValidate: componentsNames, validate: validator?.validate };
 
   useEffect(() => {
+    // Don't clobber a valid persisted step on mount/tabs change when persistence is active.
+    if (canPersist && isValidStepIndex(storedStep, tabs))
+      return;
     setCurrent(getDefaultStepIndex(tabs, defaultActiveStep));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultActiveStep, tabs]);
 
   useEffect(() => {
@@ -173,12 +170,18 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
     }
   };
 
+  const applyStep = (stepIndex: number): void => {
+    setCurrent(stepIndex);
+    if (canPersist)
+      setStoredStep(stepIndex);
+  };
+
   const successCallback = (type: 'back' | 'next' | 'reset'): void => {
     setTimeout(() => {
       const step = getWizardStep(visibleSteps, current, type);
 
       if (step >= 0 && step !== current) {
-        setCurrent(step);
+        applyStep(step);
       }
     }, 100); // It is necessary to have time to complete a request
   };
@@ -265,6 +268,11 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
       executeActionIfConfigured(
         (tab) => tab.beforeDoneActionConfiguration,
         (tab) => tab.afterDoneActionConfiguration,
+        () => {
+          // Wizard finished - drop the persisted step so a later visit starts fresh.
+          if (canPersist)
+            setStoredStep(undefined);
+        },
       );
     } catch (errInfo) {
       console.error("Couldn't Proceed", errInfo);
@@ -278,7 +286,7 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
   const setStep = (stepIndex: number): void => {
     if (stepIndex < 0 || stepIndex >= visibleSteps.length)
       throw `Step with index ${stepIndex} is not available`;
-    setCurrent(stepIndex);
+    applyStep(stepIndex);
   };
 
   // #region configurable actions

--- a/shesha-reactjs/src/designer-components/wizard/index.tsx
+++ b/shesha-reactjs/src/designer-components/wizard/index.tsx
@@ -32,6 +32,7 @@ const TabsComponent: IToolboxComponent<Omit<IWizardComponentProps, 'size'>> = {
   },
   initModel: (model) => ({
     ...model,
+    persistCurrentStep: model.persistCurrentStep ?? true,
     steps: isDefined(model.steps)
       ? model.steps.map((step) => ({
         ...step,
@@ -117,7 +118,9 @@ const TabsComponent: IToolboxComponent<Omit<IWizardComponentProps, 'size'>> = {
             },
           }))
           : [],
-      })),
+      }))
+      // Step persistence is enabled by default; existing wizards without the flag opt in.
+      .add<IWizardComponentProps>(10, (prev) => ({ ...prev, persistCurrentStep: prev.persistCurrentStep ?? true })),
   settingsFormMarkup: getSettings,
   validateSettings: (model) => validateConfigurableComponentSettings(getSettings, model),
 

--- a/shesha-reactjs/src/designer-components/wizard/models.ts
+++ b/shesha-reactjs/src/designer-components/wizard/models.ts
@@ -92,6 +92,7 @@ export interface IWizardComponentProps extends Omit<IConfigurableFormComponent, 
   labelPlacement?: 'vertical' | 'horizontal' | undefined;
   buttonsLayout?: 'left' | 'right' | 'spaceBetween' | undefined;
   showStepStatus?: boolean | undefined;
+  persistCurrentStep?: boolean | undefined;
   sequence?: IWizardSequence | undefined;
   primaryTextColor?: React.CSSProperties['color'] | undefined;
   primaryBgColor?: React.CSSProperties['color'] | undefined;

--- a/shesha-reactjs/src/designer-components/wizard/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/wizard/settingsForm.ts
@@ -120,6 +120,20 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                   },
                 ],
               })
+              .addSettingsInputRow({
+                id: nanoid(),
+                inputs: [
+                  {
+                    id: nanoid(),
+                    propertyName: 'persistCurrentStep',
+                    label: 'Persist Current Step',
+                    parentId: 'root',
+                    type: 'switch',
+                    tooltip: 'Keep the user on the same step after a page refresh (restored per browser tab).',
+                    jsSetting: true,
+                  },
+                ],
+              })
               .addSettingsInputRow(
                 {
                   id: nanoid(),

--- a/shesha-reactjs/src/designer-components/wizard/stepSelection.ts
+++ b/shesha-reactjs/src/designer-components/wizard/stepSelection.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure step-selection helpers for the wizard.
+ *
+ * Kept free of any `@/...` imports (uses structural types only) so the logic can be
+ * unit-tested in isolation without loading the wizard's provider graph.
+ */
+
+/** Minimal shape needed to resolve a step index - matches IWizardStepProps structurally. */
+export interface IStepIdentity {
+  id?: string;
+}
+
+/** True when `i` is a usable index into `tabs`. */
+export const isValidStepIndex = (i: number | undefined, tabs: ReadonlyArray<IStepIdentity>): i is number =>
+  typeof (i) === 'number' && i >= 0 && i < tabs.length;
+
+/**
+ * Resolve the configured default step: a numeric index, a step id (string), or 0 as a fallback.
+ */
+export const getDefaultStepIndex = (tabs: ReadonlyArray<IStepIdentity>, i: number | string | undefined): number => {
+  if (typeof (i) === 'number' && i >= 0 && tabs.length > i)
+    return i;
+
+  if (typeof (i) === 'string') {
+    const index = tabs.findIndex((item) => item.id === i);
+    if (index > -1)
+      return index;
+  }
+
+  return 0;
+};
+
+/**
+ * Whether the wizard should persist its step. Opt-in, and never in the designer or inside a
+ * modal (a modal won't reopen on refresh, so a restored step would apply out of context).
+ */
+export const shouldPersistStep = (
+  persistCurrentStep: boolean,
+  formMode: string | undefined,
+  isInsideModal: boolean,
+): boolean => persistCurrentStep && formMode !== 'designer' && !isInsideModal;
+
+/**
+ * Pick the step to open on mount: a valid persisted step when persistence is active,
+ * otherwise the configured default step.
+ */
+export const getInitialStepIndex = (
+  canPersist: boolean,
+  storedStep: number | undefined,
+  tabs: ReadonlyArray<IStepIdentity>,
+  defaultActiveStep: number | string | undefined,
+): number => {
+  if (canPersist && isValidStepIndex(storedStep, tabs))
+    return storedStep;
+  return getDefaultStepIndex(tabs, defaultActiveStep);
+};


### PR DESCRIPTION
This pull request adds support for persisting the current step in the wizard component, allowing users to stay on the same step after a page refresh (on a per-browser-tab basis). Step persistence is opt-in via a new `persistCurrentStep` flag, which is enabled by default for new and existing wizards. The implementation is careful to avoid persisting steps in the form designer and inside modals. The logic for step selection and persistence is refactored into a new utility module for easier testing and code clarity.

Wizard step persistence:

* Added a new `persistCurrentStep` boolean property to `IWizardComponentProps`, with UI support in the settings form and defaulting to `true` for new and existing wizards. [[1]](diffhunk://#diff-84bb4ad8c0dd122cd643b1f7f2163aea2aa2b65a97ec1025c5bcdf46a7cbc7b0R95) [[2]](diffhunk://#diff-b151b2173e0f19cf260931ff7f38699f501df57a11ba768fd20a33a24a211088R35) [[3]](diffhunk://#diff-b151b2173e0f19cf260931ff7f38699f501df57a11ba768fd20a33a24a211088L120-R123) [[4]](diffhunk://#diff-7c4d0eaa8e1923cbf2811d90725dc237cc74d13154ac4179fb5041aba3e94c58R123-R136)
* The wizard now persists the current step index to session storage when `persistCurrentStep` is enabled, restoring it after a page refresh. Persistence is disabled in the designer and in modals to avoid context issues. [[1]](diffhunk://#diff-6a8417f343e09f0cd2971dfd193732c4a063d47bbea5b9047ce7f735f1177a2dR59-R70) [[2]](diffhunk://#diff-6a8417f343e09f0cd2971dfd193732c4a063d47bbea5b9047ce7f735f1177a2dR145-R149)
* When the wizard is completed, the persisted step is cleared so a later visit starts fresh.

Step selection logic refactoring:

* Extracted step index resolution and persistence logic into a new pure utility module `stepSelection.ts`, including helpers like `getDefaultStepIndex`, `getInitialStepIndex`, `isValidStepIndex`, and `shouldPersistStep`. [[1]](diffhunk://#diff-318d491ccb9f310d44c4ff1888a71b0bd5a64d4d7a82b74b57a9ab88dcc474d7R1-R56) [[2]](diffhunk://#diff-6a8417f343e09f0cd2971dfd193732c4a063d47bbea5b9047ce7f735f1177a2dR3-R9) [[3]](diffhunk://#diff-6a8417f343e09f0cd2971dfd193732c4a063d47bbea5b9047ce7f735f1177a2dL35-L47)
* Updated wizard navigation to use the new helpers, ensuring consistent and testable step selection and persistence behavior. [[1]](diffhunk://#diff-6a8417f343e09f0cd2971dfd193732c4a063d47bbea5b9047ce7f735f1177a2dR173-R184) [[2]](diffhunk://#diff-6a8417f343e09f0cd2971dfd193732c4a063d47bbea5b9047ce7f735f1177a2dL281-R289)

Related to issue (#4574)