### PR TITLE
fix: add embedded prop to SidebarContainer and update styles for inline usage

### DIFF
--- a/shesha-reactjs/src/components/sidebarContainer/index.tsx
+++ b/shesha-reactjs/src/components/sidebarContainer/index.tsx
@@ -23,6 +23,10 @@ export interface ISidebarContainerProps extends PropsWithChildren {
   configTreePanelSize?: string | number | undefined;
   noPadding?: boolean | undefined;
   viewType?: IViewType | undefined;
+  /** Inline usage: size the sidebar to its content (capped at the viewport) instead
+   * of forcing a full-viewport height. Use when this container is embedded as a plain
+   * component (e.g. the datatable filter panel) rather than a full-screen editor. */
+  embedded?: boolean | undefined;
 }
 
 export const SidebarContainer: FC<ISidebarContainerProps> = ({
@@ -34,6 +38,7 @@ export const SidebarContainer: FC<ISidebarContainerProps> = ({
   noPadding,
   canZoom = false,
   viewType = 'configStudio',
+  embedded = false,
 }) => {
   const { formMode } = useShaFormInstance();
   const { styles } = useStyles();
@@ -122,7 +127,7 @@ export const SidebarContainer: FC<ISidebarContainerProps> = ({
   };
 
   return (
-    <div className={styles.sidebarContainer}>
+    <div className={classNames(styles.sidebarContainer, { embedded })}>
       {header && (
         <div className={styles.sidebarContainerHeader}>{typeof header === 'function' ? header() : header}</div>
       )}

--- a/shesha-reactjs/src/components/sidebarContainer/styles/styles.ts
+++ b/shesha-reactjs/src/components/sidebarContainer/styles/styles.ts
@@ -198,6 +198,21 @@ export const useStyles = createStyles(({ css, cx, prefixCls }) => {
         }
       }
 
+      /* Inline usage (e.g. the datatable advanced-filter / columns-selector panel)
+         reuses this container as a plain component rather than a full-screen editor.
+         In that case the sidebar body must size to its own content, capped at the
+         viewport, instead of forcing a fixed ~full-viewport height. The fixed
+         calc(100vh - ...) height is only correct for the full-screen editors
+         (Config Studio, model configurator); applied inline it inflates the whole
+         component to ~92vh and pushes the table below the fold. */
+      &.embedded {
+        .${sidebarContainerBody} .${sidebarContainerRight}.open .${sidebarBody},
+        .${sidebarContainerBody} .${sidebarContainerLeft}.open .${sidebarBody} {
+          height: auto;
+          max-height: calc(100vh - ${HEADER_HEIGHT} - ${TOOLBAR_HEIGHT} - ${SIDEBAR_BTN_HEIGHT});
+        }
+      }
+
       .${canvasPopupContainer} {
         position: fixed;
         top: 0;

--- a/shesha-reactjs/src/designer-components/dataTable/table/tableWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableWrapper.tsx
@@ -471,6 +471,7 @@ export const TableWrapper: FC<TableWrapperProps> = (props) => {
         content: renderSidebarContent,
       }}
       allowFullCollapse
+      embedded
     >
       <GlobalTableStyles />
       {tableFilter.length > 0 && <FilterList filters={tableFilter} rows={totalRows ?? 0} clearFilters={clearFilters} removeColumnFilter={removeColumnFilter} />}

--- a/shesha-reactjs/src/designer-components/statusTag/index.tsx
+++ b/shesha-reactjs/src/designer-components/statusTag/index.tsx
@@ -30,7 +30,10 @@ const StatusTagComponent: IToolboxComponent<IStatusTagProps> = {
 
     const { override, value, color, valueSource } = model;
 
-    const getValueByExpression = (expression: string = ''): string => {
+    const getValueByExpression = (expression?: string | null): string => {
+      // Default parameters only cover `undefined`; `override`/`color` can be `null`
+      // in a component's config, so guard explicitly to avoid `null.includes(...)`.
+      if (expression == null) return '';
       return expression.includes('{{') ? evaluateString(expression, data) : expression;
     };
 


### PR DESCRIPTION
This pull request introduces improvements to the `SidebarContainer` to support inline embedding, making it more flexible for use cases like datatable filter panels, and includes a minor bug fix in the `StatusTag` component. The main changes add an `embedded` prop to allow the sidebar to size itself to its content (instead of always taking up the full viewport), and refine how expressions are handled in `StatusTag`.

**SidebarContainer enhancements:**

* Added an `embedded` prop to `ISidebarContainerProps` and updated the `SidebarContainer` component to support inline usage, allowing the sidebar to size to its content and cap its height at the viewport when embedded [[1]](diffhunk://#diff-dfb85f5f02a0c76d169d7f1ad581cbaddba0249e69f80443e14d774aaeb46f56R26-R29) [[2]](diffhunk://#diff-dfb85f5f02a0c76d169d7f1ad581cbaddba0249e69f80443e14d774aaeb46f56R41).
* Updated the CSS styles in `styles.ts` to apply the correct sizing when the `embedded` class is present, preventing the sidebar from inflating to full viewport height in inline scenarios.
* Passed the new `embedded` prop from `TableWrapper` to `SidebarContainer` to enable the feature in datatable filter panels.
* Updated the rendered class names to include `embedded` when appropriate.

**Bug fix in StatusTag:**

* Improved the `getValueByExpression` function to handle `null` as well as `undefined` for the `expression` parameter, preventing runtime errors when `override` or `color` are set to `null` in a component's config.

* Related to issue: #5158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an embedded sidebar mode for inline panels, allowing content-driven sizing while preventing excessive expansion.
  * Enabled embedded sidebar behavior in designer table panels.

* **Bug Fixes**
  * Improved status tag expression handling when values are empty or unavailable, preventing evaluation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->