### PR TITLE
fix: title/value backgrounds fill and clip to rounded corners

### DIFF
--- a/shesha-reactjs/src/components/statistic/styles/styles.ts
+++ b/shesha-reactjs/src/components/statistic/styles/styles.ts
@@ -11,9 +11,10 @@ export const useStyles = createStyles(({ css, cx, prefixCls, iconPrefixCls, toke
     margin-bottom: ${sheshaStyles.paddingLG}px;
     background: white;
     height: 100%;
-    
+    overflow: hidden;
+
     .${prefixCls}-statistic-title {
-        padding-left: 8px;
+        padding: 8px;
         font-size: 16px;
         text-align: center;
     }

--- a/shesha-reactjs/src/designer-components/statistic/index.tsx
+++ b/shesha-reactjs/src/designer-components/statistic/index.tsx
@@ -64,7 +64,7 @@ const StatisticComponent: IToolboxComponent<IStatisticComponentProps> = {
             <ShaStatistic
               value={(value || passedModel.value || passedModel.placeholder) ?? ""}
               {...(passedModel.precision ? { precision: passedModel.precision } : {})}
-              title={<div style={removeUndefinedProps({ ...titleFontStyles, ...titleStyles })}>{passedModel.title}</div>}
+              title={passedModel.title}
               prefix={(
                 <div>
                   {passedModel.prefixIcon && <ShaIcon iconName={prefixIcon as IconType} />}
@@ -81,6 +81,7 @@ const StatisticComponent: IToolboxComponent<IStatisticComponentProps> = {
               )}
               style={removeUndefinedProps({ ...allStyles?.fullStyle })}
               styles={{
+                title: removeUndefinedProps({ ...titleFontStyles, ...titleStyles }),
                 content: removeUndefinedProps({
                   ...valueFontStyles,
                   ...valueStyles,


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/5057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistic display styling by preventing content overflow.
  * Applied consistent spacing around statistic titles.
  * Preserved custom title styling when rendering statistics in the designer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->