### PR TITLE
The isConfigurableItemFullName type guard was stricter than the data …

### DIFF
--- a/shesha-reactjs/src/interfaces/configurableItems.ts
+++ b/shesha-reactjs/src/interfaces/configurableItems.ts
@@ -2,7 +2,7 @@ import { isDefined, isNullOrWhiteSpace } from "@/utils/nullables";
 
 export interface ConfigurableItemFullName {
   readonly name: string;
-  readonly module: string | null;
+  readonly module?: string | null | undefined;
 }
 
 export type ConfigurableItemUid = string;

--- a/shesha-reactjs/src/interfaces/configurableItems.ts
+++ b/shesha-reactjs/src/interfaces/configurableItems.ts
@@ -1,4 +1,4 @@
-import { isDefined } from "@/utils/nullables";
+import { isDefined, isNullOrWhiteSpace } from "@/utils/nullables";
 
 export interface ConfigurableItemFullName {
   readonly name: string;
@@ -15,11 +15,11 @@ export const isConfigurableItemRawId = (formId: ConfigurableItemIdentifier): for
 export const isConfigurableItemFullName = (value: unknown): value is ConfigurableItemFullName => {
   return isDefined(value) && typeof (value) === "object" &&
     "name" in value && typeof (value.name) === "string" &&
-    "module" in value && (typeof (value.module) === "string" || value.module === null);
+    (!("module" in value) || typeof (value.module) === "string" || value.module === null || value.module === undefined);
 };
 
 export const configurableItemIdentifierToString = (value: ConfigurableItemIdentifier): string => {
   return isConfigurableItemFullName(value)
-    ? (value.module === null ? value.name : `${value.module}:${value.name}`)
+    ? (isNullOrWhiteSpace(value.module) ? value.name : `${value.module}:${value.name}`)
     : value;
 };

--- a/shesha-reactjs/src/providers/configurationItemsLoader/configurationLoader.ts
+++ b/shesha-reactjs/src/providers/configurationItemsLoader/configurationLoader.ts
@@ -171,8 +171,8 @@ export class ConfigurationLoader implements IConfigurationLoader {
     return Promise.resolve();
   };
 
-  getCacheKeyByFullName = (module: string | null, name: string): string => {
-    return `${module}:${name}`;
+  getCacheKeyByFullName = (module: string | null | undefined, name: string): string => {
+    return `${module ?? null}:${name}`;
   };
 
   getConfigLookupAsync = async (type: string, id: ConfigurableItemFullName): Promise<ConfigurationLookup | undefined> => {
@@ -388,7 +388,7 @@ export class ConfigurationLoader implements IConfigurationLoader {
 
   getExistingConfigRequestKey = (id: ConfigurableItemIdentifier, topLevelModule: string | undefined): string => {
     const idText = isConfigurableItemFullName(id)
-      ? `${id.module}/${id.name}`
+      ? `${id.module ?? null}/${id.name}`
       : id;
 
     return topLevelModule

--- a/shesha-reactjs/src/providers/configurationItemsLoader/configurationLoader.ts
+++ b/shesha-reactjs/src/providers/configurationItemsLoader/configurationLoader.ts
@@ -172,7 +172,7 @@ export class ConfigurationLoader implements IConfigurationLoader {
   };
 
   getCacheKeyByFullName = (module: string | null | undefined, name: string): string => {
-    return `${module ?? null}:${name}`;
+    return `${isNullOrWhiteSpace(module) ? null : module}:${name}`;
   };
 
   getConfigLookupAsync = async (type: string, id: ConfigurableItemFullName): Promise<ConfigurationLookup | undefined> => {
@@ -388,7 +388,7 @@ export class ConfigurationLoader implements IConfigurationLoader {
 
   getExistingConfigRequestKey = (id: ConfigurableItemIdentifier, topLevelModule: string | undefined): string => {
     const idText = isConfigurableItemFullName(id)
-      ? `${id.module ?? null}/${id.name}`
+      ? `${isNullOrWhiteSpace(id.module) ? null : id.module}/${id.name}`
       : id;
 
     return topLevelModule


### PR DESCRIPTION
#5162 
The isConfigurableItemFullName type guard was stricter than the data it's fed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configurable item identifiers when the module is omitted or contains only whitespace.
  * Updated validation and formatting so identifiers display as `name` when no module is provided, and `module:name` otherwise.
  * Ensured configuration loading and caching generate consistent keys for missing/blank module values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->