### PR TITLE
fix: remove global rate limiter so only login/OTP are throttled (#4771)

### DIFF
--- a/shesha-core/src/Shesha.Framework/RateLimiting/RateLimitingServiceCollectionExtensions.cs
+++ b/shesha-core/src/Shesha.Framework/RateLimiting/RateLimitingServiceCollectionExtensions.cs
@@ -15,8 +15,6 @@ namespace Shesha.RateLimiting
             configure?.Invoke(settings);
 
             var defaults = new SheshaRateLimitingOptions();
-            if (settings.GlobalPermitLimit <= 0) settings.GlobalPermitLimit = defaults.GlobalPermitLimit;
-            if (settings.GlobalWindowSeconds <= 0) settings.GlobalWindowSeconds = defaults.GlobalWindowSeconds;
             if (settings.AuthPermitLimit <= 0) settings.AuthPermitLimit = defaults.AuthPermitLimit;
             if (settings.AuthWindowSeconds <= 0) settings.AuthWindowSeconds = defaults.AuthWindowSeconds;
             if (settings.OtpPermitLimit <= 0) settings.OtpPermitLimit = defaults.OtpPermitLimit;
@@ -25,16 +23,10 @@ namespace Shesha.RateLimiting
 
             services.AddRateLimiter(options =>
             {
-                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = settings.GlobalPermitLimit,
-                            Window = TimeSpan.FromSeconds(settings.GlobalWindowSeconds),
-                            QueueLimit = 0
-                        }));
-
+                // Rate limiting is applied only to sensitive endpoints (login/OTP) via the named
+                // policies below and their [EnableRateLimiting] attributes. No global limiter is
+                // registered so that normal application traffic (e.g. configuration work, form
+                // loading) is never throttled. See issue #4771.
                 options.AddPolicy<string>(SheshaRateLimitingPolicies.Auth, context =>
                     RateLimitPartition.GetFixedWindowLimiter(
                         partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",

--- a/shesha-core/src/Shesha.Framework/RateLimiting/SheshaRateLimitingOptions.cs
+++ b/shesha-core/src/Shesha.Framework/RateLimiting/SheshaRateLimitingOptions.cs
@@ -2,9 +2,6 @@ namespace Shesha.RateLimiting
 {
     public class SheshaRateLimitingOptions
     {
-        public int GlobalPermitLimit { get; set; } = 100;
-        public int GlobalWindowSeconds { get; set; } = 60;
-
         public int AuthPermitLimit { get; set; } = 10;
         public int AuthWindowSeconds { get; set; } = 60;
 

--- a/shesha-core/src/Shesha.Web.Host/appsettings.json
+++ b/shesha-core/src/Shesha.Web.Host/appsettings.json
@@ -16,8 +16,6 @@
   },
   "DefaultLogFolder": "~/App_Data/Logs/jobss",
   "RateLimiting": {
-    "GlobalPermitLimit": 100,
-    "GlobalWindowSeconds": 60,
     "AuthPermitLimit": 10,
     "AuthWindowSeconds": 60,
     "OtpPermitLimit": 5,


### PR DESCRIPTION
The global rate limiter capped every request at 100/60s per IP, causing system-wide 429 (Too Many Requests) errors during normal application workflows such as configuring forms and editing components, as reported by yuliaGradova. Rate limiting is now scoped exclusively to the sensitive login and OTP endpoints via the named "auth"/"otp" policies and their [EnableRateLimiting] attributes. Removed the now-unused Global* options and their appsettings entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limiting now applies only to sensitive authentication and OTP endpoints.
  * General application traffic is no longer throttled by a global rate limit.
  * Authentication and OTP rejection handling, including `Retry-After` responses, remain supported.

* **Configuration**
  * Removed obsolete global rate-limit settings from the available configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->