### PR TITLE
fix: fixed undo/redo state after empty component update

### DIFF
--- a/shesha-reactjs/src/providers/formDesigner/instance.ts
+++ b/shesha-reactjs/src/providers/formDesigner/instance.ts
@@ -727,9 +727,10 @@ export class FormDesignerInstance implements IFormDesignerInstance {
   };
 
   private updateState = (updater: (state: FormDesignerFormState) => FormDesignerFormState, description: string): void => {
-    this.undoableState.executeChange(updater, description);
-    this.isDataModified = true;
-    this.notifySubscribers(['markup', 'selection', 'history', 'data-modified']);
+    if (this.undoableState.executeChange(updater, description)) {
+      this.isDataModified = true;
+      this.notifySubscribers(['markup', 'selection', 'history', 'data-modified']);
+    }
   };
 
   undo = (): void => {

--- a/shesha-reactjs/src/providers/formDesigner/undoRedoManager.ts
+++ b/shesha-reactjs/src/providers/formDesigner/undoRedoManager.ts
@@ -8,7 +8,7 @@ export interface IUndoRedoManager<T> {
   undo(): boolean;
   redo(): boolean;
   getState(): T;
-  executeChange(change: (state: T) => T, description: string): void;
+  executeChange(change: (state: T) => T, description: string): boolean;
   setState(state: T): void;
   canUndo: boolean;
   canRedo: boolean;
@@ -53,26 +53,15 @@ export class UndoRedoManager<T> implements IUndoRedoManager<T> {
   }
 
   // For simple state changes
-  executeChange(change: (state: T) => T, description: string): void {
+  executeChange(change: (state: T) => T, description: string): boolean {
     const newState = change(this.state);
     if (newState === this.state)
-      return;
+      return false;
 
     this.saveState(newState, description);
     this.state = newState;
+    return true;
   }
-
-  /*
-  // For complex operations that need their own undo logic
-  executeCommand(command: {
-    execute(state: T): void;
-    undo(state: T): void;
-    description: string;
-  }): void {
-    command.execute(this.state);
-    this.saveState(command.description);
-  }
-  */
 
   private saveState(state: T, description: string): void {
     // Remove any future states if we're not at the end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented no-op form designer actions from being marked as modifications.
  * Avoided unnecessary history entries and subscriber notifications when an action does not change the editor state.
  * Improved undo/redo state tracking for changes that produce no updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->