### PR TITLE
fix: fixed crash in CS when quick search contains number only

### DIFF
--- a/shesha-reactjs/src/configuration-studio/components/configuration-tree/index.tsx
+++ b/shesha-reactjs/src/configuration-studio/components/configuration-tree/index.tsx
@@ -2,7 +2,7 @@ import { Button, Dropdown, Input, MenuProps, Spin, Tooltip, Tree, TreeProps } fr
 import React, { FC, useMemo, useRef, useState } from 'react';
 import { MoveNodePayload } from '../../apis';
 import { isConfigItemTreeNode, isFolderTreeNode, isModuleTreeNode, isNodeWithChildren, TreeNode } from '../../models';
-import { DownOutlined, RightOutlined } from '@ant-design/icons';
+import { CaretDownOutlined, CaretRightOutlined, RightOutlined } from '@ant-design/icons';
 import { ValidationErrors } from '@/components/validationErrors';
 import { useCsTree, useCsTreeDnd } from '../../cs/hooks';
 import { useConfigurationStudio } from '../../cs/contexts';
@@ -281,7 +281,7 @@ export const ConfigurationTree: FC<IConfigurationTreeProps> = ({ debugDnd = fals
                   showLine
                   showIcon
                   multiple
-                  switcherIcon={<DownOutlined />}
+                  switcherIcon={(node) => node.expanded === true ? <CaretDownOutlined /> : <CaretRightOutlined />}
 
                   treeData={filteredTreeNodes}
                   blockNode /* required for correct dragging*/

--- a/shesha-reactjs/src/configuration-studio/cs/configurationStudio.tsx
+++ b/shesha-reactjs/src/configuration-studio/cs/configurationStudio.tsx
@@ -314,7 +314,7 @@ export class ConfigurationStudio implements IConfigurationStudio {
   };
 
   private loadQuickSearchAsync = async (): Promise<void> => {
-    this._quickSearch = await this.storage.getAsync<string>(STORAGE_KEYS.QUICK_SEARCH) ?? "";
+    this._quickSearch = await this.storage.getAsync<string>(STORAGE_KEYS.QUICK_SEARCH, false) ?? "";
   };
 
   private loadTreeStateAsync = async (): Promise<void> => {

--- a/shesha-reactjs/src/configuration-studio/storage/index.ts
+++ b/shesha-reactjs/src/configuration-studio/storage/index.ts
@@ -3,7 +3,7 @@ import { isDefined } from "../../utils/nullables";
 type StorageValue = string | number | boolean | object | null;
 
 export interface IAsyncStorage {
-  getAsync<T extends StorageValue>(key: string): Promise<T | undefined>;
+  getAsync<T extends StorageValue>(key: string, parseJson?: boolean): Promise<T | undefined>;
   setAsync<T extends StorageValue>(key: string, value: T | undefined): Promise<void>;
   removeAsync(key: string): Promise<void>;
   clearAsync(): Promise<void>;
@@ -25,7 +25,7 @@ class AsyncLocalStorage implements IAsyncStorage {
     return AsyncLocalStorage.instance;
   }
 
-  public getAsync<T extends StorageValue>(key: string): Promise<T | undefined> {
+  public getAsync<T extends StorageValue>(key: string, parseJson: boolean = true): Promise<T | undefined> {
     return new Promise((resolve) => {
       try {
         const item = localStorage.getItem(key);
@@ -35,7 +35,10 @@ class AsyncLocalStorage implements IAsyncStorage {
         }
 
         try {
-          resolve(JSON.parse(item) as T);
+          const result = parseJson
+            ? JSON.parse(item) as T
+            : item as unknown as T;
+          resolve(result);
         } catch {
           resolve(item as unknown as T);
         }


### PR DESCRIPTION
#5160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated configuration tree controls to clearly indicate expanded and collapsed states with directional caret icons.

- **Bug Fixes**
  - Improved quick search settings retrieval so saved values load correctly and default safely when unavailable.
  - Enhanced local storage handling to support both parsed data and raw text values, improving reliability when restoring configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->