### PR TITLE
fix: disabled fetching of nested lists by GetAll endpoint by default

### DIFF
--- a/shesha-core/src/Shesha.Application/SheshaCrudServiceBase.cs
+++ b/shesha-core/src/Shesha.Application/SheshaCrudServiceBase.cs
@@ -406,9 +406,16 @@ namespace Shesha
         {
             var sb = new StringBuilder();
             var allEntityProps = await EntityConfigCache.GetEntityPropertiesAsync(typeof(TEntity));
-            var properties = allEntityProps.NotNull().Where(x => !x.Suppress);
+            var properties = allEntityProps.NotNull()
+                .Where(x => !x.Suppress)
+                .ToList();
+            
             foreach (var property in properties)
             {
+                var isEntityList = property.DataType == DataTypes.Array && (property.DataFormat == ArrayFormats.EntityReference || property.DataFormat == ArrayFormats.ManyToManyEntities);
+                if (isEntityList)
+                    continue;
+
                 AppendProperty(sb, property, fullReference);
             }
 

--- a/shesha-core/src/Shesha.NHibernate/NHibernate/ProjectionHelper.cs
+++ b/shesha-core/src/Shesha.NHibernate/NHibernate/ProjectionHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Shesha.EntityReferences;
+using Shesha.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +33,8 @@ namespace Shesha.NHibernate
         {
             var groups = propertyPaths
                 .Select(path => new { Path = path, Parts = path.Split('.') })
-                .GroupBy(g => g.Parts[0]);
+                .GroupBy(g => g.Parts[0])
+                .ToList();
 
             var bindings = new List<MemberBinding>();
 
@@ -53,6 +55,10 @@ namespace Shesha.NHibernate
                     bindings.Add(Expression.Bind(topPropInfo, valueExpr));
                     continue;
                 }
+
+                var isList = topPropInfo.PropertyType.IsListType();
+                if (isList)
+                    continue;
 
                 // Nested: collect sub-paths (e.g., "City", "Id" for "Address.City", "Address.Id")
                 var subPaths = group
@@ -82,7 +88,8 @@ namespace Shesha.NHibernate
             // Group sub-paths by the immediate next property
             var groups = subPaths
                 .Select(path => new { Path = path, Parts = path.Split('.') })
-                .GroupBy(g => g.Parts[0]);
+                .GroupBy(g => g.Parts[0])
+                .ToList();
 
             var bindings = new List<MemberBinding>();
 


### PR DESCRIPTION
#4745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of list and collection properties in GraphQL responses and data projections.
  - Prevented unsupported collection-based properties from generating invalid projection bindings.
  - Improved stability when retrieving entities with nested properties and entity-reference collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->