### PR TITLE
Thulasizwe/fix/5106

### DIFF
--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -403,10 +403,10 @@ export const FileUpload: FC<IFileUploadProps> = ({
     return (
       <div>
         {showThumbnailControls && styledfileControls()}
-        <span title={file.name}>
+        {hideFileName ? null : <span title={file.name}>
           <Space>
             <div className="thumbnail-item-name">
-              {(listType === 'text' || !hideFileName) && (
+              {(listType === 'text') && (
                 <a
                   style={{ marginRight: '5px' }}
                   onClick={isImageType(file.type ?? "")
@@ -416,13 +416,13 @@ export const FileUpload: FC<IFileUploadProps> = ({
                         void downloadFile({ fileId: file.id, fileName: file.name });
                     }}
                 >
-                  {listType !== 'thumbnail' && getFileIcon(file.type ?? "")} {`${file.name} (${filesize(isDefined(file.size) ? file.size : 0)})`}
+                  {getFileIcon(file.type ?? "")} {`${file.name} (${filesize(isDefined(file.size) ? file.size : 0)})`}
                 </a>
               )}
               {showTextControls && fileControls(appPrimaryColor)}
             </div>
           </Space>
-        </span>
+        </span>}
       </div>
     );
   };

--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -396,30 +396,30 @@ export const FileUpload: FC<IFileUploadProps> = ({
       </div>
     );
 
-  const renderFileItem = (file: UploadFile): React.JSX.Element => {
+  const renderFileItem = (file: UploadFile & { id?: string }): React.JSX.Element => {
     const showThumbnailControls = listType === 'thumbnail';
     const showTextControls = listType === 'text';
 
     return (
       <div>
         {showThumbnailControls && styledfileControls()}
-        {hideFileName ? null : (
+        {!hideFileName && (
           <span title={file.name}>
             <Space>
               <div className="thumbnail-item-name">
-                {(listType === 'text') && (
-                  <a
-                    style={{ marginRight: '5px' }}
-                    onClick={isImageType(file.type ?? "")
-                      ? onPreview
-                      : () => {
-                        if (!isNullOrWhiteSpace(file.id))
-                          void downloadFile({ fileId: file.id, fileName: file.name });
-                      }}
-                  >
-                    {getFileIcon(file.type ?? "")} {`${file.name} (${filesize(isDefined(file.size) ? file.size : 0)})`}
-                  </a>
-                )}
+                <a
+                  style={{ marginRight: '5px' }}
+                  onClick={isImageType(file.type ?? "")
+                    ? onPreview
+                    : () => {
+                      // Use file.id if available (from stored file), otherwise use uid
+                      const fileId = file.id || file.uid;
+                      if (!isNullOrWhiteSpace(fileId))
+                        void downloadFile({ fileId, fileName: file.name });
+                    }}
+                >
+                  {`${file.name} (${filesize(isDefined(file.size) ? file.size : 0)})`}
+                </a>
                 {showTextControls && fileControls(appPrimaryColor)}
               </div>
             </Space>

--- a/shesha-reactjs/src/components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/components/fileUpload/index.tsx
@@ -403,26 +403,28 @@ export const FileUpload: FC<IFileUploadProps> = ({
     return (
       <div>
         {showThumbnailControls && styledfileControls()}
-        {hideFileName ? null : <span title={file.name}>
-          <Space>
-            <div className="thumbnail-item-name">
-              {(listType === 'text') && (
-                <a
-                  style={{ marginRight: '5px' }}
-                  onClick={isImageType(file.type ?? "")
-                    ? onPreview
-                    : () => {
-                      if (!isNullOrWhiteSpace(file.id))
-                        void downloadFile({ fileId: file.id, fileName: file.name });
-                    }}
-                >
-                  {getFileIcon(file.type ?? "")} {`${file.name} (${filesize(isDefined(file.size) ? file.size : 0)})`}
-                </a>
-              )}
-              {showTextControls && fileControls(appPrimaryColor)}
-            </div>
-          </Space>
-        </span>}
+        {hideFileName ? null : (
+          <span title={file.name}>
+            <Space>
+              <div className="thumbnail-item-name">
+                {(listType === 'text') && (
+                  <a
+                    style={{ marginRight: '5px' }}
+                    onClick={isImageType(file.type ?? "")
+                      ? onPreview
+                      : () => {
+                        if (!isNullOrWhiteSpace(file.id))
+                          void downloadFile({ fileId: file.id, fileName: file.name });
+                      }}
+                  >
+                    {getFileIcon(file.type ?? "")} {`${file.name} (${filesize(isDefined(file.size) ? file.size : 0)})`}
+                  </a>
+                )}
+                {showTextControls && fileControls(appPrimaryColor)}
+              </div>
+            </Space>
+          </span>
+        )}
       </div>
     );
   };

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -119,17 +119,19 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     border-bottom-left-radius: ${normalizeRadius(borderBottomLeftRadius)} !important;
   `;
 
-  const commonBorderStyles = css`
-    border-top: ${borderTopWidth || borderWidth} ${borderTopStyle || borderStyle} ${borderTopColor || borderColor};
+  const commonBorderStyles = `
+    border: ${borderWidth} ${borderStyle} ${borderColor};
     border-right: ${borderRightWidth || borderWidth} ${borderRightStyle || borderStyle}
       ${borderRightColor || borderColor};
     border-left: ${borderLeftWidth || borderWidth} ${borderLeftStyle || borderStyle} ${borderLeftColor || borderColor};
     border-bottom: ${borderBottomWidth || borderWidth} ${borderBottomStyle || borderStyle}
       ${borderBottomColor || borderColor};
+    border-top: ${borderTopWidth || borderWidth} ${borderTopStyle || borderStyle} ${borderTopColor || borderColor};
+    ${borderRadiusCss}
     box-shadow: ${boxShadow};
   `;
 
-  const commonTextStyles = css`
+  const commonTextStyles = `
     color: ${color || token.colorPrimary};
     font-family: ${fontFamily};
     font-size: ${fontSize};
@@ -150,20 +152,20 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       --thumbnail-item-height: ${hideFileName ? 'var(--thumbnail-height)' : 'calc(var(--thumbnail-height) + 32px)'};
       display: inline-block;
       vertical-align: top;
-      height: ${layout ? 'var(--thumbnail-item-height)' : '100%'} !important;
+      height: ${layout ? hideFileName ? 'var(--thumbnail-height)' : 'calc(var(--thumbnail-height) + 32px)' : '100%'} !important;
       width: ${layout ? 'var(--thumbnail-width)' : '100%'} !important;
       max-height: ${layout ? (maxHeight ?? 'auto') : '100%'} !important;
       min-height: ${layout ? (minHeight ?? 'auto') : '100%'} !important;
       max-width: ${layout ? (maxWidth ?? 'auto') : '100%'} !important;
       min-width: ${layout ? (minWidth ?? 'auto') : '100%'} !important;
       ${isThumbnail ? `
+        display: flex;
+        flex-direction: column;
       .ant-upload-list-picture-card {
         min-height: 0 !important;
       }
 
       .ant-upload-list-item-container {
-        width: var(--thumbnail-width) !important;
-        height: var(--thumbnail-item-height) !important;
         margin: 0 !important;
         padding: 0 !important;
         box-sizing: border-box !important;
@@ -177,20 +179,29 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         flex-direction: column;
       }
 
-      /* The empty upload tile (no file yet) must match the thumbnail size and carry the configured
-         border/background/radius so it looks identical to the file tiles. The designer stub renders
-         .thumbnail-stub, but the live uploader renders .ant-upload-select, which otherwise keeps
-         antd's default (mismatched size, dashed default border) in the dynamic/end-user view. */
       .${prefixCls}-upload-select,
       .${prefixCls}-upload.${prefixCls}-upload-select {
         width: var(--thumbnail-width) !important;
         height: var(--thumbnail-height) !important;
         margin: 0 !important;
         box-sizing: border-box !important;
-        background: ${backgroundImage ?? backgroundColor ?? background};
         ${commonBorderStyles}
         ${borderRadiusCss}
         ${extraStyles}
+      }
+
+      >.thumbnail-stub {
+        padding: 0 !important;
+        box-sizing: border-box !important;
+        overflow: hidden !important;
+        background: ${backgroundImage ?? backgroundColor ?? background};
+          width: 100% !important;
+          height: 100% !important;
+        display: flex !important;
+        align-items: center !important;
+        ${extraStyles}
+        ${commonBorderStyles}
+        ${commonTextStyles}
       }
 
       .${prefixCls}-upload-select .${prefixCls}-upload {
@@ -219,8 +230,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         --ant-font-size: ${fontSize} !important;
         display: flex;
         ${isThumbnail ? `
-        ${borderRadiusCss}
-        border: ${borderWidth} ${borderStyle} ${borderColor} !important;
 
         :before {
           top: 0;
@@ -234,7 +243,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
 
       .ant-upload-list-item-thumbnail {
         ${extraStyles}
-        ${borderRadiusCss}
         box-sizing: border-box !important;
         padding: 0 !important;
         ${commonBorderStyles}
@@ -267,18 +275,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
             color: ${color} !important;
           }
         }
-      }
-
-      .thumbnail-stub {
-        ${extraStyles}
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        ${borderRadiusCss}
-        ${commonBorderStyles}
-        ${commonTextStyles}
-        box-sizing: border-box !important;
       }
 
       .ant-upload-list-text {
@@ -406,7 +402,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     css`
       ${commonBorderStyles}
       ${commonTextStyles}
-      ${borderRadiusCss}
       padding: 0 !important;
       box-sizing: border-box !important;
       overflow: hidden !important;
@@ -419,9 +414,15 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       position: relative !important;
 
       .ant-image  {
+        object-fit: cover !important;
         width: 100% !important;
         height: 100% !important;
+        img {
+          object-fit: cover !important;
+          
+        }
       }
+
       .anticon {
         img {
           object-fit: cover !important;

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -382,7 +382,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       height: 100% !important;
       width: 100% !important;
       opacity: 0;
-      ${borderRadiusCss}
       transition: opacity 0.3s ease;
       display: flex;
       justify-content: center;
@@ -419,6 +418,10 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       justify-content: center !important;
       position: relative !important;
 
+      .ant-image  {
+        width: 100% !important;
+        height: 100% !important;
+      }
       .anticon {
         img {
           object-fit: cover !important;

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -63,17 +63,11 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     borderColor = '#d9d9d9',
     borderTopStyle,
     borderTopColor,
-    borderTop,
     boxShadow,
-    borderBottom,
     borderBottomColor,
     borderBottomStyle,
-    borderRight,
     borderRightWidth,
     backgroundColor,
-    backgroundPosition,
-    backgroundRepeat,
-    backgroundSize,
     borderStyle = 'solid',
     color,
     fontFamily = 'Segoe UI',
@@ -153,26 +147,55 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       --ant-button-content-font-size: ${fontSize} !important;
       --ant-button-font-weight: ${fontWeight} !important;
       --ant-font-family: ${fontFamily} !important;
-      height: ${layout ? (height ?? '54px') : '100%'} !important;
-      width: ${layout ? (width ?? '54px') : '100%'} !important;
+      --thumbnail-item-height: ${hideFileName ? 'var(--thumbnail-height)' : 'calc(var(--thumbnail-height) + 32px)'};
+      display: inline-block;
+      vertical-align: top;
+      height: ${layout ? 'var(--thumbnail-item-height)' : '100%'} !important;
+      width: ${layout ? 'var(--thumbnail-width)' : '100%'} !important;
       max-height: ${layout ? (maxHeight ?? 'auto') : '100%'} !important;
-      min-height: ${layout ? (minHeight) : '100%'} !important;
-      max-width: ${layout ? (maxWidth) : '100%'} !important;
-      min-width: ${layout ? (minWidth) : '100%'} !important;
+      min-height: ${layout ? (minHeight ?? 'auto') : '100%'} !important;
+      max-width: ${layout ? (maxWidth ?? 'auto') : '100%'} !important;
+      min-width: ${layout ? (minWidth ?? 'auto') : '100%'} !important;
       ${isThumbnail ? `
-      background: ${backgroundImage ?? backgroundColor ?? background};
-      ${backgroundPosition ? `background-position: ${backgroundPosition};` : ''}
-      ${backgroundRepeat ? `background-repeat: ${backgroundRepeat};` : ''}
-      ${backgroundSize ? `background-size: ${backgroundSize};` : ''}
-      ` : ''}
+      .ant-upload-list-picture-card {
+        min-height: 0 !important;
+      }
 
-      ${isThumbnail ? `
-      .ant-upload-list-item {
+      .ant-upload-list-item-container {
         width: var(--thumbnail-width) !important;
-        height: ${hideFileName ? 'var(--thumbnail-height)' : 'calc(var(--thumbnail-height) + 32px)'} !important;
-        border-top: ${borderTop} !important;
-        border-bottom: ${borderBottom} !important;
-        border-right: ${borderRight} !important;
+        height: var(--thumbnail-item-height) !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        box-sizing: border-box !important;
+        display: inline-block !important;
+      }
+
+      .ant-upload-list-item-container > div {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+
+      /* The empty upload tile (no file yet) must match the thumbnail size and carry the configured
+         border/background/radius so it looks identical to the file tiles. The designer stub renders
+         .thumbnail-stub, but the live uploader renders .ant-upload-select, which otherwise keeps
+         antd's default (mismatched size, dashed default border) in the dynamic/end-user view. */
+      .${prefixCls}-upload-select,
+      .${prefixCls}-upload.${prefixCls}-upload-select {
+        width: var(--thumbnail-width) !important;
+        height: var(--thumbnail-height) !important;
+        margin: 0 !important;
+        box-sizing: border-box !important;
+        background: ${backgroundImage ?? backgroundColor ?? background};
+        ${commonBorderStyles}
+        ${borderRadiusCss}
+        ${extraStyles}
+      }
+
+      .${prefixCls}-upload-select .${prefixCls}-upload {
+        width: 100% !important;
+        height: 100% !important;
       }
       ` : ''}
 
@@ -212,14 +235,32 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       .ant-upload-list-item-thumbnail {
         ${extraStyles}
         ${borderRadiusCss}
+        box-sizing: border-box !important;
         padding: 0 !important;
         ${commonBorderStyles}
       }
 
       .thumbnail-item-name {
         ${commonTextStyles}
+        ${isThumbnail ? (hideFileName ? 'display: none !important;' : `
+        display: block;
+        width: 100%;
+        height: 32px;
+        line-height: 32px;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        `) : ''}
+
         a {
           ${commonTextStyles}
+          ${isThumbnail ? `
+          display: inline-block;
+          max-width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          ` : ''}
         }
         .ant-space {
           .anticon {
@@ -237,15 +278,11 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
         ${borderRadiusCss}
         ${commonBorderStyles}
         ${commonTextStyles}
+        box-sizing: border-box !important;
       }
 
       .ant-upload-list-text {
         ${commonTextStyles}
-        max-height: calc(var(--container-max-height) - calc(${fontSize} * 4)) !important;
-        min-height: calc(var(--container-min-height) - 32px) !important;
-        width: calc(var(--container-width) - 32px) !important;
-        max-width: calc(var(--container-max-width) - 32px) !important;
-        min-width: calc(var(--container-min-width) - 32px) !important;
       }
 
       .ant-upload-drag:hover:not(.ant-upload-disabled) {
@@ -290,12 +327,6 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       }
 
       .ant-upload-list-item-container {
-        height: calc(var(--container-height) - 32px) !important;
-        max-height: calc(var(--container-max-height) - calc(${fontSize} * 4)) !important;
-        min-height: calc(var(--container-min-height) - 32px) !important;
-        width: calc(var(--container-width) - 32px) !important;
-        max-width: calc(var(--container-max-width) - 32px) !important;
-        min-width: calc(var(--container-min-width) - 32px) !important;
         margin: 0 !important;
         padding: 0 !important;
         &.ant-upload-animate-inline-appear,
@@ -325,12 +356,18 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
   const thumbnailControls = cx(
     'thumbnail-controls',
     css`
-      width: var(--thumbnail-width, 54px) !important;
-      height: var(--thumbnail-height, 54px) !important;
+      width: 100% !important;
+      height: 100% !important;
       ${borderRadiusCss}
-      object-fit: cover !important;
-      display: flex !important;
-      justify-content: center !important;
+      display: block !important;
+      overflow: hidden !important;
+
+      .ant-image-img {
+        width: 100% !important;
+        height: 100% !important;
+        object-fit: cover !important;
+        display: block !important;
+      }
     `,
   );
 
@@ -338,13 +375,14 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     'overlay-thumbnail-controls',
     css`
       position: absolute;
-      top: 0;
-      left: 0;
+      inset: 0;
       background: rgba(0, 0, 0, 0.6);
-      height: ${height ?? '54px'} !important;
-      width: ${width ?? '54px'} !important;
+      /* Fill the positioned thumbnail tile exactly instead of re-deriving width/height (an empty
+         configured dimension would collapse the overlay and push it off to the side). */
+      height: 100% !important;
+      width: 100% !important;
       opacity: 0;
-      border-radius: 8px;
+      ${borderRadiusCss}
       transition: opacity 0.3s ease;
       display: flex;
       justify-content: center;
@@ -371,9 +409,11 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
       ${commonTextStyles}
       ${borderRadiusCss}
       padding: 0 !important;
+      box-sizing: border-box !important;
+      overflow: hidden !important;
       background: ${backgroundImage ?? backgroundColor ?? background};
-      width: ${width || '54px'} !important;
-      height: ${height || '54px'} !important;
+      width: var(--thumbnail-width, ${width || '54px'}) !important;
+      height: var(--thumbnail-height, ${height || '54px'}) !important;
       display: flex !important;
       align-items: center !important;
       justify-content: center !important;

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -161,12 +161,33 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
   // of the same file reuse the already-downloaded image instead of hitting the server again.
   // Entries are revoked on unmount.
   const previewImageCache = useRef<Map<string, string>>(new Map());
+  // Content fingerprint of the thumbnail currently cached in `imageUrls` for each file uid.
+  // A file's uid/id stay the same when its content is replaced (upload new version), so keying
+  // the "reuse existing thumbnail" guard on uid alone would keep showing the stale image. Tracking
+  // a content fingerprint (size + url) lets us detect a replace and re-fetch a fresh thumbnail.
+  const thumbnailFingerprints = useRef<Map<string, string>>(new Map());
+  // Per-file-id cache-buster bumped on each replace. The thumbnail endpoint is keyed only by
+  // file id + dimensions, so its URL is byte-identical after a replace and the browser's HTTP
+  // cache would serve the stale image even on a fresh request. Appending this token to the URL
+  // makes a replaced file request a new URL (cache miss) while unchanged files stay cacheable.
+  const thumbnailCacheBusters = useRef<Map<string, number>>(new Map());
   const model = rest;
 
   // Handler for replacing a file
   const handleReplaceFileChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const file = e.target.files?.[0];
     if (file && fileToReplace) {
+      // A replaced file keeps the same uid/id, so any cached thumbnail/preview for it now shows the
+      // old content. Invalidate those caches up front so the new version is re-fetched fresh (the
+      // fingerprint guard below also covers this, but the backend may reuse the url for the file id).
+      thumbnailFingerprints.current.delete(fileToReplace.uid);
+      // Bump the cache-buster so the re-fetched thumbnail URL differs from the browser-cached one.
+      thumbnailCacheBusters.current.set(fileToReplace.id, (thumbnailCacheBusters.current.get(fileToReplace.id) ?? 0) + 1);
+      const cachedPreview = previewImageCache.current.get(fileToReplace.id);
+      if (isNotNullOrWhiteSpace(cachedPreview)) {
+        URL.revokeObjectURL(cachedPreview);
+        previewImageCache.current.delete(fileToReplace.id);
+      }
       try {
         // This uses the StoredFilesProvider's replaceFile action which manages state properly
         replaceFile({
@@ -290,14 +311,28 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       }
 
       const newImageUrls: { [key: string]: string } = {};
+      // Blob URLs owned by the upload cache must never be revoked here; that cache manages them.
+      const uploadedFileBlobUrlSet = new Set(uploadedFileBlobUrls.current.values());
       for (const file of fileList) {
         if (isImageType(file.type ?? "") && !isNullOrWhiteSpace(file.url)) {
-          // Preserve existing URL to avoid unnecessary re-fetches
+          // A file keeps the same uid/id when its content is replaced (upload new version), so the
+          // cached thumbnail must only be reused while the file's content is unchanged. Fingerprint
+          // the content (size + url) so a replace invalidates the stale thumbnail and re-fetches.
+          const fingerprint = `${file.size ?? ''}_${file.url}`;
+          // Preserve existing URL to avoid unnecessary re-fetches, but only when the content matches.
           const existingUrl = imageUrlsRef.current[file.uid];
-          if (isNotNullOrWhiteSpace(existingUrl)) {
+          if (isNotNullOrWhiteSpace(existingUrl) && thumbnailFingerprints.current.get(file.uid) === fingerprint) {
             newImageUrls[file.uid] = existingUrl;
             continue;
           }
+
+          // Content changed (e.g. replaced): drop the stale thumbnail so a fresh one is fetched.
+          // Only revoke blob URLs we own here; raw server URLs (initial state) and blobs owned by
+          // uploadedFileBlobUrls are left alone (the latter is managed by that cache).
+          if (isNotNullOrWhiteSpace(existingUrl) && existingUrl.startsWith('blob:') && !uploadedFileBlobUrlSet.has(existingUrl)) {
+            URL.revokeObjectURL(existingUrl);
+          }
+          thumbnailFingerprints.current.delete(file.uid);
 
           // Check for blob URL from recent upload (avoids server round-trip immediately after upload).
           // The entry is kept for the lifetime of the component (cleaned up on unmount or when the
@@ -307,6 +342,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
           const blobUrl = uploadedFileBlobUrls.current.get(tempKey);
           if (isNotNullOrWhiteSpace(blobUrl)) {
             newImageUrls[file.uid] = blobUrl;
+            thumbnailFingerprints.current.set(file.uid, fingerprint);
             continue;
           }
 
@@ -316,11 +352,15 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
             }
             // The backend returns a degenerate 1x1 thumbnail when width/height are omitted, so always
             // send concrete dimensions derived from the configured thumbnail size (with a safe default).
+            // `v` is a cache-buster that only changes when the file is replaced (see above), so the
+            // browser HTTP cache serves unchanged thumbnails but re-downloads a replaced one.
+            const cacheBuster = thumbnailCacheBusters.current.get(file.id);
             const thumbnailUrl = buildUrl(STORED_FILE_URLS.DOWNLOAD_THUMBNAIL, {
               id: file.id,
               width: resolveThumbnailSize(model.thumbnailWidth ?? `${model.allStyles?.dimensionsStyles.width ?? ''}`),
               height: resolveThumbnailSize(model.thumbnailHeight ?? `${model.allStyles?.dimensionsStyles.height ?? ''}`),
               fitOption: 1, // 1: FitToHeight
+              ...(isDefined(cacheBuster) && cacheBuster > 0 ? { v: cacheBuster } : {}),
             });
 
             const { url: imageUrl, revoke } = await fetchStoredFile(httpClient, thumbnailUrl);
@@ -332,6 +372,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
             // Track revoke callback for cleanup
             revokeCallbacks.push(revoke);
             newImageUrls[file.uid] = imageUrl;
+            thumbnailFingerprints.current.set(file.uid, fingerprint);
           } catch (error) {
             console.error(`Failed to fetch image for file ${file.name} (${file.uid}):`, error);
             // Don't add to newImageUrls or revokeCallbacks - this file will not have a thumbnail

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -231,7 +231,6 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
     },
     style: calculateFileUploadStyles({
       enableStyleOnReadonly,
-      isDisabled: disabled,
       listType,
       allStyles: model.allStyles,
     }),
@@ -377,6 +376,32 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
           if (!liveKeys.has(key)) {
             URL.revokeObjectURL(url);
             uploadedFileBlobUrls.current.delete(key);
+          }
+        });
+
+        // Clean up thumbnail fingerprints, cache busters, and preview cache for files no longer in the list
+        const liveUids = new Set(fileList.map((f) => f.uid));
+        const liveIds = new Set(fileList.map((f) => f.id).filter((id) => isNotNullOrWhiteSpace(id)));
+
+        // Prune thumbnail fingerprints for deleted files
+        thumbnailFingerprints.current.forEach((_, uid) => {
+          if (!liveUids.has(uid)) {
+            thumbnailFingerprints.current.delete(uid);
+          }
+        });
+
+        // Prune thumbnail cache busters for deleted files
+        thumbnailCacheBusters.current.forEach((_, id) => {
+          if (!liveIds.has(id)) {
+            thumbnailCacheBusters.current.delete(id);
+          }
+        });
+
+        // Prune preview image cache for deleted files
+        previewImageCache.current.forEach((url, id) => {
+          if (!liveIds.has(id)) {
+            URL.revokeObjectURL(url);
+            previewImageCache.current.delete(id);
           }
         });
 

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -34,7 +34,6 @@ import { FileVersionsButton, ExtraContent, PLACEHOLDER_FILE, getListTypeAndLayou
 import classNames from 'classnames';
 import { isFileTypeAllowed } from '@/utils/fileValidation';
 import { ShaIcon, IconType } from '@/components/shaIcon';
-import { defaultStyles } from '@/designer-components/attachmentsEditor/utils';
 import { calculateFileUploadStyles } from '@/utils/fileUploadStyles';
 import { getFileExtension } from '@/utils/storedFile/utils';
 import { DownloadFileArgs, ReplaceFilePayload, StoredFileModel } from '@/utils/storedFile/models';

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -35,6 +35,7 @@ import classNames from 'classnames';
 import { isFileTypeAllowed } from '@/utils/fileValidation';
 import { ShaIcon, IconType } from '@/components/shaIcon';
 import { defaultStyles } from '@/designer-components/attachmentsEditor/utils';
+import { calculateFileUploadStyles } from '@/utils/fileUploadStyles';
 import { getFileExtension } from '@/utils/storedFile/utils';
 import { DownloadFileArgs, ReplaceFilePayload, StoredFileModel } from '@/utils/storedFile/models';
 import { useHttpClient } from '@/providers/sheshaApplication/publicApi/http/hooks';
@@ -220,8 +221,6 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
   const hasFiles = !!fileList.length;
 
   const { dimensionsStyles: containerDimensionsStyles, jsStyle: containerJsStyle, stylingBoxAsCSS } = useFormComponentStyles({ ...model.container });
-  const defaultBorder = defaultStyles().border?.border?.all ?? {};
-
   const { styles } = useStyles({
     downloadedFileStyles: downloadedFileStyles ?? {},
     containerStyles: {
@@ -231,20 +230,12 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       ...containerJsStyle,
       ...stylingBoxAsCSS,
     },
-    style: !enableStyleOnReadonly && disabled === true
-      // In thumbnail mode the configured background/border/shadow describe the thumbnail tile and
-      // must render identically in read-only and edit mode, so keep the appearance styles even when
-      // styling-on-readonly is disabled. In text mode fall back to the plain default border.
-      ? listType === 'thumbnail'
-        ? {
-          ...(model.allStyles?.dimensionsStyles ?? {}),
-          ...(model.allStyles?.fontStyles ?? {}),
-          ...(model.allStyles?.borderStyles ?? {}),
-          ...(model.allStyles?.backgroundStyles ?? {}),
-          ...(model.allStyles?.shadowStyles ?? {}),
-        }
-        : { ...(model.allStyles?.dimensionsStyles ?? {}), ...(model.allStyles?.fontStyles ?? {}), border: `${defaultBorder.width} ${defaultBorder.style} ${defaultBorder.color}` }
-      : { ...(model.allStyles?.fullStyle ?? {}) },
+    style: calculateFileUploadStyles({
+      enableStyleOnReadonly,
+      isDisabled: disabled,
+      listType,
+      allStyles: model.allStyles,
+    }),
     model: {
       gap: addPx(gap, allData) ?? '0px',
       layout: listType === 'thumbnail' && !isDragger,

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -211,7 +211,18 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
       ...stylingBoxAsCSS,
     },
     style: !enableStyleOnReadonly && disabled === true
-      ? { ...(model.allStyles?.dimensionsStyles ?? {}), ...(model.allStyles?.fontStyles ?? {}), border: `${defaultBorder.width} ${defaultBorder.style} ${defaultBorder.color}` }
+      // In thumbnail mode the configured background/border/shadow describe the thumbnail tile and
+      // must render identically in read-only and edit mode, so keep the appearance styles even when
+      // styling-on-readonly is disabled. In text mode fall back to the plain default border.
+      ? listType === 'thumbnail'
+        ? {
+          ...(model.allStyles?.dimensionsStyles ?? {}),
+          ...(model.allStyles?.fontStyles ?? {}),
+          ...(model.allStyles?.borderStyles ?? {}),
+          ...(model.allStyles?.backgroundStyles ?? {}),
+          ...(model.allStyles?.shadowStyles ?? {}),
+        }
+        : { ...(model.allStyles?.dimensionsStyles ?? {}), ...(model.allStyles?.fontStyles ?? {}), border: `${defaultBorder.width} ${defaultBorder.style} ${defaultBorder.color}` }
       : { ...(model.allStyles?.fullStyle ?? {}) },
     model: {
       gap: addPx(gap, allData) ?? '0px',

--- a/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
@@ -197,6 +197,9 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style = 
       padding: 0 !important;
       border: unset !important;
       width: ${layout ? width : '100%'};
+      /* With the file name hidden there is no name row, so the item must collapse to exactly the
+         thumbnail height instead of reserving antd's default name-row space below it. */
+      ${model.hideFileName === true ? `height: ${thumbnailHeight} !important;` : ''}
       :before {
         ${rest as CSSObject}
         display: none;
@@ -205,6 +208,9 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style = 
 
     .ant-upload-list-item-thumbnail {
       ${rest as CSSObject}
+      /* Draw the configured border inside the fixed thumbnail box so the image (below) doesn't
+         overpaint it — without border-box the image sized to the full width/height covers the border. */
+      box-sizing: border-box !important;
       background: ${background ?? backgroundImage ?? (backgroundColor ?? 'transparent')} !important;
       background-size: ${backgroundSize ?? 'cover'} !important;
       background-position: ${backgroundPosition ?? 'center'} !important;
@@ -212,6 +218,7 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style = 
       box-shadow: ${boxShadow};
       border-radius: ${borderRadius} !important;
       height: ${thumbnailHeight} !important;
+      overflow: hidden !important;
       display: flex !important;
       justify-content: center !important;
       align-items: center !important;
@@ -223,10 +230,12 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style = 
        justify-content: center;
        align-items: center;
       }
-      
+
       img {
-        width: ${thumbnailWidth} !important;
-        height: ${thumbnailHeight} !important;
+        /* Fill the bordered container's content box (not the full outer size) so the border stays
+           visible around the image. */
+        width: 100% !important;
+        height: 100% !important;
         border-radius: ${borderRadius} !important;
         object-fit: cover !important;
         display: flex !important;
@@ -239,7 +248,7 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls }, { style = 
     }
 
     .ant-upload-list-item-name {
-      ${layout || model.hideFileName ? 'display: none !important' : ''};
+      ${layout || model.hideFileName ? 'display: none !important; height: 0 !important; margin: 0 !important; padding: 0 !important;' : ''};
     }
 
     .ant-upload-list-text {

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -233,7 +233,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                               jsSetting: true,
                             },
                           ],
-                          hidden: { _code: 'return !getSettingValue(data?.customContent) || getSettingValue(data?.extraFormSelectionMode) !== "dynamic";', _mode: 'code', _value: false },
+                          hidden: { _code: 'return !getSettingValue(data?.customContent);', _mode: 'code', _value: false },
                         })
                         .toJson(),
                     ],

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settings.ts
@@ -227,13 +227,13 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                           inputs: [
                             {
                               id: nanoid(),
-                              type: "formTypeAutocomplete",
-                              propertyName: "extraFormType",
-                              label: "Form Type",
+                              type: "formAutocomplete",
+                              propertyName: "extraFormId",
+                              label: "Form",
                               jsSetting: true,
                             },
                           ],
-                          hidden: { _code: 'return !getSettingValue(data?.customContent);', _mode: 'code', _value: false },
+                          hidden: { _code: 'return !getSettingValue(data?.customContent) || getSettingValue(data?.extraFormSelectionMode) === "dynamic";', _mode: 'code', _value: false },
                         })
                         .toJson(),
                     ],

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -18,6 +18,7 @@ import { migrateVisibility } from '@/designer-components/_common-migrations/migr
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { getSettings } from './settingsForm';
 import { defaultStyles } from './utils';
+import { calculateFileUploadStyles } from '@/utils/fileUploadStyles';
 import { isEntityTypeIdEmpty } from '@/providers/metadataDispatcher/entities/utils';
 import { migratePrevStyles } from '../_common-migrations/migrateStyles';
 import { FileUploadComponentDefinition, IFileUploadProps } from './interfaces';
@@ -36,22 +37,13 @@ const FileUploadComponent: FileUploadComponentDefinition = {
   preserveDimensionsInDesigner: true,
   dataTypeSupported: ({ dataType }) => dataType === DataTypes.file,
   Factory: ({ model }) => {
-    const isReadonlyWithoutStyle = !model.enableStyleOnReadonly && model.readOnly;
-    // In thumbnail mode the configured background/border/shadow describe the thumbnail tile and
-    // must render identically in read-only and edit mode, so keep the appearance styles even when
-    // styling-on-readonly is disabled (only the interactive upload controls are hidden).
-    const isThumbnail = model.listType === 'thumbnail';
-    const finalStyle = isReadonlyWithoutStyle
-      ? {
-        ...model.allStyles?.fontStyles,
-        ...model.allStyles?.dimensionsStyles,
-        ...(isThumbnail ? {
-          ...model.allStyles?.borderStyles,
-          ...model.allStyles?.backgroundStyles,
-          ...model.allStyles?.shadowStyles,
-        } : {}),
-      }
-      : model.allStyles?.fullStyle;
+    const finalStyle = calculateFileUploadStyles({
+      enableStyleOnReadonly: model.enableStyleOnReadonly,
+      isReadOnly: model.readOnly,
+      isDisabled: model.disabled,
+      listType: model.listType,
+      allStyles: model.allStyles,
+    });
     // TODO: refactor and implement a generic way for values evaluation
     const { formSettings, formMode } = useForm();
     const { data } = useFormData();

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -36,10 +36,22 @@ const FileUploadComponent: FileUploadComponentDefinition = {
   preserveDimensionsInDesigner: true,
   dataTypeSupported: ({ dataType }) => dataType === DataTypes.file,
   Factory: ({ model }) => {
-    const finalStyle = (!model.enableStyleOnReadonly && model.readOnly) ? {
-      ...model.allStyles?.fontStyles,
-      ...model.allStyles?.dimensionsStyles,
-    } : model.allStyles?.fullStyle;
+    const isReadonlyWithoutStyle = !model.enableStyleOnReadonly && model.readOnly;
+    // In thumbnail mode the configured background/border/shadow describe the thumbnail tile and
+    // must render identically in read-only and edit mode, so keep the appearance styles even when
+    // styling-on-readonly is disabled (only the interactive upload controls are hidden).
+    const isThumbnail = model.listType === 'thumbnail';
+    const finalStyle = isReadonlyWithoutStyle
+      ? {
+        ...model.allStyles?.fontStyles,
+        ...model.allStyles?.dimensionsStyles,
+        ...(isThumbnail ? {
+          ...model.allStyles?.borderStyles,
+          ...model.allStyles?.backgroundStyles,
+          ...model.allStyles?.shadowStyles,
+        } : {}),
+      }
+      : model.allStyles?.fullStyle;
     // TODO: refactor and implement a generic way for values evaluation
     const { formSettings, formMode } = useForm();
     const { data } = useFormData();

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -40,7 +40,6 @@ const FileUploadComponent: FileUploadComponentDefinition = {
     const finalStyle = calculateFileUploadStyles({
       enableStyleOnReadonly: model.enableStyleOnReadonly,
       isReadOnly: model.readOnly,
-      isDisabled: model.disabled,
       listType: model.listType,
       allStyles: model.allStyles,
     });

--- a/shesha-reactjs/src/utils/fileUploadStyles.ts
+++ b/shesha-reactjs/src/utils/fileUploadStyles.ts
@@ -1,0 +1,56 @@
+import { CSSProperties } from 'react';
+import { IFormComponentStyles } from '@/providers';
+import { defaultStyles } from '@/designer-components/attachmentsEditor/utils';
+
+export interface IFileUploadStyleOptions {
+  enableStyleOnReadonly?: boolean;
+  isReadOnly?: boolean;
+  isDisabled?: boolean;
+  listType?: 'text' | 'thumbnail';
+  allStyles?: IFormComponentStyles;
+}
+
+/**
+ * Calculate the final styles for file upload components based on read-only state and list type.
+ * Shared between FileUpload designer component and StoredFilesRendererBase.
+ */
+export const calculateFileUploadStyles = (options: IFileUploadStyleOptions): CSSProperties => {
+  const {
+    enableStyleOnReadonly = true,
+    isReadOnly = false,
+    isDisabled = false,
+    listType = 'text',
+    allStyles
+  } = options;
+
+  const isReadonlyOrDisabled = isReadOnly || isDisabled;
+  const isReadonlyWithoutStyle = !enableStyleOnReadonly && isReadonlyOrDisabled;
+
+  if (isReadonlyWithoutStyle) {
+    const isThumbnail = listType === 'thumbnail';
+
+    // In thumbnail mode, the configured background/border/shadow describe the thumbnail tile
+    // and must render identically in read-only and edit mode, so keep the appearance styles
+    // even when styling-on-readonly is disabled (only the interactive upload controls are hidden).
+    if (isThumbnail) {
+      return {
+        ...(allStyles?.dimensionsStyles ?? {}),
+        ...(allStyles?.fontStyles ?? {}),
+        ...(allStyles?.borderStyles ?? {}),
+        ...(allStyles?.backgroundStyles ?? {}),
+        ...(allStyles?.shadowStyles ?? {}),
+      };
+    }
+
+    // In text mode, fall back to the plain default border
+    const defaultBorder = defaultStyles().border?.border?.all ?? {};
+    return {
+      ...(allStyles?.dimensionsStyles ?? {}),
+      ...(allStyles?.fontStyles ?? {}),
+      border: `${defaultBorder.width} ${defaultBorder.style} ${defaultBorder.color}`,
+    };
+  }
+
+  // When styles are enabled on read-only, use the full style
+  return allStyles?.fullStyle ?? {};
+};

--- a/shesha-reactjs/src/utils/fileUploadStyles.ts
+++ b/shesha-reactjs/src/utils/fileUploadStyles.ts
@@ -3,11 +3,10 @@ import { IFormComponentStyles } from '@/providers';
 import { defaultStyles } from '@/designer-components/attachmentsEditor/utils';
 
 export interface IFileUploadStyleOptions {
-  enableStyleOnReadonly?: boolean;
-  isReadOnly?: boolean;
-  isDisabled?: boolean;
-  listType?: 'text' | 'thumbnail';
-  allStyles?: IFormComponentStyles;
+  enableStyleOnReadonly?: boolean | undefined;
+  isReadOnly?: boolean | undefined;
+  listType?: 'text' | 'thumbnail' | undefined;
+  allStyles?: IFormComponentStyles | undefined;
 }
 
 /**
@@ -18,12 +17,11 @@ export const calculateFileUploadStyles = (options: IFileUploadStyleOptions): CSS
   const {
     enableStyleOnReadonly = true,
     isReadOnly = false,
-    isDisabled = false,
     listType = 'text',
-    allStyles
+    allStyles,
   } = options;
 
-  const isReadonlyOrDisabled = isReadOnly || isDisabled;
+  const isReadonlyOrDisabled = isReadOnly;
   const isReadonlyWithoutStyle = !enableStyleOnReadonly && isReadonlyOrDisabled;
 
   if (isReadonlyWithoutStyle) {


### PR DESCRIPTION
#5106
#5120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thumbnails/previews now refresh correctly after file replacement via per-file fingerprinting and cache-busting, preventing stale cached images.
  * Corrected filename/link presentation and icon visibility when `hideFileName` is enabled, with more compact list spacing.

* **Improvements**
  * Refined thumbnail tile borders, sizing, and cropping (full “cover” image behavior) for more consistent overflow handling.
  * Standardized file-upload styling, including read-only behavior, using a shared style calculation helper.

* **Configuration**
  * Updated the “Custom Actions” extra form field to use `extraFormId`, and adjusted row visibility to match dynamic selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->