### PR TITLE
Calender fixes

### DIFF
--- a/shesha-reactjs/src/components/calendar/utils.ts
+++ b/shesha-reactjs/src/components/calendar/utils.ts
@@ -31,6 +31,8 @@ export const getLayerEventItems = (
       if (!isDefined(id))
         return;
 
+      const entityTitle = typeof item['title'] === "string" ? item['title'] : "";
+
       const event: ICalendarEvent = {
         ...item,
         id: id,
@@ -39,8 +41,8 @@ export const getLayerEventItems = (
         icon,
         showIcon,
         color,
-        iconColor: iconColor || '#000000',
-        title: "",
+        iconColor: isNullOrWhiteSpace(iconColor) ? '#000000' : iconColor,
+        title: entityTitle,
         titleTemplate: title,
         onDblClick,
         onSelect,

--- a/shesha-reactjs/src/components/shaIcon/index.tsx
+++ b/shesha-reactjs/src/components/shaIcon/index.tsx
@@ -12,7 +12,7 @@ export interface IShaIconProps extends IconBaseProps {
   style?: CSSProperties | undefined;
 }
 
-export const ShaIcon: FC<IShaIconProps> = ({ iconName = 'WarningFilled', style, className, twoToneColor }) => {
+export const ShaIcon: FC<IShaIconProps> = ({ iconName = 'WarningFilled', style, className, twoToneColor, ...rest }) => {
   const { theme } = useThemeState();
 
   const IconComponent = isDefined(iconName) ? AntdIcons[iconName as IconType] as FC<IconBaseProps & { twoToneColor?: string }> : undefined;
@@ -24,5 +24,5 @@ export const ShaIcon: FC<IShaIconProps> = ({ iconName = 'WarningFilled', style, 
     ? twoToneColor
     : isNullOrWhiteSpace(primaryColor) ? '#1890ff' : primaryColor;
 
-  return <IconComponent style={style} className={className} twoToneColor={resolvedTwoToneColor} />;
+  return <IconComponent {...rest} style={style} className={className} twoToneColor={resolvedTwoToneColor} />;
 };

--- a/shesha-reactjs/src/components/shaIcon/index.tsx
+++ b/shesha-reactjs/src/components/shaIcon/index.tsx
@@ -21,5 +21,5 @@ export const ShaIcon: FC<IShaIconProps> = ({ iconName = 'WarningFilled', ...prop
 
   props.twoToneColor = theme.application?.primaryColor || '#1890ff';
 
-  return <IconComponent />;
+  return <IconComponent {...props} />;
 };

--- a/shesha-reactjs/src/components/shaIcon/index.tsx
+++ b/shesha-reactjs/src/components/shaIcon/index.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, FC } from 'react';
 import { IconBaseProps } from '@ant-design/icons/lib/components/Icon';
 import { useThemeState } from '@/providers';
 import * as AntdIcons from '@ant-design/icons';
-import { isDefined } from '@/utils/nullables';
+import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 
 export type IconType = keyof typeof AntdIcons;
 
@@ -12,14 +12,17 @@ export interface IShaIconProps extends IconBaseProps {
   style?: CSSProperties | undefined;
 }
 
-export const ShaIcon: FC<IShaIconProps> = ({ iconName = 'WarningFilled', ...props }) => {
+export const ShaIcon: FC<IShaIconProps> = ({ iconName = 'WarningFilled', style, className, twoToneColor }) => {
   const { theme } = useThemeState();
 
-  const IconComponent = isDefined(iconName) ? AntdIcons[iconName as IconType] as FC<IconBaseProps> : undefined;
+  const IconComponent = isDefined(iconName) ? AntdIcons[iconName as IconType] as FC<IconBaseProps & { twoToneColor?: string }> : undefined;
   if (!IconComponent)
     return undefined;
 
-  props.twoToneColor = theme.application?.primaryColor || '#1890ff';
+  const primaryColor = theme.application?.primaryColor;
+  const resolvedTwoToneColor = isDefined(twoToneColor)
+    ? twoToneColor
+    : isNullOrWhiteSpace(primaryColor) ? '#1890ff' : primaryColor;
 
-  return <IconComponent {...props} />;
+  return <IconComponent style={style} className={className} twoToneColor={resolvedTwoToneColor} />;
 };


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/5037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar events now use the source item’s `title` as the event title when it’s a valid string.
  * Calendar event icons now default to `#000000` when the provided `iconColor` is null/empty/whitespace.
  * Icon rendering now correctly applies caller-provided styling/class names and theme-derived two-tone color (falling back to `#1890ff`), with icon props forwarded as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->