### PR TITLE
refactor: optimize markup generation in PropertiesPanel using useMemo

### DIFF
--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/itemListConfiguratorModal.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/itemListConfiguratorModal.tsx
@@ -1,5 +1,5 @@
 import { IItemListConfiguratorModalSettingsInputProps } from '@/designer-components/settingsInput/interfaces';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { FCUnwrapped, FormMarkup } from '@/providers/form/models';
 import { ItemListConfiguratorModal } from '@/designer-components/itemListConfigurator/itemListConfiguratorModal';
 import { Alert } from 'antd';
@@ -11,6 +11,15 @@ const EMPTY_VALUE: ListItemWithId[] = [];
 export const ItemListConfiguratorModalWrapper: FCUnwrapped<IItemListConfiguratorModalSettingsInputProps> = (props) => {
   const { value, onChange, readOnly, size, onAddNewItem, listItemSettingsMarkup, buttonText, buttonTextReadOnly, modalSettings, modalReadonlySettings } = props;
   const activeModalSettings = readOnly ? modalReadonlySettings : modalSettings;
+  const settingsMarkupFactory = useCallback((): FormMarkup => ({
+    components: listItemSettingsMarkup ?? [],
+    formSettings: {
+      colon: false,
+      layout: 'vertical',
+      labelCol: { span: 24 },
+      wrapperCol: { span: 24 },
+    },
+  }), [listItemSettingsMarkup]);
   return (
     <ItemListConfiguratorModal
       value={value ?? EMPTY_VALUE}
@@ -18,17 +27,7 @@ export const ItemListConfiguratorModalWrapper: FCUnwrapped<IItemListConfigurator
       readOnly={readOnly ?? false}
       initNewItem={onAddNewItem}
       size={size}
-      settingsMarkupFactory={() => {
-        return {
-          components: listItemSettingsMarkup ?? [],
-          formSettings: {
-            colon: false,
-            layout: 'vertical',
-            labelCol: { span: 24 },
-            wrapperCol: { span: 24 },
-          },
-        } satisfies FormMarkup;
-      }}
+      settingsMarkupFactory={settingsMarkupFactory}
       itemRenderer={({ item }) => ({
         ...item,
         label: getFirstNonEmptyStringPropertyOrUndefined(item, ["title", "label", "name"]) ?? "",

--- a/shesha-reactjs/src/designer-components/itemListConfigurator/propertiesPanel.tsx
+++ b/shesha-reactjs/src/designer-components/itemListConfigurator/propertiesPanel.tsx
@@ -32,9 +32,10 @@ export const PropertiesPanel = <TItem extends ListItemWithId>(props: IProperties
 
   const markup = useMemo(() => {
     const m = settingsMarkupFactory(item);
-    return { ...m, components: cloneDeep(m.components) };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item]);
+    return Array.isArray(m)
+      ? cloneDeep(m)
+      : { ...m, components: cloneDeep(m.components) };
+  }, [item, settingsMarkupFactory]);
   return (
     <SourceFilesFolderProvider folder={`item-${item.id}`}>
       <ConfigurableForm<TItem>

--- a/shesha-reactjs/src/designer-components/itemListConfigurator/propertiesPanel.tsx
+++ b/shesha-reactjs/src/designer-components/itemListConfigurator/propertiesPanel.tsx
@@ -4,8 +4,9 @@ import { ConfigurableFormInstance } from '@/interfaces';
 import { SourceFilesFolderProvider } from '@/providers/sourceFileManager/sourcesFolderProvider';
 import { sheshaStyles } from '@/styles';
 import { Form } from 'antd';
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
+import { cloneDeep } from 'lodash';
 import { ItemSettingsMarkupFactory } from './interfaces';
 import { ConfigurableForm } from '@/components/configurableForm';
 
@@ -28,7 +29,12 @@ export const PropertiesPanel = <TItem extends ListItemWithId>(props: IProperties
     300,
   );
 
-  const markup = settingsMarkupFactory(item);
+
+  const markup = useMemo(() => {
+    const m = settingsMarkupFactory(item);
+    return { ...m, components: cloneDeep(m.components) };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item]);
   return (
     <SourceFilesFolderProvider folder={`item-${item.id}`}>
       <ConfigurableForm<TItem>

--- a/shesha-reactjs/src/designer-components/propertiesTabs/settings.tsx
+++ b/shesha-reactjs/src/designer-components/propertiesTabs/settings.tsx
@@ -16,6 +16,7 @@ import { DefaultOptionType } from 'antd/lib/select';
 import { getFirstNonEmptyStringPropertyOrUndefined } from '@/utils/object';
 
 const tabSettingsMarkup = itemSettings as FormMarkup;
+const tabSettingsMarkupFactory = (): FormMarkup => tabSettingsMarkup;
 
 const TAB_TYPES: DefaultOptionType[] = [
   { value: 'line', label: 'Line' },
@@ -85,7 +86,7 @@ const TabSettings: FC<ISettingsFormFactoryArgs<IPropertiesTabsComponentProps>> =
           <ItemListConfiguratorModal<ITabPaneProps>
             readOnly={readOnly}
             initNewItem={onAddNewItem}
-            settingsMarkupFactory={() => tabSettingsMarkup}
+            settingsMarkupFactory={tabSettingsMarkupFactory}
             itemRenderer={({ item }) => ({
               label: getFirstNonEmptyStringPropertyOrUndefined(item, ["title", "label", "name"]) ?? "",
               description: item.tooltip,


### PR DESCRIPTION
This pull request improves the stability and performance of the `PropertiesPanel` component by ensuring that the `markup.components` object is deeply cloned and only recalculated when the `item` changes. This helps prevent unintended side effects and unnecessary re-renders.

**Performance and stability improvements:**

* [`propertiesPanel.tsx`](diffhunk://#diff-da69aae8538e374176f8dba91636876bc27d5aa6cfdf1931554be7f592408dc9L7-R9): Wrapped the creation of `markup` in a `useMemo` hook to memoize the value and avoid unnecessary recalculations. The `components` property of the markup is now deeply cloned using `cloneDeep` to prevent mutation side effects. [[1]](diffhunk://#diff-da69aae8538e374176f8dba91636876bc27d5aa6cfdf1931554be7f592408dc9L7-R9) [[2]](diffhunk://#diff-da69aae8538e374176f8dba91636876bc27d5aa6cfdf1931554be7f592408dc9L31-R37)
* [`propertiesPanel.tsx`](diffhunk://#diff-da69aae8538e374176f8dba91636876bc27d5aa6cfdf1931554be7f592408dc9L7-R9): Added the `cloneDeep` import from `lodash` to support deep cloning of objects.

Related issue:  #5079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh behavior for item list settings to reduce unexpected UI inconsistencies caused by reused/updated markup.
  * Made generated configuration content safer to reuse by preventing later changes from affecting already-rendered UI.
* **Performance**
  * Reduced unnecessary recalculations by memoizing settings markup generation and reusing stable factory outputs across renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->