### PR TITLE
refactor: enhance wizard reset functionality and optimize field name collection

### DIFF
--- a/shesha-reactjs/src/designer-components/wizard/hooks.ts
+++ b/shesha-reactjs/src/designer-components/wizard/hooks.ts
@@ -129,10 +129,22 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
 
   const componentsNames = useMemo(() => collectFieldNames(components), [components, collectFieldNames]);
 
-  // Field name paths across every step, used to reset step data on reset()
+  // Resolve a step's custom-footer components from the flat markup (mirrors visibleSteps)
+  const resolveFooterComponents = useCallback((step: IWizardStepProps): IConfigurableFormComponent[] => {
+    const footerId = step.stepFooter?.id ?? (step.hasCustomFooter ? `${step.id}_footer` : undefined);
+    if (!step.hasCustomFooter || !footerId) return [];
+    return (componentRelations[footerId] || [])
+      .map((id) => allComponents[id])
+      .filter(isConfigurableFormComponent);
+  }, [componentRelations, allComponents]);
+
+  // Field name paths across every step (including custom-footer fields), used to reset step data on reset()
   const allStepsFieldNames = useMemo(
-    () => tabs.flatMap((step) => collectFieldNames(step.components)),
-    [tabs, collectFieldNames],
+    () => tabs.flatMap((step) => [
+      ...collectFieldNames(step.components),
+      ...collectFieldNames(resolveFooterComponents(step)),
+    ]),
+    [tabs, collectFieldNames, resolveFooterComponents],
   );
 
   var formInstance = allData.form?.formInstance;

--- a/shesha-reactjs/src/designer-components/wizard/hooks.ts
+++ b/shesha-reactjs/src/designer-components/wizard/hooks.ts
@@ -4,7 +4,7 @@ import { IActionExecutionContext, IConfigurableActionConfiguration } from '@/int
 import { IConfigurableFormComponent, isConfigurableFormComponent, useForm, useSheshaApplication, ShaForm } from '@/providers';
 import { IWizardComponentProps, IWizardStepProps } from './models';
 import { useConfigurableAction } from '@/providers/configurableActionsDispatcher';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDeepCompareMemo } from '@/hooks';
 import { useFormExpression } from '@/hooks';
 import { useFormDesignerComponents } from '@/providers/form/hooks';
@@ -113,10 +113,11 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
 
   const currentStep = visibleSteps[current];
   const components = currentStep?.components;
-  const componentsNames = useMemo(() => {
-    if (!components) return [];
-    const flat = componentsTreeToFlatStructure(toolbox, components);
-    const properties = [];
+
+  const collectFieldNames = useCallback((comps: IConfigurableFormComponent[] | undefined): string[][] => {
+    if (!comps) return [];
+    const flat = componentsTreeToFlatStructure(toolbox, comps);
+    const properties: string[][] = [];
     for (const comp in flat.allComponents)
       if (Object.hasOwn(flat.allComponents, comp)) {
         const component = flat.allComponents[comp];
@@ -124,7 +125,15 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
           properties.push(component.propertyName.split("."));
       }
     return properties;
-  }, [components, toolbox]);
+  }, [toolbox]);
+
+  const componentsNames = useMemo(() => collectFieldNames(components), [components, collectFieldNames]);
+
+  // Field name paths across every step, used to reset step data on reset()
+  const allStepsFieldNames = useMemo(
+    () => tabs.flatMap((step) => collectFieldNames(step.components)),
+    [tabs, collectFieldNames],
+  );
 
   var formInstance = allData.form?.formInstance;
   useEffect(() => {
@@ -272,6 +281,9 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
   };
 
   const reset = (): void => {
+    // Clear the data entered across every step, resetting fields to their initial values
+    if (isDefined(formInstance) && isNonEmptyArray(allStepsFieldNames))
+      formInstance.resetFields(allStepsFieldNames);
     successCallback('reset');
   };
 
@@ -361,7 +373,7 @@ export const useWizard = (model: IWizardComponentProps): IWizardComponent => {
       ownerUid: actionsOwnerId,
       hasArguments: false,
       executer: () => {
-        successCallback('reset');
+        reset();
         return Promise.resolve();
       },
     },


### PR DESCRIPTION
This pull request refactors and improves the wizard form reset functionality in the `useWizard` hook. The main changes include extracting field name collection logic into a reusable function, ensuring all step fields are reset properly, and updating the reset action to use the new logic.

**Wizard reset improvements:**

* Refactored field name extraction into a reusable `collectFieldNames` function using `useCallback`, allowing consistent collection of field names for individual steps or all steps.
* Added `allStepsFieldNames` to gather all field names across wizard steps, ensuring the reset operation covers every step.
* Updated the `reset` function to clear all fields across every wizard step by calling `formInstance.resetFields(allStepsFieldNames)`, improving data consistency when resetting.
* Changed the reset action's executor to call the new `reset` function, ensuring the enhanced reset logic is used throughout.

**Code quality improvements:**

* Added `useCallback` to memoize the `collectFieldNames` function, improving performance and preventing unnecessary recalculations.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * “Reset Steps” in the wizard now clears entered form values across all steps, not just the current step.
  * The reset behavior has been updated to reliably reset available wizard form fields before completing the reset action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related issue:  #5079