### PR TITLE
fix(subform): reset derived form state when selection mode changes (#…

### DIFF
--- a/shesha-reactjs/src/providers/subForm/index.tsx
+++ b/shesha-reactjs/src/providers/subForm/index.tsx
@@ -172,7 +172,16 @@ const SubFormProvider: FC<PropsWithChildren<ISubFormProviderProps>> = (props) =>
   }, [formId, formConfig.formId, formSelectionMode]);
 
   useEffect(() => {
+    // A selection-mode change invalidates the previously resolved form. Reset all derived state
+    // (render guard, per-entity-type cache and the resolved formConfig) so the mode-specific
+    // effects re-resolve from scratch instead of racing on values left over from the other mode.
+    // Without this the subform gets stuck on the previous form - or blanks out - after switching
+    // between 'name' and 'dynamic' (#5087).
     prevRenderedEntityTypeForm.current = null;
+    entityTypeFormCache.current = {};
+    setFormConfig({ formId: formSelectionMode === 'dynamic' ? undefined : formId, lazy: true });
+    // only react to mode changes here; formId changes are handled by the sync effect above
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formSelectionMode]);
 
   const setMarkup = useCallback((payload: IPersistedFormPropsWithComponents): void => {


### PR DESCRIPTION
…5087)

Switching the subform's formSelectionMode between 'name' and 'dynamic' left stale derived state behind: the resolved formConfig, the per-entity-type form cache and the render guard were never cleared together, so the subform got stuck on the previous form or blanked out and only recovered after reconfiguring. Reset all three atomically on a mode change so the mode-specific effects re-resolve the form from scratch instead of racing on leftover values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switching form selection modes now fully refreshes the form state, reducing the chance of showing stale or incorrect form content.
  * Previously cached per-entity form data is cleared when the mode changes, so the interface reflects the current selection more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->