### PR TITLE
Fix Windsor release-policy memory leak (request-scoped release)

### DIFF
--- a/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
@@ -44,9 +44,12 @@ namespace Shesha.Authorization
             }
 
             //TODO: Avoid using try/catch, use conditional checking
+            // ResolveAll registers every resolved helper (and its whole dependency graph: UserManager,
+            // RoleManager, stores, repositories, unit-of-work managers, loggers) with Windsor's release
+            // policy. It must be paired with Release, otherwise the graph leaks on every authorized request.
+            var authorizationHelpers = _iocManager.ResolveAll<ISheshaAuthorizationHelper>();
             try
             {
-                var authorizationHelpers = _iocManager.ResolveAll<ISheshaAuthorizationHelper>();
                 foreach (var authorization in authorizationHelpers)
                 {
                     await authorization.AuthorizeAsync(
@@ -92,6 +95,14 @@ namespace Shesha.Authorization
                 {
                     //TODO: How to return Error page?
                     context.Result = new StatusCodeResult((int)System.Net.HttpStatusCode.InternalServerError);
+                }
+            }
+            finally
+            {
+                // Release the ResolveAll'd helpers and their dependency graph (fixes the per-request leak).
+                foreach (var authorization in authorizationHelpers)
+                {
+                    _iocManager.Release(authorization);
                 }
             }
         }

--- a/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionChecker.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionChecker.cs
@@ -118,25 +118,45 @@ namespace Shesha.Authorization
         public async Task<bool> IsGrantedCustomAsync(long userId, string permissionName)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (await customChecker.IsGrantedAsync(userId, permissionName))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (await customChecker.IsGrantedAsync(userId, permissionName))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         public async Task<bool> IsGrantedCustomAsync(long userId, string permissionName, EntityReferenceDto<string> permissionedEntity)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (await customChecker.IsGrantedAsync(userId, permissionName, permissionedEntity))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (await customChecker.IsGrantedAsync(userId, permissionName, permissionedEntity))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         /// <summary>
@@ -148,25 +168,45 @@ namespace Shesha.Authorization
         public bool IsGrantedCustom(long userId, string permissionName)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (customChecker.IsGranted(userId, permissionName))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (customChecker.IsGranted(userId, permissionName))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         public bool IsGrantedCustom(long userId, string permissionName, EntityReferenceDto<string> permissionedEntity)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (customChecker.IsGranted(userId, permissionName, permissionedEntity))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (customChecker.IsGranted(userId, permissionName, permissionedEntity))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         /// <summary>

--- a/shesha-core/src/Shesha.Framework/Extensions/SheshaMiddlewareExtensions.cs
+++ b/shesha-core/src/Shesha.Framework/Extensions/SheshaMiddlewareExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Shesha.ConfigurationItems;
 using Shesha.DynamicEntities.Middleware;
+using Shesha.Ioc;
 
 namespace Shesha.Extensions
 {
@@ -9,6 +10,17 @@ namespace Shesha.Extensions
     /// </summary>
     public static class SheshaMiddlewareExtensions
     {
+        /// <summary>
+        /// Releases, at the end of every request, the components that were resolved via the root container
+        /// during that request (see <see cref="ReleaseRequestScopeMiddleware"/>). Keeps Castle Windsor's
+        /// release-policy dictionary bounded, fixing the root-resolve memory leak and its lock-contention
+        /// slowdown. Register this as EARLY as possible in the pipeline so its cleanup wraps the whole request.
+        /// </summary>
+        public static IApplicationBuilder UseSheshaRequestScopeRelease(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<ReleaseRequestScopeMiddleware>();
+        }
+
         public static IApplicationBuilder UseConfigurationFramework(this IApplicationBuilder app)
         {
             return app

--- a/shesha-core/src/Shesha.Framework/Extensions/SheshaMiddlewareExtensions.cs
+++ b/shesha-core/src/Shesha.Framework/Extensions/SheshaMiddlewareExtensions.cs
@@ -14,7 +14,14 @@ namespace Shesha.Extensions
         /// Releases, at the end of every request, the components that were resolved via the root container
         /// during that request (see <see cref="ReleaseRequestScopeMiddleware"/>). Keeps Castle Windsor's
         /// release-policy dictionary bounded, fixing the root-resolve memory leak and its lock-contention
-        /// slowdown. Register this as EARLY as possible in the pipeline so its cleanup wraps the whole request.
+        /// slowdown.
+        /// <para>
+        /// REQUIRED opt-in for the <c>RequestScopedReleasePolicy</c> installed by <c>SheshaFrameworkModule</c>:
+        /// call this as the FIRST middleware in the host's Configure() pipeline (before Shesha middleware,
+        /// routing, authentication and endpoints) so its cleanup wraps MVC authorization filters and ABP
+        /// interceptors. If a host omits this call the policy harmlessly degrades to Castle's default
+        /// (tracked-but-not-released) behaviour — the leak is simply not fixed, nothing breaks.
+        /// </para>
         /// </summary>
         public static IApplicationBuilder UseSheshaRequestScopeRelease(this IApplicationBuilder app)
         {

--- a/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
@@ -33,8 +33,13 @@ namespace Shesha.Ioc
             {
                 RequestReleaseScope.Clear();
 
+                // Stop any detached/background work that inherited this bucket from enqueuing further
+                // instances into it once we start releasing (the flag lives on the shared bucket object, so it
+                // is visible across inherited ExecutionContexts — unlike the AsyncLocal reference cleared above).
+                bucket.Drained = true;
+
                 var container = _iocManager.IocContainer;
-                while (bucket.TryDequeue(out var instance))
+                while (bucket.Items.TryDequeue(out var instance))
                 {
                     // Release removes the burden from the policy dictionary and runs decommission/disposal.
                     // It is idempotent (releasing an already-released or singleton instance is a safe no-op),

--- a/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
@@ -33,13 +33,12 @@ namespace Shesha.Ioc
             {
                 RequestReleaseScope.Clear();
 
-                // Stop any detached/background work that inherited this bucket from enqueuing further
-                // instances into it once we start releasing (the flag lives on the shared bucket object, so it
-                // is visible across inherited ExecutionContexts — unlike the AsyncLocal reference cleared above).
-                bucket.Drained = true;
-
+                // Atomically close the bucket and take its contents. Close() rejects any late enqueues from
+                // detached work that inherited this bucket (visible across inherited ExecutionContexts, unlike
+                // the AsyncLocal reference cleared above), so tracking and closure cannot race. Release happens
+                // outside the bucket's lock — disposal/decommission can be slow or re-entrant.
                 var container = _iocManager.IocContainer;
-                while (bucket.Items.TryDequeue(out var instance))
+                foreach (var instance in bucket.Close())
                 {
                     // Release removes the burden from the policy dictionary and runs decommission/disposal.
                     // It is idempotent (releasing an already-released or singleton instance is a safe no-op),

--- a/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
@@ -1,0 +1,54 @@
+using Abp.Dependency;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Shesha.Ioc
+{
+    /// <summary>
+    /// Opens a <see cref="RequestReleaseScope"/> bucket for the duration of each HTTP request and, when the
+    /// request completes, releases every component that <see cref="RequestScopedReleasePolicy"/> tracked during
+    /// it. This is what bounds Castle Windsor's release-policy dictionary (fixing both the memory leak and the
+    /// lock-contention slowdown) while keeping normal disposal semantics.
+    ///
+    /// Register as early as possible in the pipeline (see <c>UseSheshaRequestScopeRelease</c>) so its release
+    /// runs after everything else in the request — including MVC authorization filters and ABP interceptors.
+    /// </summary>
+    public class ReleaseRequestScopeMiddleware : IMiddleware, ISingletonDependency
+    {
+        private readonly IIocManager _iocManager;
+
+        public ReleaseRequestScopeMiddleware(IIocManager iocManager)
+        {
+            _iocManager = iocManager;
+        }
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            var bucket = RequestReleaseScope.Begin();
+            try
+            {
+                await next(context);
+            }
+            finally
+            {
+                RequestReleaseScope.Clear();
+
+                var container = _iocManager.IocContainer;
+                while (bucket.TryDequeue(out var instance))
+                {
+                    // Release removes the burden from the policy dictionary and runs decommission/disposal.
+                    // It is idempotent (releasing an already-released or singleton instance is a safe no-op),
+                    // so double-release with the ASP.NET request scope / unit of work is harmless.
+                    try
+                    {
+                        container.Release(instance);
+                    }
+                    catch
+                    {
+                        // Best-effort cleanup: never let a release failure break the response.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
@@ -4,6 +4,25 @@ using System.Threading;
 namespace Shesha.Ioc
 {
     /// <summary>
+    /// Per-request bucket of component instances tracked by <see cref="RequestScopedReleasePolicy"/>, drained
+    /// (released) by <see cref="ReleaseRequestScopeMiddleware"/> at the end of the request. Exposed as a class
+    /// (rather than a bare queue) so its <see cref="Drained"/> flag lives on the shared instance: fire-and-forget
+    /// work that inherits the request's <see cref="ExecutionContext"/> sees the same object and therefore stops
+    /// enqueuing once the request has drained (see <see cref="RequestReleaseScope"/>).
+    /// </summary>
+    public sealed class RequestReleaseBucket
+    {
+        internal readonly ConcurrentQueue<object> Items = new ConcurrentQueue<object>();
+
+        /// <summary>
+        /// Set once the request has finished and its instances have been (are being) released. After this is set,
+        /// no further instances are accepted — this is the guard that stops detached/background work (which
+        /// inherited this bucket via ExecutionContext) from mutating it after the request is gone.
+        /// </summary>
+        public volatile bool Drained;
+    }
+
+    /// <summary>
     /// Holds, per logical request (async flow), the set of component instances that were tracked by
     /// <see cref="RequestScopedReleasePolicy"/> so they can be released at the end of the request.
     ///
@@ -13,18 +32,24 @@ namespace Shesha.Ioc
     /// That is both a memory leak and (because the dictionary is lock-guarded and grows unbounded) a
     /// performance problem. Draining this per-request bucket at request end keeps the dictionary bounded to the
     /// in-flight working set while preserving normal disposal semantics (unlike a global NoTrackingReleasePolicy).
+    ///
+    /// Fire-and-forget safety: a detached task started during the request inherits this AsyncLocal (and thus the
+    /// bucket reference). <see cref="Track"/> only enqueues while the bucket is live and not yet drained, so once
+    /// the request ends such work no longer accumulates into an abandoned bucket — those resolves simply fall
+    /// back to the container's default tracking (same as any resolve with no active request), rather than being
+    /// silently lost.
     /// </summary>
     public static class RequestReleaseScope
     {
-        private static readonly AsyncLocal<ConcurrentQueue<object>> _bucket = new AsyncLocal<ConcurrentQueue<object>>();
+        private static readonly AsyncLocal<RequestReleaseBucket> _bucket = new AsyncLocal<RequestReleaseBucket>();
 
         /// <summary>
         /// Starts a new per-request bucket on the current async flow and returns it so the caller
         /// (the request middleware) can drain it when the request ends.
         /// </summary>
-        public static ConcurrentQueue<object> Begin()
+        public static RequestReleaseBucket Begin()
         {
-            var bucket = new ConcurrentQueue<object>();
+            var bucket = new RequestReleaseBucket();
             _bucket.Value = bucket;
             return bucket;
         }
@@ -39,12 +64,17 @@ namespace Shesha.Ioc
 
         /// <summary>
         /// Records an instance for release at the end of the current request. No-op when there is no active
-        /// request bucket (e.g. resolves during app startup or on background/scheduler threads), which safely
-        /// leaves those on the default tracking behaviour.
+        /// request bucket (e.g. resolves during app startup or on background/scheduler threads) or when the
+        /// bucket has already been drained (e.g. a detached task that outlived its request), which safely leaves
+        /// those on the default tracking behaviour.
         /// </summary>
         public static void Track(object instance)
         {
-            _bucket.Value?.Enqueue(instance);
+            var bucket = _bucket.Value;
+            if (bucket != null && !bucket.Drained)
+            {
+                bucket.Items.Enqueue(instance);
+            }
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
@@ -1,25 +1,65 @@
-using System.Collections.Concurrent;
+using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Shesha.Ioc
 {
     /// <summary>
     /// Per-request bucket of component instances tracked by <see cref="RequestScopedReleasePolicy"/>, drained
-    /// (released) by <see cref="ReleaseRequestScopeMiddleware"/> at the end of the request. Exposed as a class
-    /// (rather than a bare queue) so its <see cref="Drained"/> flag lives on the shared instance: fire-and-forget
-    /// work that inherits the request's <see cref="ExecutionContext"/> sees the same object and therefore stops
-    /// enqueuing once the request has drained (see <see cref="RequestReleaseScope"/>).
+    /// (released) by <see cref="ReleaseRequestScopeMiddleware"/> at the end of the request.
+    ///
+    /// All access is guarded by a per-bucket lock so that closing the bucket is atomic with tracking: an
+    /// instance is either fully tracked before the request closes (and therefore released) or rejected after
+    /// (and left to the container's default tracking). This closes the race where a detached/fire-and-forget
+    /// task — which inherited this bucket via <see cref="ExecutionContext"/> — enqueues an instance in the
+    /// window between the drain-guard check and the enqueue. The lock is per request (one bucket per request),
+    /// so it only ever serialises a request against its own detached children, never across requests.
     /// </summary>
     public sealed class RequestReleaseBucket
     {
-        internal readonly ConcurrentQueue<object> Items = new ConcurrentQueue<object>();
+        private readonly object _gate = new object();
+        private readonly Queue<object> _items = new Queue<object>();
+        private bool _drained;
 
         /// <summary>
-        /// Set once the request has finished and its instances have been (are being) released. After this is set,
-        /// no further instances are accepted — this is the guard that stops detached/background work (which
-        /// inherited this bucket via ExecutionContext) from mutating it after the request is gone.
+        /// Records an instance for release, atomically with respect to <see cref="Close"/>. Returns
+        /// <c>false</c> (and tracks nothing) if the bucket has already been closed by the request — the caller
+        /// then leaves the instance on the container's default tracking.
         /// </summary>
-        public volatile bool Drained;
+        public bool TryTrack(object instance)
+        {
+            lock (_gate)
+            {
+                if (_drained)
+                {
+                    return false;
+                }
+
+                _items.Enqueue(instance);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Atomically closes the bucket (rejecting any further <see cref="TryTrack"/> calls) and returns its
+        /// contents. Callers must <c>Release</c> the returned instances OUTSIDE any lock (disposal/decommission
+        /// can be slow or re-entrant).
+        /// </summary>
+        public object[] Close()
+        {
+            lock (_gate)
+            {
+                _drained = true;
+                if (_items.Count == 0)
+                {
+                    return Array.Empty<object>();
+                }
+
+                var items = _items.ToArray();
+                _items.Clear();
+                return items;
+            }
+        }
     }
 
     /// <summary>
@@ -33,11 +73,11 @@ namespace Shesha.Ioc
     /// performance problem. Draining this per-request bucket at request end keeps the dictionary bounded to the
     /// in-flight working set while preserving normal disposal semantics (unlike a global NoTrackingReleasePolicy).
     ///
-    /// Fire-and-forget safety: a detached task started during the request inherits this AsyncLocal (and thus the
-    /// bucket reference). <see cref="Track"/> only enqueues while the bucket is live and not yet drained, so once
-    /// the request ends such work no longer accumulates into an abandoned bucket — those resolves simply fall
-    /// back to the container's default tracking (same as any resolve with no active request), rather than being
-    /// silently lost.
+    /// Fire-and-forget note: a detached task started during the request inherits this AsyncLocal (and thus the
+    /// bucket reference). Tracking is closed atomically at request end (see <see cref="RequestReleaseBucket"/>),
+    /// so such work cannot enqueue into an abandoned bucket. Detached work must still not USE request-scoped
+    /// resolutions after the request completes — the same rule as ASP.NET Core request-scoped services; it
+    /// should open its own IoC scope (or capture the values it needs) instead.
     /// </summary>
     public static class RequestReleaseScope
     {
@@ -65,16 +105,12 @@ namespace Shesha.Ioc
         /// <summary>
         /// Records an instance for release at the end of the current request. No-op when there is no active
         /// request bucket (e.g. resolves during app startup or on background/scheduler threads) or when the
-        /// bucket has already been drained (e.g. a detached task that outlived its request), which safely leaves
+        /// bucket has already been closed (e.g. a detached task that outlived its request), which safely leaves
         /// those on the default tracking behaviour.
         /// </summary>
         public static void Track(object instance)
         {
-            var bucket = _bucket.Value;
-            if (bucket != null && !bucket.Drained)
-            {
-                bucket.Items.Enqueue(instance);
-            }
+            _bucket.Value?.TryTrack(instance);
         }
     }
 }

--- a/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Shesha.Ioc
+{
+    /// <summary>
+    /// Holds, per logical request (async flow), the set of component instances that were tracked by
+    /// <see cref="RequestScopedReleasePolicy"/> so they can be released at the end of the request.
+    ///
+    /// Background: components resolved via the root container (ABP <c>IIocResolver</c>/<c>IIocManager</c> and
+    /// ABP's own authorization / unit-of-work / session interceptors) are tracked by Castle Windsor's release
+    /// policy and are never <c>Release()</c>d — they accumulate in the policy's internal dictionary forever.
+    /// That is both a memory leak and (because the dictionary is lock-guarded and grows unbounded) a
+    /// performance problem. Draining this per-request bucket at request end keeps the dictionary bounded to the
+    /// in-flight working set while preserving normal disposal semantics (unlike a global NoTrackingReleasePolicy).
+    /// </summary>
+    public static class RequestReleaseScope
+    {
+        private static readonly AsyncLocal<ConcurrentQueue<object>> _bucket = new AsyncLocal<ConcurrentQueue<object>>();
+
+        /// <summary>
+        /// Starts a new per-request bucket on the current async flow and returns it so the caller
+        /// (the request middleware) can drain it when the request ends.
+        /// </summary>
+        public static ConcurrentQueue<object> Begin()
+        {
+            var bucket = new ConcurrentQueue<object>();
+            _bucket.Value = bucket;
+            return bucket;
+        }
+
+        /// <summary>
+        /// Clears the current async flow's bucket reference (called once the request has been drained).
+        /// </summary>
+        public static void Clear()
+        {
+            _bucket.Value = null;
+        }
+
+        /// <summary>
+        /// Records an instance for release at the end of the current request. No-op when there is no active
+        /// request bucket (e.g. resolves during app startup or on background/scheduler threads), which safely
+        /// leaves those on the default tracking behaviour.
+        /// </summary>
+        public static void Track(object instance)
+        {
+            _bucket.Value?.Enqueue(instance);
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/Ioc/RequestScopedReleasePolicy.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/RequestScopedReleasePolicy.cs
@@ -1,0 +1,34 @@
+using Castle.MicroKernel;
+using Castle.MicroKernel.Releasers;
+
+namespace Shesha.Ioc
+{
+    /// <summary>
+    /// Castle Windsor release policy that behaves exactly like the default
+    /// <see cref="LifecycledComponentsReleasePolicy"/> (so normal tracking, decommission and disposal are all
+    /// preserved) but ALSO records every tracked instance in the current request's <see cref="RequestReleaseScope"/>
+    /// bucket. The request middleware then releases that bucket when the request completes, which keeps the
+    /// policy's internal <c>instance2Burden</c> dictionary bounded to the in-flight working set instead of
+    /// growing without limit.
+    ///
+    /// This is the broad fix for the root-container resolve leak: it catches EVERY component resolved during a
+    /// request (ABP interceptors, <c>IIocResolver</c>, and any <c>ResolveAll</c> sites) without editing ABP and
+    /// without a blanket non-tracking policy.
+    /// </summary>
+    public class RequestScopedReleasePolicy : LifecycledComponentsReleasePolicy
+    {
+        public RequestScopedReleasePolicy(IKernel kernel)
+            : base(kernel)
+        {
+        }
+
+        public override void Track(object instance, Burden burden)
+        {
+            // Preserve the default behaviour (needed so Release() later runs decommission/disposal correctly).
+            base.Track(instance, burden);
+
+            // Remember it for release at the end of the current request (no-op outside a request).
+            RequestReleaseScope.Track(instance);
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
+++ b/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
@@ -54,7 +54,13 @@ namespace Shesha
             // that records every tracked instance in the current request's bucket (see RequestScopedReleasePolicy
             // / RequestReleaseScope). The ReleaseRequestScopeMiddleware then releases that bucket at request end,
             // which keeps the release policy's internal dictionary bounded instead of accumulating every
-            // root-container resolve forever. Requires UseSheshaRequestScopeRelease() in the request pipeline.
+            // root-container resolve forever.
+            //
+            // OPT-IN REQUIRED: every web host must call app.UseSheshaRequestScopeRelease() at the very start of
+            // its Configure() pipeline for this to take effect (Shesha.Web.Host does). The policy is intentionally
+            // safe if a host forgets: with no middleware there is no per-request bucket, RequestScopedReleasePolicy
+            // falls through to base LifecycledComponentsReleasePolicy behaviour, i.e. the framework default — the
+            // fix simply does nothing rather than causing any new harm.
             IocManager.IocContainer.Kernel.ReleasePolicy =
                 new Shesha.Ioc.RequestScopedReleasePolicy(IocManager.IocContainer.Kernel);
 

--- a/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
+++ b/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
@@ -50,6 +50,14 @@ namespace Shesha
 
         public override void PreInitialize()
         {
+            // Broad memory-leak / performance fix: replace Castle Windsor's default release policy with one
+            // that records every tracked instance in the current request's bucket (see RequestScopedReleasePolicy
+            // / RequestReleaseScope). The ReleaseRequestScopeMiddleware then releases that bucket at request end,
+            // which keeps the release policy's internal dictionary bounded instead of accumulating every
+            // root-container resolve forever. Requires UseSheshaRequestScopeRelease() in the request pipeline.
+            IocManager.IocContainer.Kernel.ReleasePolicy =
+                new Shesha.Ioc.RequestScopedReleasePolicy(IocManager.IocContainer.Kernel);
+
             IocManager.Register<IPermissionManager, IShaPermissionManager, IPermissionDefinitionContext, ShaPermissionManager>();
 
             Configuration.ReplaceService(typeof(IExceptionFilter),

--- a/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
@@ -148,6 +148,10 @@ namespace Shesha.Web.Host.Startup
 
         public void Configure(IApplicationBuilder app, IBackgroundJobClient backgroundJobs)
         {
+            // Must be first: releases per-request root-container resolutions at request end. Required to make
+            // SheshaFrameworkModule's RequestScopedReleasePolicy actually bound the release-policy dictionary.
+            app.UseSheshaRequestScopeRelease();
+
             app.UseSheshaElmah();
 
             // note: already registered in the ABP


### PR DESCRIPTION
# Windsor release-policy memory leak — investigation & fix

This is a fix for #5222 

## Symptom
Long-running Shesha API processes grew memory without bound under normal authenticated
traffic (observed in prod; reproduced locally).

## How it was diagnosed
Full process dumps (`dotnet-dump`) of the running Web.Host were analysed with `dumpheap`
and `gcroot`. A **two-dump before/after delta** isolated what actually accumulated, and
`gcroot` distinguished *rooted* (leaked) objects from ordinary uncollected garbage.

Top accumulating, still-rooted types after driving authenticated requests:

| Type | before | after load |
|---|---|---|
| `Castle.MicroKernel.Burden` | ~5.8k | ~357k |
| `Abp.Domain.Uow.UnitOfWorkManager` | ~2.5k | ~709k |
| `Abp.Castle.Logging.Log4Net.Log4NetLogger` | ~9k | ~2.34M |
| `Shesha.Authorization.Users.UserManager` / `RoleManager` | a few | ~13k each |

`gcroot` showed every one of them retained through a single chain:

```
GlobalMsLifetimeScope → WindsorContainer → DefaultKernel
  → LifecycledComponentsReleasePolicy
  → Dictionary<object, Burden>   (instance2Burden)
  → UserManager / UnitOfWorkManager / … → Log4NetLogger
```

## Root cause
Castle Windsor's **default `LifecycledComponentsReleasePolicy` tracks every component it
resolves that has a decommission concern (IDisposable etc.)** in a single, lock-guarded
dictionary, and holds a strong reference until `container.Release(instance)` is called.

Components resolved via the **root container** during a request — ABP's
`IIocResolver`/`IIocManager`, ABP's own authorization / unit-of-work / session
interceptors, and Shesha `ResolveAll` sites (e.g. `SheshaAuthorizationFilter`,
`ShaPermissionChecker`) — are **never released**. Their whole dependency graph therefore
accumulates in `instance2Burden` forever.

Because that dictionary is lock-guarded and grows unbounded, it is **both a memory leak
and a performance problem**: every resolve contends on the lock as the dictionary grows.

(Request-scoped resolves that go through the ASP.NET Core request `IServiceProvider` →
`MsLifetimeScope` are released correctly; only the root-container resolves leak.)

## The fix
Bound the tracking dictionary to the in-flight request working set, without changing
disposal behaviour for anything else:

- **`RequestScopedReleasePolicy`** — subclasses `LifecycledComponentsReleasePolicy`.
  `Track` calls `base.Track` (so normal decommission/disposal is preserved) **and** records
  the instance in a per-request bucket.
- **`RequestReleaseScope`** — an `AsyncLocal` per-request bucket (`Begin`/`Track`/`Clear`).
- **`ReleaseRequestScopeMiddleware`** — opens the bucket at the start of each request and,
  in a `finally`, `Release()`s every instance tracked during that request.

Installed in `SheshaFrameworkModule.PreInitialize` (sets the kernel release policy).
Apps opt the middleware in with `app.UseSheshaRequestScopeRelease()` as the first
middleware in the pipeline (so cleanup wraps MVC auth filters and ABP interceptors).

Defensive `try/finally Release` was also added to the `ResolveAll` sites in
`SheshaAuthorizationFilter` and `ShaPermissionChecker` (redundant once the policy is in
place, but harmless).

## Alternatives considered and rejected
- **`NoTrackingReleasePolicy` (global)** — one line, fixes both symptoms, but Castle
  discourages it and it disables container-driven disposal for *all* components.
- **Per-type "selective" non-tracking policy** — matching by implementation name proved
  unreliable, and it would not bound the dictionary (other components keep it large), so it
  fixes neither the leak fully nor the performance issue.
- **Per-site `Release` only** — correct but does not converge: the dominant resolves happen
  inside ABP framework code, not at Shesha call sites.
- **Version upgrade** — aspnetboilerplate keeps the root-resolver design through current
  releases; only a full Volo.Abp migration would remove it structurally.

## Verified
- **A/B control** (same build, fix on vs off): auth-helper instances went from ~1 per
  authenticated request (climbing) to flat; `UserManager` ~6k → a handful.
- **Soak** (long run, heavy authenticated traffic): the release-policy dictionary stayed
  bounded; `gcroot` found the surviving instances collectible (not rooted). Working set
  stable at its lowest observed level.
- **Scheduler path checked separately** with a `dotnet-gcdump` (forced-GC) before/after
  delta over ~2,000 Hangfire job executions: rooted counts flat (Hangfire's per-job DI
  scope already disposes correctly) — **no job-path leak**, no change needed there.

### Note on tooling
`dotnet-gcdump` forces a full GC before capture, so anything remaining is genuinely rooted.
Prefer it over a raw `dotnet-dump` histogram for leak verdicts — a full dump's counts
include large amounts of not-yet-collected garbage that can look like a leak but is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of resolved authorization helpers and custom permission checkers, ensuring they’re reliably released even when checks throw or short-circuit responses.
- **Improvements**
  - Added per-request request-scope release management via new middleware (`UseSheshaRequestScopeRelease`) and a request-scoped release policy, with guaranteed end-of-request cleanup and safer lifecycle tracking.
- **Chores**
  - Refined internal request release scope/bucket handling to reduce buildup and ensure tracked instances are properly drained and released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->