### PR TITLE
feat: enhance configuration item import functionality and folder hierarchy management

### DIFF
--- a/shesha-core/src/Shesha.Application/ConfigurationStudio/ConfigurationStudioAppService.ConfigurationTree.cs
+++ b/shesha-core/src/Shesha.Application/ConfigurationStudio/ConfigurationStudioAppService.ConfigurationTree.cs
@@ -95,7 +95,7 @@ namespace Shesha.ConfigurationStudio
         private async Task DeleteFolderRecursiveAsync(ConfigurationItemFolder folder) 
         {
             // delete items
-            var items = ItemRepo.DeleteAsync(e => e.Folder == folder);
+            await ItemRepo.DeleteAsync(e => e.Folder == folder);
 
             // process subfolders
             var subFolders = await FolderRepository.GetAllListAsync(e => e.Parent == folder);

--- a/shesha-core/src/Shesha.Framework/ConfigurationItems/Distribution/ConfigurationPackageManager.cs
+++ b/shesha-core/src/Shesha.Framework/ConfigurationItems/Distribution/ConfigurationPackageManager.cs
@@ -123,6 +123,14 @@ namespace Shesha.ConfigurationItems.Distribution
 
             var dto = await exporter.ExportItemAsync(item);
 
+            // Folder path is package metadata, not part of the item's content/hash, so it is set here
+            // at packaging time rather than inside the shared item exporter (which also feeds
+            // SaveToRevisionAsync's ConfigHash). GetFullChain returns leaf -> root, so reverse it;
+            // an empty list means the item sits at the module root.
+            dto.FolderPath = item.Folder != null
+                ? item.Folder.GetFullChain(f => f.Parent).Select(f => f.Name).Reverse().ToList()
+                : new List<string>();
+
             var exportItem = new ConfigurationItemsExportItem
             {
                 RelativePath = GetItemRelativePath(item),

--- a/shesha-core/src/Shesha.Framework/ConfigurationItems/Distribution/DistributedConfigurableItemBase.cs
+++ b/shesha-core/src/Shesha.Framework/ConfigurationItems/Distribution/DistributedConfigurableItemBase.cs
@@ -54,6 +54,15 @@ namespace Shesha.ConfigurationItems.Distribution
         /// </summary>
         public bool Suppress { get; set; }
 
+        /// <summary>
+        /// Folder path within the module, ordered root -> leaf (e.g. ["Entities", "Customers"]).
+        /// <para>null = not specified (legacy package, leave the existing folder untouched);</para>
+        /// <para>empty = module root (move item out of any folder);</para>
+        /// <para>non-empty = target folder hierarchy (created on import if missing).</para>
+        /// Deliberately not initialized so that a missing property deserializes to null.
+        /// </summary>
+        public List<string>? FolderPath { get; set; }
+
         #region V1 properties
 
         public DateTime? DateUpdated { get; set; }

--- a/shesha-core/src/Shesha.Framework/Services/ConfigurationItems/ConfigurationItemImportBase.cs
+++ b/shesha-core/src/Shesha.Framework/Services/ConfigurationItems/ConfigurationItemImportBase.cs
@@ -22,6 +22,12 @@ namespace Shesha.Services.ConfigurationItems
         public IUnitOfWorkManager UnitOfWorkManager { get; set; } = default!;
         public IConfigurationFrameworkRuntime CfRuntime { get; set; }
 
+        /// <summary>
+        /// Repository of configuration item folders. Property-injected (like <see cref="UnitOfWorkManager"/>)
+        /// so that concrete importer constructors don't need to change.
+        /// </summary>
+        public IRepository<ConfigurationItemFolder, Guid> FolderRepo { get; set; } = default!;
+
         public ConfigurationItemImportBase(IRepository<Module, Guid> _moduleRepo, IRepository<FrontEndApp, Guid> _frontendAppRepo)
         {
             ModuleRepo = _moduleRepo;
@@ -86,6 +92,43 @@ namespace Shesha.Services.ConfigurationItems
         public virtual Task<List<DistributedConfigurableItemBase>> SortItemsAsync(List<DistributedConfigurableItemBase> items)
         {
             return Task.FromResult(items);
+        }
+
+        /// <summary>
+        /// Resolves the target folder for an imported item, creating any missing folders in the hierarchy.
+        /// Folders are matched by name + parent within the module (portable across environments).
+        /// </summary>
+        /// <param name="module">Module the folders belong to</param>
+        /// <param name="path">Folder path, ordered root -> leaf. null or empty => item sits at module root (returns null)</param>
+        /// <param name="context">Import context</param>
+        /// <returns>The leaf folder, or null when the item belongs at the module root</returns>
+        protected async Task<ConfigurationItemFolder?> EnsureFolderAsync(Module? module, List<string>? path, IConfigurationItemsImportContext context)
+        {
+            if (module == null || path == null || path.Count == 0)
+                return null;
+
+            ConfigurationItemFolder? parent = null;
+            foreach (var name in path)
+            {
+                var parentId = parent?.Id;
+                var moduleId = module.Id;
+                var existing = await FolderRepo.FirstOrDefaultAsync(f =>
+                    f.Module.Id == moduleId &&
+                    (parentId == null ? f.Parent == null : f.Parent != null && f.Parent.Id == parentId) &&
+                    f.Name == name);
+
+                if (existing == null)
+                {
+                    existing = new ConfigurationItemFolder { Module = module, Parent = parent, Name = name };
+                    await FolderRepo.InsertAsync(existing);
+                    // Persist so the generated Id is available for the next (child) segment.
+                    await UnitOfWorkManager.Current.SaveChangesAsync();
+                }
+
+                parent = existing;
+            }
+
+            return parent;
         }
     }
 
@@ -188,9 +231,6 @@ namespace Shesha.Services.ConfigurationItems
                 // check if form exists
                 var item = explicitItem ?? await Repository.FirstOrDefaultAsync(f => f.Name == distributedItem.Name && (f.Module == null && distributedItem.ModuleName == null || f.Module != null && f.Module.Name == distributedItem.ModuleName));
 
-                if (await SkipImportAsync(item, distributedItem))
-                    return item;
-
                 var isNew = item == null;
                 if (item == null)
                 {
@@ -198,6 +238,19 @@ namespace Shesha.Services.ConfigurationItems
                     item.Module = await GetModuleAsync(distributedItem.ModuleName, context);
                     item.Application = await GetFrontEndAppAsync(distributedItem.FrontEndApplication, context);
                     item.Name = distributedItem.Name;
+                }
+
+                // Reconcile folder from the package (source of truth). Applies to both new and existing items.
+                // null path => not specified (legacy package) => leave the existing folder untouched.
+                if (distributedItem.FolderPath != null)
+                    item.Folder = await EnsureFolderAsync(item.Module, distributedItem.FolderPath, context);
+
+                // Skip only applies to pre-existing items whose content is unchanged.
+                if (!isNew && await SkipImportAsync(item, distributedItem))
+                {
+                    // Persist any folder-only move without creating a new content revision.
+                    await Repository.UpdateAsync(item);
+                    return item;
                 }
 
                 await MapStandardPropsToItemAsync(item, distributedItem);

--- a/shesha-reactjs/src/configuration-studio/cs/configurationStudio.tsx
+++ b/shesha-reactjs/src/configuration-studio/cs/configurationStudio.tsx
@@ -1041,7 +1041,7 @@ export class ConfigurationStudio implements IConfigurationStudio {
       return {
         title: 'Import Configuration',
         content: <ConfigurationItemsImport onImported={onImported} setImporterApi={(api) => importerApi.setApi(api)} />,
-        footer: <ConfigurationItemsImportFooter hideModal={hideModal} importerApi={importerApi} />,
+        footer: <ConfigurationItemsImportFooter hideModal={hideModal} importerApi={importerApi} onImported={onImported} />,
       };
     });
 

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/configuration-items-import.tsx
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/configuration-items-import.tsx
@@ -18,11 +18,12 @@ const actionsOwner = 'Configuration Items';
 interface IConfigurationItemsImportFooterProps {
   hideModal: () => void;
   importerApi: MutableApi<IImportInterface>;
+  onImported?: () => void;
 }
 
 export const ConfigurationItemsImportFooter: FC<IConfigurationItemsImportFooterProps> = (props) => {
   const [inProgress, setInProgress] = useState(false);
-  const { hideModal, importerApi } = props;
+  const { hideModal, importerApi, onImported } = props;
   const { message, notification } = App.useApp();
 
   const onImport = (): void => {
@@ -31,7 +32,8 @@ export const ConfigurationItemsImportFooter: FC<IConfigurationItemsImportFooterP
     const importer = importerApi.getApi() ?? throwError("importerRef is not defined");
     importer.importExecuter().then(() => {
       message.info('Items imported successfully');
-      hideModal();
+      // Signal success so the caller can refresh the tree; fall back to just closing the modal.
+      (onImported ?? hideModal)();
     }).catch((error: unknown) => {
       notification.error({
         title: "Failed to import package",
@@ -89,7 +91,7 @@ export const useConfigurationItemsImportAction = (): void => {
           },
           showModalFooter: false,
           content: <ConfigurationItemsImport onImported={onImported} setImporterApi={importerApi.setApi} />,
-          footer: <ConfigurationItemsImportFooter hideModal={hideModal} importerApi={importerApi} />,
+          footer: <ConfigurationItemsImportFooter hideModal={hideModal} importerApi={importerApi} onImported={onImported} />,
         };
         createModal({ ...modalProps });
       });


### PR DESCRIPTION
This pull request introduces support for storing and importing the folder hierarchy of configuration items, ensuring that items retain their folder structure when exported and imported between environments. It also improves the import UI by allowing the caller to refresh the configuration tree after a successful import. The main changes are grouped below.

### Backend: Folder Hierarchy Support for Configuration Items

* Added a `FolderPath` property to `DistributedConfigurableItemBase` to represent the item's folder hierarchy in export/import operations. This property is set during export and used during import to place items in the correct folders. [[1]](diffhunk://#diff-a3cd055da533ef969dc04597134c58c5b75d7648a5a10bfc5aff922232478c5bR57-R65) [[2]](diffhunk://#diff-58094c0d003d25828063e07a6f5fed285b8bbe1f2cdcf521cd76dfa76df7598dR126-R133)
* Implemented `EnsureFolderAsync` in `ConfigurationItemImportBase` to resolve or create the target folder structure during import, ensuring folders are matched by name and parent within the module.
* Modified the import logic to apply the folder from the package as the source of truth, updating the item's folder even if the content is unchanged, and persisting folder-only moves.
* Added property injection for the folder repository (`FolderRepo`) in `ConfigurationItemImportBase` to support folder creation without changing constructors.
* Fixed a missing `await` in `DeleteFolderRecursiveAsync` to ensure items are deleted before processing subfolders.

### Frontend: Import UI Improvements

* Updated `ConfigurationItemsImportFooter` and related modal logic to accept an optional `onImported` callback, allowing the caller to refresh the configuration tree after a successful import. The fallback remains to simply close the modal if no callback is provided. [[1]](diffhunk://#diff-194ccfece92cf8ad467eedbf47b59fe6cfb38e4bb280a2f322935f065c31a2b7L1044-R1044) [[2]](diffhunk://#diff-0087ad0661a1807255016b6e21e6fbd8010416e019ccffab0c6ed690922c8717R21-R26) [[3]](diffhunk://#diff-0087ad0661a1807255016b6e21e6fbd8010416e019ccffab0c6ed690922c8717L34-R36) [[4]](diffhunk://#diff-0087ad0661a1807255016b6e21e6fbd8010416e019ccffab0c6ed690922c8717L92-R94)

These changes ensure that configuration item folders are preserved across export/import and improve the user experience for configuration item import operations.

Related to issue: #5005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration packages now preserve and recreate folder hierarchies during import and export.
  * Imported items can be moved into their specified folders, including newly created folder paths.
  * Configuration Studio automatically refreshes its tree after a successful package import.

* **Bug Fixes**
  * Folder deletion now completes all item deletions before removing subfolders and the parent folder.
  * Existing items can have folder-only changes saved even when other import updates are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->