### PR TITLE
fix: filtered out settings definition in disabled or deleted modules

### DIFF
--- a/shesha-core/src/Shesha.Framework/Settings/DynamicSettingDefinitionProvider.cs
+++ b/shesha-core/src/Shesha.Framework/Settings/DynamicSettingDefinitionProvider.cs
@@ -16,7 +16,6 @@ namespace Shesha.Settings
         private readonly IRepository<SettingConfiguration, Guid> _settingConfigurationRepository;
         private readonly ISettingDefinitionManager _settingDefinitionManager;
         private readonly IUnitOfWorkManager _uowManager;
-        
 
         public DynamicSettingDefinitionProvider(IRepository<SettingConfiguration, Guid> settingConfigurationRepository, ISettingDefinitionManager settingDefinitionManager, IUnitOfWorkManager uowManager)
         {
@@ -32,7 +31,7 @@ namespace Shesha.Settings
             using (var uow = _uowManager.Begin()) 
             {
                 var settings = context.GetAll();
-                var dbSettings = _settingConfigurationRepository.GetAll().Where(sc => sc.Module != null).ToList();
+                var dbSettings = _settingConfigurationRepository.GetAll().Where(sc => sc.Module != null && sc.Module.IsEnabled && !sc.Module.IsDeleted).ToList();
 
                 var dynamicallyCreatedSettings = dbSettings
                     .Where(c => !settings.Any(d => d.Value.Name == c.Name && d.Value.ModuleName == c.Module.NotNull().Name))
@@ -40,6 +39,9 @@ namespace Shesha.Settings
 
                 foreach (var setting in dynamicallyCreatedSettings)
                 {
+                    if (string.IsNullOrWhiteSpace(setting.Name))
+                        continue;
+
                     var definition = _settingDefinitionManager.CreateUserSettingDefinition(setting.Module.NotNull().Name, setting.Name, setting.DataType, null);
 
                     var id = new SettingIdentifier(definition.ModuleName, definition.Name);

--- a/shesha-core/src/Shesha.Framework/Settings/SettingDefinitionManager.cs
+++ b/shesha-core/src/Shesha.Framework/Settings/SettingDefinitionManager.cs
@@ -2,8 +2,10 @@
 using Abp.Collections.Extensions;
 using Abp.Dependency;
 using Abp.Reflection;
+using Shesha.ConfigurationItems;
 using Shesha.Extensions;
 using Shesha.Reflection;
+using Shesha.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -18,11 +20,13 @@ namespace Shesha.Settings
     {
         private readonly ITypeFinder _typeFinder;
         private readonly IIocManager _iocManager;
+        private readonly IModuleManager _moduleManager;        
 
         protected Lazy<IDictionary<SettingIdentifier, SettingDefinition>> SettingDefinitions { get; }
 
-        public SettingDefinitionManager(ITypeFinder typeFinder, IIocManager iocManager)
+        public SettingDefinitionManager(IModuleManager moduleManager, ITypeFinder typeFinder, IIocManager iocManager)
         {
+            _moduleManager = moduleManager;
             _typeFinder = typeFinder;
             _iocManager = iocManager;
 
@@ -86,6 +90,8 @@ namespace Shesha.Settings
         // Generic method to create a SettingDefinition
         public virtual SettingDefinition CreateUserSettingDefinition(string module, string name, string dataType, object? value = default)
         {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException($"Setting name can not be empty or null or whitespace.", nameof(name));
             var type = GetTypeFromName(dataType);
 
             object? convertedDefaultValue = value == null && type.IsValueType 
@@ -103,10 +109,15 @@ namespace Shesha.Settings
             SettingDefinition setting = (SettingDefinition)constructor.Invoke([name, convertedDefaultValue, name]);
 
             setting.ModuleName = module;
+            
+            var moduleInfo = _moduleManager.GetModuleInfos().FirstOrDefault(m => m.Name == module);
+            setting.ModuleAccessor = moduleInfo?.GetModuleAccessor();
+
             setting.DisplayName = name;
             setting.IsUserSpecific = true;
             setting.Accessor = name;
             setting.Category = "User Settings";
+            setting.CategoryAccessor = "";
             return setting;
         }
 

--- a/shesha-functional-tests/backend/Boxfusion.SheshaFunctionalTests.sln
+++ b/shesha-functional-tests/backend/Boxfusion.SheshaFunctionalTests.sln
@@ -65,6 +65,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shesha.Tests.ModuleB", "..\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Boxfusion.SheshaFunctionalTest.DisabledModule", "src\Module\Boxfusion.SheshaFunctionalTests.DisabledModule\Boxfusion.SheshaFunctionalTest.DisabledModule.csproj", "{D456D00C-4A9C-4380-9F16-B05645A69EDB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shesha.Testing", "..\..\shesha-core\src\Shesha.Testing\Shesha.Testing.csproj", "{347B2973-7427-256E-524B-C314BADE8257}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -234,6 +236,12 @@ Global
 		{D456D00C-4A9C-4380-9F16-B05645A69EDB}.DebugLocalShesha|Any CPU.Build.0 = Debug|Any CPU
 		{D456D00C-4A9C-4380-9F16-B05645A69EDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D456D00C-4A9C-4380-9F16-B05645A69EDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{347B2973-7427-256E-524B-C314BADE8257}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{347B2973-7427-256E-524B-C314BADE8257}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{347B2973-7427-256E-524B-C314BADE8257}.DebugLocalShesha|Any CPU.ActiveCfg = Debug|Any CPU
+		{347B2973-7427-256E-524B-C314BADE8257}.DebugLocalShesha|Any CPU.Build.0 = Debug|Any CPU
+		{347B2973-7427-256E-524B-C314BADE8257}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{347B2973-7427-256E-524B-C314BADE8257}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -259,6 +267,7 @@ Global
 		{5C0BEB31-7CAB-4DBF-8F27-9BDCF5AC9E65} = {244B7A5A-6740-4EE8-BCA3-5484C9DDF56A}
 		{54AF3A7B-FAED-42DF-8560-1045141E8B17} = {244B7A5A-6740-4EE8-BCA3-5484C9DDF56A}
 		{BF46801F-B5F5-490A-BDF1-1474EF2240F5} = {244B7A5A-6740-4EE8-BCA3-5484C9DDF56A}
+		{347B2973-7427-256E-524B-C314BADE8257} = {75540715-92AC-4551-9DCE-F71CF71009E3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {95ED23F3-8DEA-456E-A44B-87A161CB696A}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now exclude modules that are disabled or deleted.
  * Invalid settings without a name are skipped instead of being created.
  * User setting definitions now display more accurate module, category, and user-specific information.
  * Improved validation prevents unnamed settings from being registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->