### PR TITLE
fix: ensure userId is non-nullable in ChangePasswordAsync method

### DIFF
--- a/shesha-core/src/Shesha.Application/Users/UserAppService.cs
+++ b/shesha-core/src/Shesha.Application/Users/UserAppService.cs
@@ -708,7 +708,7 @@ namespace Shesha.Users
 
         public async Task<bool> ChangePasswordAsync(ChangePasswordDto input)
         {
-            long userId = _abpSession.UserId.Value;
+            long userId = _abpSession.UserId!.Value;
             var user = await _userManager.GetUserByIdAsync(userId);
             var loginAsync = await _logInManager.LoginAsync(user.UserName, input.CurrentPassword, shouldLockout: false);
             if (loginAsync.Result != ShaLoginResultType.Success)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password-change handling when the current user session identifier is recognized as available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->