### PR TITLE
validate module name in configuration item fullname resolution

### DIFF
--- a/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
+++ b/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
@@ -99,11 +99,14 @@ interface IResponseItem {
   label?: string | undefined;
   description?: string | undefined;
   versionNo?: number | undefined;
-  module?: {
+  module?: string | {
     id: string;
     name: string;
   } | undefined;
 }
+
+const getItemModuleName = (module: IResponseItem['module']): string | undefined =>
+  typeof module === 'string' ? (module || undefined) : module?.name;
 
 interface IConfigurationItemProps {
   name: string;
@@ -136,17 +139,18 @@ const identifierToString = <TValue extends ConfigurableItemFullName = Configurab
 };
 
 const getItemValue = (item: IResponseItem): string => {
-  return item.module
-    ? `${item.module.name}:${item.name}`
+  const moduleName = getItemModuleName(item.module);
+  return moduleName
+    ? `${moduleName}:${item.name}`
     : item.name;
 };
 
 const getDisplayText = (item: IResponseItem | undefined): string | null => {
-  return item
-    ? item.module
-      ? `${item.module.name}: ${item.name}`
-      : item.name
-    : null;
+  if (!item) return null;
+  const moduleName = getItemModuleName(item.module);
+  return moduleName
+    ? `${moduleName}: ${item.name}`
+    : item.name;
 };
 
 export const GenericConfigurableItemAutocompleteInternal = <TValue extends ConfigurableItemFullName = ConfigurableItemFullName>(props: ConfigurableItemAutocompleteRuntimeProps<TValue>): React.JSX.Element => {
@@ -204,18 +208,23 @@ export const GenericConfigurableItemAutocompleteInternal = <TValue extends Confi
     if (fetchedItems) {
       const result: IOption[] = [];
       fetchedItems.forEach((item) => {
-        const moduleDto = item.module ?? { name: LEGACY_ITEMS_MODULE_NAME, id: '-' };
+        const moduleName = getItemModuleName(item.module);
+        const moduleDto = typeof item.module === 'object' && item.module
+          ? item.module
+          : moduleName
+            ? { name: moduleName, id: moduleName }
+            : { name: LEGACY_ITEMS_MODULE_NAME, id: '-' };
 
         const opt: IOption = {
           label: getItemValue(item),
           value: getItemValue(item),
           rawValue: {
             name: item.name,
-            module: item.module?.name ?? null,
+            module: moduleName ?? null,
           },
           optionData: {
             name: item.name,
-            module: item.module?.name ?? null,
+            module: moduleName ?? null,
             label: item.label,
             description: item.description,
           },

--- a/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
+++ b/shesha-reactjs/src/components/configurableItemAutocomplete/generic.tsx
@@ -209,7 +209,7 @@ export const GenericConfigurableItemAutocompleteInternal = <TValue extends Confi
       const result: IOption[] = [];
       fetchedItems.forEach((item) => {
         const moduleName = getItemModuleName(item.module);
-        const moduleDto = typeof item.module === 'object' && item.module
+        const moduleDto = typeof item.module === 'object'
           ? item.module
           : moduleName
             ? { name: moduleName, id: moduleName }

--- a/shesha-reactjs/src/interfaces/configurableItems.ts
+++ b/shesha-reactjs/src/interfaces/configurableItems.ts
@@ -15,7 +15,7 @@ export const isConfigurableItemRawId = (formId: ConfigurableItemIdentifier): for
 export const isConfigurableItemFullName = (value: unknown): value is ConfigurableItemFullName => {
   return isDefined(value) && typeof (value) === "object" &&
     "name" in value && typeof (value.name) === "string" &&
-    "module" in value && typeof (value.module) === "string";
+    "module" in value && (typeof (value.module) === "string" || value.module === null);
 };
 
 export const configurableItemIdentifierToString = (value: ConfigurableItemIdentifier): string => {

--- a/shesha-reactjs/src/interfaces/configurableItems.ts
+++ b/shesha-reactjs/src/interfaces/configurableItems.ts
@@ -19,5 +19,7 @@ export const isConfigurableItemFullName = (value: unknown): value is Configurabl
 };
 
 export const configurableItemIdentifierToString = (value: ConfigurableItemIdentifier): string => {
-  return isConfigurableItemFullName(value) ? `${value.module}:${value.name}` : value;
+  return isConfigurableItemFullName(value)
+    ? (value.module === null ? value.name : `${value.module}:${value.name}`)
+    : value;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configurable item identifier handling to support entries where the module value is `null`.
  * Identifiers are now displayed consistently: they show just the item name when the module is missing, and include the module prefix when it’s present.
  * Autocomplete option formatting and grouping were updated accordingly for consistent results across both module data shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->