### PR TITLE
fix(form-designer): preserve DataContext children on save

### DIFF
--- a/shesha-reactjs/src/providers/form/utils.ts
+++ b/shesha-reactjs/src/providers/form/utils.ts
@@ -636,11 +636,11 @@ export const componentsFlatStructureToTree = (
         container.push(component);
 
       //  process all childs if any
-      if (id in flat.componentRelations && isComponentsContainer(component)) {
+      if (id in flat.componentRelations && !staticContainerIds.includes(id)) {
         const childComponents: IConfigurableFormComponent[] = [];
         processComponent(childComponents, id);
 
-        component['components'] = childComponents;
+        (component as unknown as Record<string, unknown>)['components'] = childComponents;
       }
 
       // note: this function may be called for custom container without type


### PR DESCRIPTION
#5124 
DataContext children live in componentRelations, so the flat->tree save dropped them when no  array existed (isComponentsContainer gate). Now nested via the relations key. Fixes children vanishing on reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how nested form components are assembled, so child elements are now grouped more reliably in the form structure.
  * Fixed an issue where some components could be missed or incorrectly attached when rendering complex component hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->