### PR TITLE
fix kanban inconsistent child re-render

### DIFF
--- a/shesha-reactjs/src/components/chevron/index.tsx
+++ b/shesha-reactjs/src/components/chevron/index.tsx
@@ -10,13 +10,18 @@ import { jsonSafeParse } from "@/utils/object";
 import { addPx } from '@/utils/style';
 import { Button, Form, FormInstance } from "antd";
 import classNames from "classnames";
-import { IChevronButton, IChevronControlProps } from "./models";
+import { IChevronButton, IChevronControlProps, isChevronItem } from "./models";
+import { useRefListItemGroupConfigurator } from "@/components/refListSelectorDisplay/provider";
 import { useStyles } from "./styles";
 
 
 export const ChevronControl: FC<IChevronControlProps> = (props) => {
   const fontStyles = useMemo(() => getFontStyle(props.font), [props.font]);
-  const { value, activeColor, showIcons, colorSource, items, width, height, stylingBox } = props;
+  const { value, activeColor, showIcons, colorSource, width, height, stylingBox } = props;
+  const { items: refListItems } = useRefListItemGroupConfigurator();
+  // Render from the reference list held by the provider rather than the saved snapshot,
+  // so the designer, preview and runtime cannot drift apart.
+  const items = useMemo(() => refListItems.filter(isChevronItem), [refListItems]);
   const { styles } = useStyles({ height });
   const [form] = Form.useForm();
   const { theme } = useTheme();
@@ -104,7 +109,7 @@ export const ChevronControl: FC<IChevronControlProps> = (props) => {
         </Button>
       )}
       <div ref={containerRef} className={styles.pipelineStages}>
-        {items?.map((item) => {
+        {items.map((item) => {
           return renderButton(item, item.id, form);
         })}
       </div>

--- a/shesha-reactjs/src/components/chevron/models.ts
+++ b/shesha-reactjs/src/components/chevron/models.ts
@@ -1,6 +1,8 @@
 import { IFontValue } from "@/designer-components/_settings/utils/font/interfaces";
 import { IReferenceListIdentifier } from "@/interfaces";
 import { IButtonGroupItem, IButtonItem, IConfigurableFormComponent } from "@/providers";
+import { RefListGroupItemProps as ConfiguredRefListItem } from "@/components/refListSelectorDisplay/provider/models";
+import { isDefined, isNullOrWhiteSpace } from "@/utils/nullables";
 
 export type RefListGroupItemProps = IRefListItemFormModel | IRefListItemGroup;
 
@@ -38,3 +40,6 @@ export interface IChevronButton extends IButtonGroupItem {
   itemValue: number;
   item: string;
 }
+
+export const isChevronItem = (item: ConfiguredRefListItem): item is ConfiguredRefListItem & IChevronButton =>
+  isDefined(item.itemValue) && !isNullOrWhiteSpace(item.item);

--- a/shesha-reactjs/src/components/kanban/index.tsx
+++ b/shesha-reactjs/src/components/kanban/index.tsx
@@ -1,10 +1,11 @@
 import { useRefListItemGroupConfigurator } from '@/components/refListSelectorDisplay/provider';
 import { App, Flex, Form, Modal } from 'antd';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import KanbanPlaceholder from './components/kanbanPlaceholder';
 import KanbanColumn, { KanbanUrls } from './components/renderColumn';
-import { IKanbanButton, IKanbanProps } from './model';
-import { useKanbanActions } from './utils';
+import { IKanbanProps, isKanbanColumn, isRefListCellValue } from './model';
+import { IDataColumnsProps, isDataColumn } from '@/providers/datatableColumnsConfigurator/models';
+import { KanbanColumnState, useKanbanActions } from './utils';
 import { addPx } from '@/utils/style';
 import { getOverflowStyle } from '@/designer-components/_settings/utils/overflow/util';
 import { getPropertyOrUndefined, jsonSafeParse } from '@/utils/object';
@@ -23,12 +24,11 @@ import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { RecursivePartial } from '@/interfaces/entity';
 
 const KanbanReactComponent: FCUnwrapped<IKanbanProps> = (props) => {
-  const { gap, groupingProperty, createFormId, items, componentName, editFormId } = props;
+  const { gap, groupingProperty, createFormId, componentName, editFormId } = props;
 
-  const { tableData, modelType } = useDataTableStore();
+  const { tableData, modelType, configurableColumns, registerConfigurableColumns } = useDataTableStore();
   const { message } = App.useApp();
   const allData = useAvailableConstantsData();
-  const [columns, setColumns] = useState<IKanbanButton[]>([]);
   const [urls, setUrls] = useState<KanbanUrls>({ updateUrl: '', deleteUrl: '', postUrl: '' });
   const [tasks, setTasks] = useState<ITableRowData[]>([]);
   const { formMode } = useFormState();
@@ -40,11 +40,51 @@ const KanbanReactComponent: FCUnwrapped<IKanbanProps> = (props) => {
   const [selectedColumn, setSelectedColumn] = useState<number | null>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [settings, setSettings] = useState<IAnyObject>({});
-  const { storeSettings } = useRefListItemGroupConfigurator();
+  const { storeSettings, items: refListItems } = useRefListItemGroupConfigurator();
   const { getMetadata } = useMetadataDispatcher();
+
+  // Columns come from the reference list held by the provider, not from the saved snapshot,
+  // so the designer, preview and runtime can never drift apart. Per-item configuration saved
+  // on the model is merged onto these items by the provider.
+  const columns = useMemo(() => refListItems.filter(isKanbanColumn), [refListItems]);
 
   const styling = jsonSafeParse<StyleBoxValue>(props.columnStyles?.stylingBox || '{}');
   const stylingBoxAsCSS = pickStyleFromModel(styling);
+
+  const getGroupingValue = useCallback(
+    (task: ITableRowData): number | undefined => getPropertyOrUndefined<number>(task, groupingProperty, (value) => {
+      // A reference list cell can arrive either as a raw value or as { item, itemValue }.
+      const rawValue = isRefListCellValue(value) ? value.itemValue : value;
+      const numericValue = typeof rawValue === 'number' ? rawValue : parseFloat(String(rawValue));
+      return Number.isNaN(numericValue) ? undefined : numericValue;
+    }),
+    [groupingProperty],
+  );
+
+  useEffect(() => {
+    if (isNullOrWhiteSpace(groupingProperty))
+      return;
+    // The Kanban renders no grid of its own, so nothing else asks the table to fetch the grouping
+    // property. Without it every row arrives without the value used to place cards into columns.
+    const isAlreadyFetched = configurableColumns.some((column) => isDataColumn(column) && column.propertyName === groupingProperty);
+    if (isAlreadyFetched)
+      return;
+
+    const groupingColumn: IDataColumnsProps = {
+      id: `${props.id}-${groupingProperty}`,
+      columnType: 'data',
+      propertyName: groupingProperty,
+      caption: groupingProperty,
+      sortOrder: configurableColumns.length,
+      itemType: 'item',
+      allowSorting: false,
+      isVisible: true,
+    };
+    registerConfigurableColumns(props.id, [...configurableColumns, groupingColumn]);
+    // registerConfigurableColumns is omitted from the dependencies because the actions object is
+    // recreated on every render; the effect only needs to re-run when the columns themselves change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configurableColumns, groupingProperty, props.id]);
 
   useEffect(() => {
     if (!isInDesigner && modelType && groupingProperty) {
@@ -62,24 +102,21 @@ const KanbanReactComponent: FCUnwrapped<IKanbanProps> = (props) => {
         throw error;
       });
 
-      const filteredTasks = tableData.filter((item) => item[groupingProperty]);
+      // isDefined rather than truthiness: itemValue 0 is a valid column (e.g. "None").
+      const filteredTasks = tableData.filter((item) => isDefined(getGroupingValue(item)));
       setTasks(filteredTasks);
     }
-  }, [isInDesigner, modelType, groupingProperty, tableData, getMetadata]);
-
-  useEffect(() => {
-    setColumns(items ?? []);
-  }, [items]);
+  }, [isInDesigner, modelType, groupingProperty, tableData, getMetadata, getGroupingValue]);
 
   useEffectOnce(() => {
     const initializeSettings = async (): Promise<void> => {
       try {
         if (!isNullOrWhiteSpace(componentName)) {
-          const resp = await fetchColumnState(componentName);
+          const resp: KanbanColumnState = (await fetchColumnState(componentName)) ?? {};
           setSettings(resp);
           // Loop through and store settings asynchronously
           for (const [columnId, isCollapsed] of Object.entries(resp)) {
-            await storeSettings(columnId, isCollapsed as boolean); // Await inside loop
+            await storeSettings(columnId, isCollapsed);
           }
         } else
           setSettings({});
@@ -96,11 +133,10 @@ const KanbanReactComponent: FCUnwrapped<IKanbanProps> = (props) => {
   });
 
   useEffect(() => {
-    if (isDefined(selectedItem)) {
+    // editForm is only mounted while an item is selected; closeModal resets it while it is
+    // still connected, so there is nothing to reset here.
+    if (isDefined(selectedItem))
       editForm.setFieldsValue(selectedItem as RecursivePartial<ITableRowData>);
-    } else {
-      editForm.resetFields();
-    }
   }, [selectedItem, editForm]);
 
   const closeModal = (): void => {
@@ -170,12 +206,14 @@ const KanbanReactComponent: FCUnwrapped<IKanbanProps> = (props) => {
   const memoizedFilteredTasks = useMemo(() => {
     return columns.map((column) => ({
       column,
-      tasks: tasks.filter((task) => getPropertyOrUndefined<number>(task, groupingProperty, (value) => value ? parseFloat(String(value)) : undefined) === column.itemValue),
+      tasks: tasks.filter((task) => getGroupingValue(task) === column.itemValue),
       isCollapsed: settings[column.itemValue] || false, // Default to false if not set
     }));
-  }, [columns, tasks, groupingProperty, settings]);
+  }, [columns, tasks, settings, getGroupingValue]);
 
   const overflowStyle = getOverflowStyle(true, false);
+
+  console.log("COLUMNS::",columns)
 
   return (
     <>

--- a/shesha-reactjs/src/components/kanban/index.tsx
+++ b/shesha-reactjs/src/components/kanban/index.tsx
@@ -213,8 +213,6 @@ const KanbanReactComponent: FCUnwrapped<IKanbanProps> = (props) => {
 
   const overflowStyle = getOverflowStyle(true, false);
 
-  console.log("COLUMNS::",columns)
-
   return (
     <>
       {!isNonEmptyArray(columns) ? (

--- a/shesha-reactjs/src/components/kanban/model.ts
+++ b/shesha-reactjs/src/components/kanban/model.ts
@@ -3,11 +3,21 @@ import { IButtonGroupItem, IConfigurableActionConfiguration, IStyleValue } from 
 import { CSSProperties } from 'react';
 import { IEntityTypeIdentifier } from '@/providers/sheshaApplication/publicApi/entities/models';
 import { IReferenceListIdentifier } from '@/interfaces';
+import { RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
+import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 
 export interface IKanbanButton extends IButtonGroupItem {
   itemValue: number;
   item: string;
 }
+
+export const isKanbanColumn = (item: RefListGroupItemProps): item is RefListGroupItemProps & IKanbanButton =>
+  isDefined(item.itemValue) && !isNullOrWhiteSpace(item.item);
+
+/** A reference list cell is returned either as a raw value or as an object carrying `itemValue`. */
+export const isRefListCellValue = (value: unknown): value is { itemValue: number } =>
+  typeof value === 'object' && value !== null && 'itemValue' in value &&
+  typeof (value as { itemValue: unknown }).itemValue === 'number';
 export interface IKanbanProps extends IConfigurableFormComponent, IStyleValue {
   items?: IKanbanButton[] | undefined;
   referenceList?: IReferenceListIdentifier | undefined;

--- a/shesha-reactjs/src/components/kanban/utils.ts
+++ b/shesha-reactjs/src/components/kanban/utils.ts
@@ -1,21 +1,41 @@
-import { extractAjaxResponse, IAjaxResponse, IAnyObject } from '@/interfaces';
+import { extractAjaxResponse, IAjaxResponse } from '@/interfaces';
 import { useHttpClient } from '@/providers';
 import { ITableRowData } from '@/providers/dataTable/interfaces';
 import { buildUrl } from '@/utils';
+import { isDefined } from '@/utils/nullables';
+import { jsonSafeParse } from '@/utils/object';
+
+/** Collapsed state of every Kanban column, keyed by column item value. */
+export type KanbanColumnState = Record<string, boolean>;
+
+type GetUserSettingValueRequest = {
+  name: string;
+  module: string;
+};
+
+type UpdateUserSettingValueRequest = {
+  name: string;
+  module: string;
+  value: string;
+  datatype: string;
+};
+
+/** GetUserValue returns the value as stored - the JSON string written below - or null when nothing is saved yet. */
+type UserSettingValue = string | KanbanColumnState | null;
 
 export type KanbanActions = {
   updateKanban: (payload: ITableRowData, url: string) => Promise<ITableRowData>;
   deleteKanban: (payload: string, url: string) => Promise<void>;
   createKanbanItem: (payload: ITableRowData, url: string) => Promise<ITableRowData>;
-  fetchColumnState: (descriminator: string) => Promise<IAnyObject>;
-  updateUserSettings: (updatedSettings: unknown, descriminator: string) => Promise<void>;
+  fetchColumnState: (descriminator: string) => Promise<KanbanColumnState | null>;
+  updateUserSettings: (updatedSettings: KanbanColumnState, descriminator: string) => Promise<void>;
 };
 
 export const useKanbanActions = (): KanbanActions => {
   const httpClient = useHttpClient();
 
-  const updateUserSettings = async (updatedSettings: unknown, descriminator: string): Promise<void> => {
-    const response = await httpClient.post<IAjaxResponse<void>>(
+  const updateUserSettings = async (updatedSettings: KanbanColumnState, descriminator: string): Promise<void> => {
+    const response = await httpClient.post<IAjaxResponse<void>, UpdateUserSettingValueRequest>(
       '/api/services/app/Settings/UpdateUserValue',
       {
         name: descriminator,
@@ -26,13 +46,21 @@ export const useKanbanActions = (): KanbanActions => {
     );
     extractAjaxResponse(response.data);
   };
-  const fetchColumnState = async (descriminator: string): Promise<IAnyObject> => {
-    const response = await httpClient.post<IAjaxResponse<IAnyObject>>('/api/services/app/Settings/GetUserValue', {
-      name: descriminator,
-      module: 'Shesha',
-    });
+  const fetchColumnState = async (descriminator: string): Promise<KanbanColumnState | null> => {
+    const response = await httpClient.post<IAjaxResponse<UserSettingValue>, GetUserSettingValueRequest>(
+      '/api/services/app/Settings/GetUserValue',
+      {
+        name: descriminator,
+        module: 'Shesha',
+      },
+    );
     const responseData = extractAjaxResponse(response.data);
-    return responseData;
+    const columnState = typeof responseData === 'string'
+      ? jsonSafeParse<KanbanColumnState>(responseData)
+      : responseData;
+    return isDefined(columnState) && typeof columnState === 'object'
+      ? columnState
+      : null;
   };
   const updateKanban = async (payload: ITableRowData, url: string): Promise<ITableRowData> => {
     const response = await httpClient.put<IAjaxResponse<ITableRowData>>(url, payload);

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/models.ts
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/models.ts
@@ -6,6 +6,7 @@ export type RefListGroupItemProps = IRefListItemFormModel | IRefListItemGroup;
 export interface IRefListGroupItemBase extends Omit<IButtonItem, 'childItems'> {
   referenceList?: IReferenceListIdentifier | undefined;
   item?: string | undefined;
+  itemValue?: number | undefined;
 }
 
 export type IRefListItemFormModel = IRefListGroupItemBase;

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
@@ -6,7 +6,6 @@ import { getItemPositionById } from '@/components/refListSelectorDisplay/provide
 import { createReducer } from '@reduxjs/toolkit';
 import { setItems, selectItemAction, updateItemAction, updateChildItemsAction, storeSettingsAction } from './actions';
 import { isDefined } from '@/utils/nullables';
-import { IReferenceListItem } from '@/interfaces/referenceList';
 
 export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT_INITIAL_STATE, (builder) => {
   builder
@@ -16,7 +15,7 @@ export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT
       const priorByValue = new Map<number, RefListGroupItemProps>();
       const indexPriorItems = (items: RefListGroupItemProps[]): void => {
         items.forEach((prior) => {
-          const value = (prior as Partial<IReferenceListItem>).itemValue;
+          const value = prior.itemValue;
           if (isDefined(value))
             priorByValue.set(value, prior);
           // grouped items keep their settings under childItems, so recurse to preserve nested config too

--- a/shesha-reactjs/src/designer-components/chevron/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/chevron/settingsForm.ts
@@ -91,7 +91,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                   inputType: 'referenceListAutocomplete',
                   propertyName: 'referenceList',
                   label: 'Reference List',
-                  tooltip: 'Make sure to reselect the reference list if any changes are made to its items',
+                  tooltip: 'The reference list whose items are rendered as steps. Changes to its items are picked up automatically',
                   filter: { and: [{ '==': [{ var: 'isLast' }, true] }] },
                 })
                 .addSettingsInput({

--- a/shesha-reactjs/src/designer-components/kanban/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/kanban/settingsForm.ts
@@ -250,7 +250,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                   inputType: 'referenceListAutocomplete',
                   propertyName: 'referenceList',
                   label: 'Reference List',
-                  tooltip: 'Make sure to reselect the reference list if any changes are made to its items',
+                  tooltip: 'The reference list whose items are rendered as columns. Changes to its items are picked up automatically',
                   filter: { and: [{ '==': [{ var: 'isLast' }, true] }] },
                 })
                 .addSettingsInput({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chevron controls now stay in sync with updated reference-list items across design, preview, and runtime.
  * Kanban columns now auto-update from the selected reference list, and task grouping works reliably with numeric values.

* **Bug Fixes**
  * Kanban editing no longer resets unexpectedly when the selected item changes.
  * Improved robustness when loading and applying saved column-visibility settings.

* **Documentation**
  * Updated “Reference List” tooltips for Chevron and Kanban to clarify that item changes are picked up automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->