### PR TITLE
Nhlakanipho/b/5071

### DIFF
--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -6,7 +6,7 @@ import { ValueRenderer } from '@/components/valueRenderer/index';
 import { useDeepCompareMemo } from '@/hooks';
 import { useFormComponentStyles } from '@/hooks/formComponentHooks';
 import { useDeepCompareEffect } from '@/hooks/useDeepCompareEffect';
-import { IAnyObject, IFormSettings } from '@/interfaces';
+import { IAnyObject } from '@/interfaces';
 import { configurableItemIdentifierToString } from '@/interfaces/configurableItems';
 import { DEFAULT_FORM_SETTINGS, FormFullName, FormIdentifier, HttpClientApi, IFormDto, IPersistedFormProps, useAppConfigurator, useConfigurableActionDispatcher, useShaFormInstance } from '@/providers';
 import { useConfigurationItemsLoader } from '@/providers/configurationItemsLoader';
@@ -406,34 +406,6 @@ export const DataList: FC<IDataListProps> = ({
     return false;
   };
 
-  const rawItemWidth = (style as CSSProperties | undefined)?.width ?? props.container?.dimensions?.width;
-  const isFixedWidth = (val: unknown): boolean => {
-    if (val === undefined || val === null || val === '') return false;
-    if (typeof val === 'number') return true;
-    const s = String(val).trim().toLowerCase();
-    return s !== 'auto' && s !== 'unset' && s !== 'inherit' && s !== 'initial' && s !== 'none';
-  };
-  const itemWidth = isFixedWidth(rawItemWidth)
-    ? (typeof rawItemWidth === 'number' ? `${rawItemWidth}px` : rawItemWidth)
-    : '300px';
-
-  /**
-   * `horizontal` and `wrap` orientations size every card to `itemWidth` (300px by default). A proportional
-   * `labelCol` (`{ span: 6 }` by default) then resolves to ~75px, which is not enough for a typical label:
-   * antd clips it, because `.ant-form-item-label` is `overflow: hidden`, or wraps it into an unreadable
-   * two-line stack. antd already falls back to a vertical layout below its `screenXSMax` breakpoint for
-   * exactly this reason, but it keys off the viewport — which stays wide here, since it is the card that is
-   * narrow. So apply the same fallback keyed off the card: the label gets the full card width, on one line.
-   *
-   * Only px widths are judged. A card sized in %/rem/vw has no width resolvable here, so its configured
-   * layout is left alone rather than overridden on a guess.
-   */
-  const stackCardLabels = ((): boolean => {
-    if (orientation === 'vertical') return false;
-    const px = /^(\d+(?:\.\d+)?)px$/.exec(String(itemWidth ?? '').trim());
-    return px !== null && Number(px[1]) <= theme.screenXSMax;
-  })();
-
   useDeepCompareEffect(() => {
     let isReady = true;
 
@@ -474,7 +446,7 @@ export const DataList: FC<IDataListProps> = ({
       updateRows();
       updateContent();
     }
-  }, [records, formId, formType, createFormId, createFormType, entityType, formSelectionMode, showEditIcons, canEditInline, canDeleteInline, noDataIcon, noDataSecondaryText, noDataText, style, groupStyle, orientation, itemWidth, stackCardLabels]);
+  }, [records, formId, formType, createFormId, createFormType, entityType, formSelectionMode, showEditIcons, canEditInline, canDeleteInline, noDataIcon, noDataSecondaryText, noDataText, style, groupStyle, orientation]);
 
   const renderSubForm = (item: ITableRowData, index: number): ReactNode => {
     // Note: keep these `undefined` (not `null`) so they match the values used when the entity form is
@@ -587,21 +559,13 @@ export const DataList: FC<IDataListProps> = ({
     if (isFormFullName(entityForm.formId))
       attributes['data-sha-form-name'] = `${entityForm.formId.module}/${entityForm.formId.name}`;
 
-    const baseFormSettings = entityForm.formConfiguration.settings ?? DEFAULT_FORM_SETTINGS;
-    // `labelCol`/`wrapperCol` have to be widened along with the layout: antd's `-vertical` rules do not
-    // reset the label `Col` width, and `FormItemProvider` re-injects `formSettings.labelCol` into every
-    // `Form.Item`, so leaving them at `{ span: 6 }` would keep the label boxed into 25% of the card.
-    const cardFormSettings: IFormSettings = stackCardLabels
-      ? { ...baseFormSettings, layout: 'vertical', labelCol: { span: 24 }, wrapperCol: { span: 24 } }
-      : baseFormSettings;
-
     return (
       <AttributeDecorator attributes={attributes}>
         <div onDoubleClick={dblClick} style={{ width: '100%' }}>
           <DataListItemRenderer
             isNewObject={false}
             markup={entityForm.formConfiguration.markup}
-            formSettings={cardFormSettings}
+            formSettings={entityForm.formConfiguration.settings ?? DEFAULT_FORM_SETTINGS}
             data={item}
             listId={id}
             listName="Data List"
@@ -826,6 +790,17 @@ export const DataList: FC<IDataListProps> = ({
     );
   };
 
+
+  const rawItemWidth = (style as CSSProperties | undefined)?.width ?? props.container?.dimensions?.width;
+  const isFixedWidth = (val: unknown): boolean => {
+    if (val === undefined || val === null || val === '') return false;
+    if (typeof val === 'number') return true;
+    const s = String(val).trim().toLowerCase();
+    return s !== 'auto' && s !== 'unset' && s !== 'inherit' && s !== 'initial' && s !== 'none';
+  };
+  const itemWidth = isFixedWidth(rawItemWidth)
+    ? (typeof rawItemWidth === 'number' ? `${rawItemWidth}px` : rawItemWidth)
+    : '300px';
 
   const getContainerStyles = (): CSSProperties => {
     const containerStyles: CSSProperties = {

--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -6,7 +6,7 @@ import { ValueRenderer } from '@/components/valueRenderer/index';
 import { useDeepCompareMemo } from '@/hooks';
 import { useFormComponentStyles } from '@/hooks/formComponentHooks';
 import { useDeepCompareEffect } from '@/hooks/useDeepCompareEffect';
-import { IAnyObject } from '@/interfaces';
+import { IAnyObject, IFormSettings } from '@/interfaces';
 import { configurableItemIdentifierToString } from '@/interfaces/configurableItems';
 import { DEFAULT_FORM_SETTINGS, FormFullName, FormIdentifier, HttpClientApi, IFormDto, IPersistedFormProps, useAppConfigurator, useConfigurableActionDispatcher, useShaFormInstance } from '@/providers';
 import { useConfigurationItemsLoader } from '@/providers/configurationItemsLoader';
@@ -406,6 +406,34 @@ export const DataList: FC<IDataListProps> = ({
     return false;
   };
 
+  const rawItemWidth = (style as CSSProperties | undefined)?.width ?? props.container?.dimensions?.width;
+  const isFixedWidth = (val: unknown): boolean => {
+    if (val === undefined || val === null || val === '') return false;
+    if (typeof val === 'number') return true;
+    const s = String(val).trim().toLowerCase();
+    return s !== 'auto' && s !== 'unset' && s !== 'inherit' && s !== 'initial' && s !== 'none';
+  };
+  const itemWidth = isFixedWidth(rawItemWidth)
+    ? (typeof rawItemWidth === 'number' ? `${rawItemWidth}px` : rawItemWidth)
+    : '300px';
+
+  /**
+   * `horizontal` and `wrap` orientations size every card to `itemWidth` (300px by default). A proportional
+   * `labelCol` (`{ span: 6 }` by default) then resolves to ~75px, which is not enough for a typical label:
+   * antd clips it, because `.ant-form-item-label` is `overflow: hidden`, or wraps it into an unreadable
+   * two-line stack. antd already falls back to a vertical layout below its `screenXSMax` breakpoint for
+   * exactly this reason, but it keys off the viewport — which stays wide here, since it is the card that is
+   * narrow. So apply the same fallback keyed off the card: the label gets the full card width, on one line.
+   *
+   * Only px widths are judged. A card sized in %/rem/vw has no width resolvable here, so its configured
+   * layout is left alone rather than overridden on a guess.
+   */
+  const stackCardLabels = ((): boolean => {
+    if (orientation === 'vertical') return false;
+    const px = /^(\d+(?:\.\d+)?)px$/.exec(String(itemWidth ?? '').trim());
+    return px !== null && Number(px[1]) <= theme.screenXSMax;
+  })();
+
   useDeepCompareEffect(() => {
     let isReady = true;
 
@@ -446,7 +474,7 @@ export const DataList: FC<IDataListProps> = ({
       updateRows();
       updateContent();
     }
-  }, [records, formId, formType, createFormId, createFormType, entityType, formSelectionMode, showEditIcons, canEditInline, canDeleteInline, noDataIcon, noDataSecondaryText, noDataText, style, groupStyle, orientation]);
+  }, [records, formId, formType, createFormId, createFormType, entityType, formSelectionMode, showEditIcons, canEditInline, canDeleteInline, noDataIcon, noDataSecondaryText, noDataText, style, groupStyle, orientation, itemWidth, stackCardLabels]);
 
   const renderSubForm = (item: ITableRowData, index: number): ReactNode => {
     // Note: keep these `undefined` (not `null`) so they match the values used when the entity form is
@@ -559,13 +587,21 @@ export const DataList: FC<IDataListProps> = ({
     if (isFormFullName(entityForm.formId))
       attributes['data-sha-form-name'] = `${entityForm.formId.module}/${entityForm.formId.name}`;
 
+    const baseFormSettings = entityForm.formConfiguration.settings ?? DEFAULT_FORM_SETTINGS;
+    // `labelCol`/`wrapperCol` have to be widened along with the layout: antd's `-vertical` rules do not
+    // reset the label `Col` width, and `FormItemProvider` re-injects `formSettings.labelCol` into every
+    // `Form.Item`, so leaving them at `{ span: 6 }` would keep the label boxed into 25% of the card.
+    const cardFormSettings: IFormSettings = stackCardLabels
+      ? { ...baseFormSettings, layout: 'vertical', labelCol: { span: 24 }, wrapperCol: { span: 24 } }
+      : baseFormSettings;
+
     return (
       <AttributeDecorator attributes={attributes}>
         <div onDoubleClick={dblClick} style={{ width: '100%' }}>
           <DataListItemRenderer
             isNewObject={false}
             markup={entityForm.formConfiguration.markup}
-            formSettings={entityForm.formConfiguration.settings ?? DEFAULT_FORM_SETTINGS}
+            formSettings={cardFormSettings}
             data={item}
             listId={id}
             listName="Data List"
@@ -790,17 +826,6 @@ export const DataList: FC<IDataListProps> = ({
     );
   };
 
-
-  const rawItemWidth = (style as CSSProperties | undefined)?.width ?? props.container?.dimensions?.width;
-  const isFixedWidth = (val: unknown): boolean => {
-    if (val === undefined || val === null || val === '') return false;
-    if (typeof val === 'number') return true;
-    const s = String(val).trim().toLowerCase();
-    return s !== 'auto' && s !== 'unset' && s !== 'inherit' && s !== 'initial' && s !== 'none';
-  };
-  const itemWidth = isFixedWidth(rawItemWidth)
-    ? (typeof rawItemWidth === 'number' ? `${rawItemWidth}px` : rawItemWidth)
-    : '300px';
 
   const getContainerStyles = (): CSSProperties => {
     const containerStyles: CSSProperties = {

--- a/shesha-reactjs/src/components/dataList/styles/styles.ts
+++ b/shesha-reactjs/src/components/dataList/styles/styles.ts
@@ -1,5 +1,15 @@
 import { createStyles } from '@/styles';
 
+/**
+ * Largest share of a card's width a label may take, so the value beside it always keeps room.
+ *
+ * A label sizes to its own text but stops here; anything longer wraps onto a second line *within* that share
+ * (the card's form sets `labelWrap`, so it wraps rather than being clipped) while its value stays to the
+ * right. At 60% a ~200px card gives the label ~115px — enough for a two-word label at the bold 14px the
+ * layout applies — and leaves ~75px for the value.
+ */
+const MAX_LABEL_SHARE = '60%';
+
 export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
   const shaDatalistComponentItemCheckbox = "sha-datalist-component-item-checkbox";
   const shaDatalistComponentDivider = "sha-datalist-component-divider";
@@ -99,6 +109,38 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
                     &.${prefixCls}-space-horizontal {
                         display: inline-flex;
                         flex-wrap: nowrap;
+                    }
+                }
+            }
+
+            /*
+             * Cards in 'wrap'/'horizontal' orientation are only as wide as the configured item width, so a
+             * proportional labelCol ({ span: 6 } by default) collapses to a fraction of the label's width and
+             * antd clips it - .ant-form-item-label is 'overflow: hidden'. Size each label to its own text
+             * instead and give the value the space to its right.
+             *
+             * 'flex-wrap: nowrap' is the important part. .ant-row is 'flex-flow: row wrap', and flex line
+             * breaking compares items' hypothetical sizes *before* shrinking, so the value drops onto its own
+             * line as soon as label + value content exceeds the card - no amount of flex-shrink prevents it.
+             * Keeping the row on one line means both shrink to fit instead, and the value stays beside its
+             * label at every card width.
+             *
+             * Scoped to '-horizontal' items so components configured for a vertical layout keep theirs.
+             */
+            &.wrap,
+            &.horizontal {
+                .${prefixCls}-form-item-horizontal > .${prefixCls}-form-item-row {
+                    flex-wrap: nowrap;
+
+                    > .${prefixCls}-form-item-label {
+                        flex: 0 1 auto;
+                        max-width: ${MAX_LABEL_SHARE};
+                    }
+
+                    > .${prefixCls}-form-item-control {
+                        flex: 1 1 auto;
+                        min-width: 0;
+                        max-width: 100%;
                     }
                 }
             }

--- a/shesha-reactjs/src/providers/dataListCrudContext/index.tsx
+++ b/shesha-reactjs/src/providers/dataListCrudContext/index.tsx
@@ -287,6 +287,7 @@ const CrudProvider = <TValue extends object = object>(props: PropsWithChildren<I
       <Form<TValue>
         key={state.mode}
         component={false}
+        labelWrap
         {... (form ? { form } : {})}
         onValuesChange={onValuesChangeInternal}
         {...props.formSettings}

--- a/shesha-reactjs/src/providers/dataListCrudContext/index.tsx
+++ b/shesha-reactjs/src/providers/dataListCrudContext/index.tsx
@@ -284,13 +284,17 @@ const CrudProvider = <TValue extends object = object>(props: PropsWithChildren<I
 
   return (
     <CrudContext.Provider value={contextValue}>
+      {/* `labelWrap` stops antd clipping labels: without it `.ant-form-item-label` keeps `overflow: hidden`,
+          so a label too long for its card is hidden rather than wrapped. Kept *after* the `formSettings`
+          spread deliberately — those settings are form configuration deserialized from the database, so a
+          stored blob carrying a `labelWrap` key would otherwise switch clipping back on. */}
       <Form<TValue>
         key={state.mode}
         component={false}
-        labelWrap
         {... (form ? { form } : {})}
         onValuesChange={onValuesChangeInternal}
         {...props.formSettings}
+        labelWrap
         initialValues={state.initialValues ? state.initialValues as Record<string, unknown> : {}}
       >
         <ParentProvider


### PR DESCRIPTION
This pull request improves the layout and usability of labels and values in horizontally oriented data list cards, ensuring that labels and their corresponding values remain side-by-side and readable at all card widths. The main changes introduce a maximum label width, adjust flexbox styling to prevent label/value wrapping issues, and enable label wrapping in forms.

**Layout and Styling Improvements:**

* Added a constant `MAX_LABEL_SHARE` (60%) to limit the maximum width a label can take within a card, ensuring enough space remains for the value beside it.
* Updated horizontal and wrap card layouts to use `flex-wrap: nowrap` and set `.form-item-label` to `max-width: ${MAX_LABEL_SHARE}`, preventing the value from dropping to a new line and keeping label/value pairs aligned.

**Form Behavior:**

* Enabled the `labelWrap` property on forms to allow long labels to wrap within their allotted space instead of being clipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data list form label layout to keep labels and corresponding values aligned in a single row.
  * Updated label wrapping behavior to avoid value clipping/overflow issues and prevent long labels from pushing inputs onto a new line.
  * Added stricter layout constraints for horizontal and wrap orientations, ensuring labels can wrap cleanly while preserving readable spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->