### PR TITLE
fix: update query casting method in DynamicRepository to use correct overload

### DIFF
--- a/shesha-core/src/Shesha.NHibernate/Services/DynamicRepository.cs
+++ b/shesha-core/src/Shesha.NHibernate/Services/DynamicRepository.cs
@@ -148,7 +148,9 @@ namespace Shesha.Services
         {
             var where = new Func<IQueryable<int>, Expression<Func<int, bool>>, IQueryable<int>>(Queryable.Where).Method;
             var whereForMyType = where.GetGenericMethodDefinition().MakeGenericMethod(entityType);
-            var query = CurrentSession.Query<object>(entityType.FullName).Cast(entityType.GetRequiredFullName());
+            // note: use the `Cast(Type)` overload, not `Cast(string)`. The latter resolves the type name using
+            // Dynamic LINQ's own type provider, which no longer resolves application types (System.Linq.Dynamic.Core 1.4+)
+            var query = CurrentSession.Query<object>(entityType.GetRequiredFullName()).Cast(entityType);
 
             return whereForMyType.Invoke(query, [query, lambda]).ForceCastAs<IQueryable>();
         }

--- a/shesha-core/src/Shesha.NHibernate/Services/DynamicRepository.cs
+++ b/shesha-core/src/Shesha.NHibernate/Services/DynamicRepository.cs
@@ -148,8 +148,7 @@ namespace Shesha.Services
         {
             var where = new Func<IQueryable<int>, Expression<Func<int, bool>>, IQueryable<int>>(Queryable.Where).Method;
             var whereForMyType = where.GetGenericMethodDefinition().MakeGenericMethod(entityType);
-            // note: use the `Cast(Type)` overload, not `Cast(string)`. The latter resolves the type name using
-            // Dynamic LINQ's own type provider, which no longer resolves application types (System.Linq.Dynamic.Core 1.4+)
+        
             var query = CurrentSession.Query<object>(entityType.GetRequiredFullName()).Cast(entityType);
 
             return whereForMyType.Invoke(query, [query, lambda]).ForceCastAs<IQueryable>();


### PR DESCRIPTION
This pull request makes a targeted fix to the `Where` method in `DynamicRepository.cs` to ensure correct type resolution when casting query results. The change switches from using the `Cast(string)` overload to the `Cast(Type)` overload, addressing an issue with type resolution in newer versions of System.Linq.Dynamic.Core.

**Query type resolution fix:**

* Updated the `Where` method to use `Cast(Type)` instead of `Cast(string)` when casting query results, ensuring that application types are resolved correctly with System.Linq.Dynamic.Core 1.4+ (`DynamicRepository.cs`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic query behavior when applying filters across different entity types.
  * Resolved a potential type-casting mismatch that could cause dynamic queries to fail or return unexpected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related to issue: #3779