### PR TITLE
Remove redundant variables and related code from labelValueEditor and settingsControl components

### DIFF
--- a/shesha-reactjs/src/components/codeVariablesTable/index.tsx
+++ b/shesha-reactjs/src/components/codeVariablesTable/index.tsx
@@ -1,42 +1,6 @@
-import { Table, Tag } from 'antd';
-import { nanoid } from '@/utils/uuid';
-import React, { FC, useMemo } from 'react';
-import { ColumnsType } from 'antd/es/table';
-
-const columns: ColumnsType<ICodeExposedVariable> = [
-  {
-    title: 'Variable name',
-    dataIndex: 'name',
-    key: 'name',
-  },
-  {
-    title: 'Description',
-    dataIndex: 'description',
-    key: 'description',
-  },
-  {
-    title: 'Datatype',
-    key: 'type',
-    dataIndex: 'type',
-    render: (tag: string) => <Tag key={tag}>{tag}</Tag>,
-  },
-];
-
 export interface ICodeExposedVariable {
   id?: string;
   name: string;
   description: string;
   type: string;
 }
-
-export interface ICodeVariablesTableProps {
-  data?: ICodeExposedVariable[] | undefined;
-}
-
-export const CodeVariablesTables: FC<ICodeVariablesTableProps> = ({ data }) => {
-  const mappedVariables = useMemo(() => {
-    return data?.map<ICodeExposedVariable>(({ id, ...rest }) => ({ ...rest, id: id ?? nanoid() }));
-  }, [data]);
-
-  return <Table columns={columns} dataSource={mappedVariables} pagination={false} rowKey="id" />;
-};

--- a/shesha-reactjs/src/components/labelValueEditor/labelValueEditor.tsx
+++ b/shesha-reactjs/src/components/labelValueEditor/labelValueEditor.tsx
@@ -8,10 +8,8 @@ import {
   Input,
   Modal,
   Row,
-  Tabs,
 } from 'antd';
 import { BorderlessTableOutlined } from '@ant-design/icons';
-import { CodeVariablesTables, ICodeExposedVariable } from '@/components/codeVariablesTable';
 import { ILabelValueEditorPropsBase } from './interfaces';
 import { ListEditor } from '@/components/listEditor';
 import { ItemChangeDetails } from '../listEditor';
@@ -34,8 +32,6 @@ export interface ILabelValueEditorProps extends ILabelValueEditorPropsBase {
   onChange?: ((newValue: ILabelValueItem[]) => void) | undefined;
 
   mode?: 'dialog' | 'inline' | undefined;
-
-  exposedVariables?: ICodeExposedVariable[] | undefined;
 
   description?: string | undefined;
 
@@ -74,7 +70,6 @@ const LabelValueEditor: FC<ILabelValueEditorProps> = ({
   valueName = "value",
   description,
   mode = 'dialog',
-  exposedVariables,
   readOnly = false,
 }) => {
   const [showModal, setShowModal] = useState(false);
@@ -108,12 +103,7 @@ const LabelValueEditor: FC<ILabelValueEditorProps> = ({
               <Alert type="info" title={description} />
               <br />
             </Show>
-            <Tabs
-              items={[
-                { key: "keyValuePairs", label: "Key/Value pairs", children: children },
-                { key: "variable", label: "Variables", children: <CodeVariablesTables data={exposedVariables} /> },
-              ]}
-            />
+            {children}
           </Modal>
         </Fragment>
       )}

--- a/shesha-reactjs/src/designer-components/_settings/settingsControl.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/settingsControl.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useCallback } from 'react';
 import { getPropertySettingsFromValue } from './utils/utils';
 import { useStyles } from './styles/styles';
-import { ICodeExposedVariable } from '@/components/codeVariablesTable';
 import camelcase from 'camelcase';
 import { GetAvailableConstantsFunc, GetResultTypeFunc, ICodeEditorProps } from '../codeEditor/interfaces';
 import { CodeEditorWithStandardConstants } from '../codeEditor/codeEditorWithConstants';
@@ -32,21 +31,6 @@ export interface ISettingsControlProps<Value = unknown> {
   useAsyncEvaluation?: boolean | undefined;
   lazy?: boolean | undefined;
 }
-
-export const defaultExposedVariables: ICodeExposedVariable[] = [
-  { name: "data", description: "Selected form values", type: "object" },
-  { name: "pageContext", description: "Contexts data of current page", type: "object" },
-  { name: "contexts", description: "Contexts data", type: "object" },
-  { name: "globalState", description: "Global state", type: "object" },
-  { name: "setGlobalState", description: "Functiont to set globalState", type: "function" },
-  { name: "formMode", description: "Form mode", type: "'designer' | 'edit' | 'readonly'" },
-  { name: "form", description: "Form instance", type: "object" },
-  { name: "selectedRow", description: "Selected row of nearest table (null if not available)", type: "object" },
-  { name: "moment", description: "moment", type: "object" },
-  { name: "http", description: "axiosHttp", type: "object" },
-  { name: "message", description: "message framework", type: "object" },
-  { name: "modal", description: "API for displaying modal dialogs and forms", type: "object" },
-];
 
 export const SettingsControl = <Value = unknown>(props: ISettingsControlProps<Value>): ReactElement => {
   const { onChange } = props;

--- a/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/filters/filterItemSettingsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/tableViewSelector/filters/filterItemSettingsEditor.tsx
@@ -1,4 +1,3 @@
-import { CodeVariablesTables } from '@/components/codeVariablesTable';
 import { ListEditorRenderer } from '@/components/listEditorRenderer';
 import QueryBuilderExpressionViewer from '@/designer-components/queryBuilder/queryBuilderExpressionViewer';
 import { QueryBuilderPlainRenderer } from '@/designer-components/queryBuilder/queryBuilderFieldPlain';
@@ -65,28 +64,6 @@ export const FilterItemSettingsEditor: FC<IFilterItemSettingsEditorProps> = ({ v
             key: 'expressionViewerTab',
             label: 'Query expression viewer',
             children: <QueryBuilderExpressionViewer value={expressionObject} />,
-          },
-          {
-            key: 'exposedVariables',
-            label: 'Variables',
-            children: (
-              <CodeVariablesTables
-                data={[
-                  {
-                    id: '61955479-c9fd-4613-b639-d2be14795245',
-                    name: 'data',
-                    description: 'The state of the form',
-                    type: 'object',
-                  },
-                  {
-                    id: 'e27dd783-c204-4b53-a6a0-babe4cb46e39',
-                    name: 'globalState',
-                    description: 'The global state',
-                    type: 'object',
-                  },
-                ]}
-              />
-            ),
           },
         ]}
       />

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/labelValueEditor.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/labelValueEditor.tsx
@@ -1,9 +1,8 @@
 import { LabelValueEditor } from '@/components/labelValueEditor/labelValueEditor';
-import { defaultExposedVariables } from '@/designer-components/_settings/settingsControl';
 import { ILabelValueEditorSettingsInputProps } from '@/designer-components/settingsInput/interfaces';
 import React from 'react';
 import { FCUnwrapped } from '@/providers/form/models';
 
 export const LabelValueEditorWrapper: FCUnwrapped<ILabelValueEditorSettingsInputProps> = (props) => {
-  return <LabelValueEditor {...props} exposedVariables={defaultExposedVariables} />;
+  return <LabelValueEditor {...props} />;
 };

--- a/shesha-reactjs/src/designer-components/labelValueEditor/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/labelValueEditor/interfaces.ts
@@ -1,11 +1,9 @@
 import { IConfigurableFormComponent } from '@/providers/form/models';
-import { ICodeExposedVariable } from '@/components/codeVariablesTable';
 import { ILabelValueEditorPropsBase } from '@/components/labelValueEditor/interfaces';
 import { ComponentDefinition } from '@/interfaces';
 
 export interface ILabelValueEditorComponentProps extends IConfigurableFormComponent, ILabelValueEditorPropsBase {
   mode?: 'dialog' | 'inline';
-  exposedVariables?: ICodeExposedVariable[];
 }
 
 export type LabelValueEditorComponentDefinition = ComponentDefinition<"labelValueEditor", ILabelValueEditorComponentProps>;


### PR DESCRIPTION
This pull request removes the `CodeVariablesTables` component and all related code, streamlining the codebase by eliminating unused or unnecessary functionality. It also removes the concept of "exposed variables" from the `LabelValueEditor` and related components, simplifying their interfaces and usage.

### Component and Interface Cleanup

* Removed the `CodeVariablesTables` component and its associated interface `ICodeExposedVariable` from the codebase, along with all references and usages. [[1]](diffhunk://#diff-c5c26bc9392aecff1bc497bbdebe56848ff7209933d5ac6e4ab112fd411de0dfL1-L42) [[2]](diffhunk://#diff-0320e45fd5ee09dc1c018491abc3c44e6ab43e7b1812fb1bd44697cee19355d6L1) [[3]](diffhunk://#diff-0320e45fd5ee09dc1c018491abc3c44e6ab43e7b1812fb1bd44697cee19355d6L69-L90)
* Removed the `exposedVariables` prop from `LabelValueEditor` and related interfaces, and eliminated the default exposed variables definition. [[1]](diffhunk://#diff-72c6d3dbf4c70f9eeb413e8e4796cb9a59c7d81ed8f7384be966435890c17657L38-L39) [[2]](diffhunk://#diff-72c6d3dbf4c70f9eeb413e8e4796cb9a59c7d81ed8f7384be966435890c17657L77) [[3]](diffhunk://#diff-6d50cf6a50cd7561e06ac6b202c208df4dd68b9f78a02d2716906e139a2f3957L4) [[4]](diffhunk://#diff-6d50cf6a50cd7561e06ac6b202c208df4dd68b9f78a02d2716906e139a2f3957L36-L50) [[5]](diffhunk://#diff-4c5a71e0de01f62f779ba443c0d09a68cf349da1232f10aff91300b64cef0a4fL2-R7) [[6]](diffhunk://#diff-1f8d1155cef9a3b9860b88c7b64e004425169cfff465b871ae64a2b12ea2fdfaL2-L8)

### UI Simplification

* Simplified the `LabelValueEditor` modal by removing the tabs for variables, displaying only the key/value pairs editor.

These changes reduce complexity and improve maintainability by removing unused features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the label/value editor modal to show only the main editor content.
  * Removed the separate Variables tab from several configuration panels.
  * Cleaned up related editor settings so they no longer pass or display unused variable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related to issue: #5078 