### PR TITLE
fix reflist item action execution order

### DIFF
--- a/shesha-reactjs/src/components/refListSelectorDisplay/options/properties.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/options/properties.tsx
@@ -1,9 +1,7 @@
-import { Form } from 'antd';
-import React, { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useEffect, useMemo } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { getSettings } from './refListItemsSettingsForm';
 import { useRefListItemGroupConfigurator } from '../provider';
-import { ConfigurableFormInstance } from '@/interfaces';
 import { getComponentModel } from '../provider/utils';
 import { ConfigurableForm } from '@/components/configurableForm';
 import { useFormViaFactory } from '@/form-factory/hooks';
@@ -13,13 +11,7 @@ import { isNullOrWhiteSpace } from '@/utils/nullables';
 
 export const RefListItemProperties: FC = () => {
   const { selectedItemId, getItem, updateItem, readOnly } = useRefListItemGroupConfigurator();
-  // note: we have to memoize the editor to prevent unneeded re-rendering and loosing of the focus
-  const [editor, setEditor] = useState<ReactNode>(<></>);
-  const [form] = Form.useForm<RefListGroupItemProps>();
-
   const markup = useFormViaFactory(getSettings);
-
-  const formRef = useRef<ConfigurableFormInstance<RefListGroupItemProps> | undefined>(undefined);
 
   // The id is passed as an argument rather than captured: use-debounce invokes the latest
   // callback with the queued arguments, so a pending save would otherwise land on whichever
@@ -46,41 +38,28 @@ export const RefListItemProperties: FC = () => {
     };
   }, [debouncedSave, selectedItemId]);
 
-  useEffect(() => {
-    form.resetFields();
+  // note: we have to memoize the editor to prevent unneeded re-rendering and loosing of the focus
+  const editor = useMemo<ReactNode>(() => {
+    if (isNullOrWhiteSpace(selectedItemId)) return null;
+    const item = getItem(selectedItemId);
+    if (!item) return null;
 
-    if (formRef.current) {
-      const values = form.getFieldsValue();
+    const componentModel = getComponentModel(item);
 
-      formRef.current.setFormData({ values, mergeValues: false });
-    }
-  }, [form, selectedItemId]);
-
-  useEffect(() => {
-    const getEditor = (): ReactNode => {
-      if (!selectedItemId) return null;
-      const item = getItem(selectedItemId);
-      if (!item) return null;
-
-      const componentModel = getComponentModel(item);
-
-      return (
-        <ConfigurableForm<RefListGroupItemProps>
-          key={selectedItemId}
-          formRef={formRef}
-          labelCol={{ span: 24 }}
-          wrapperCol={{ span: 24 }}
-          mode={readOnly ? 'readonly' : 'edit'}
-          markup={markup}
-          form={form}
-          initialValues={componentModel}
-          onValuesChange={handleValuesChange}
-        />
-      );
-    };
-
-    setEditor(getEditor());
-  }, [handleValuesChange, form, getItem, markup, readOnly, selectedItemId]);
+    // note: no shared form instance - the keyed remount must start from an empty store, otherwise
+    // rc-field-form merges the previously selected item's values over these initialValues (#5125)
+    return (
+      <ConfigurableForm<RefListGroupItemProps>
+        key={selectedItemId}
+        labelCol={{ span: 24 }}
+        wrapperCol={{ span: 24 }}
+        mode={readOnly ? 'readonly' : 'edit'}
+        markup={markup}
+        initialValues={componentModel}
+        onValuesChange={handleValuesChange}
+      />
+    );
+  }, [handleValuesChange, getItem, markup, readOnly, selectedItemId]);
 
   return <>{editor}</>;
 };

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/index.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useReducer, useContext, PropsWithChildren, useEffect } from 'react';
+import React, { FC, useReducer, useContext, PropsWithChildren, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   IUpdateItemSettingsPayload,
   RefListItemGroupConfiguratorActionsContext,
@@ -58,38 +58,45 @@ const RefListSelectorDisplayProvider: FC<PropsWithChildren<IRefListItemGroupConf
     });
   }, [getReferenceList, props.items, props.referenceList]);
 
-  const selectItem = (uid: string): void => {
+  const selectItem = useCallback((uid: string): void => {
     dispatch(selectItemAction(uid));
-  };
+  }, []);
 
-  const updateItem = (payload: IUpdateItemSettingsPayload): void => {
+  const updateItem = useCallback((payload: IUpdateItemSettingsPayload): void => {
     if (!state.readOnly) dispatch(updateItemAction(payload));
-  };
+  }, [state.readOnly]);
 
-  const getItem = (uid: string): RefListGroupItemProps | undefined => {
-    return getItemById(state.items, uid);
-  };
+  // note: the items are read through a ref so that getItem keeps a stable identity - consumers
+  // memoize on it and must not recompute every time an item is updated (#5125)
+  const itemsRef = useRef(state.items);
+  useEffect(() => {
+    itemsRef.current = state.items;
+  }, [state.items]);
 
-  const updateChildItems = (payload: IUpdateChildItemsPayload): void => {
+  const getItem = useCallback((uid: string): RefListGroupItemProps | undefined => {
+    return getItemById(itemsRef.current, uid);
+  }, []);
+
+  const updateChildItems = useCallback((payload: IUpdateChildItemsPayload): void => {
     if (!state.readOnly) dispatch(updateChildItemsAction(payload));
-  };
+  }, [state.readOnly]);
 
-  const storeSettings = (columnId: string, isCollapsed: boolean): Promise<void> => {
+  const storeSettings = useCallback((columnId: string, isCollapsed: boolean): Promise<void> => {
     dispatch(storeSettingsAction({ columnId: columnId, isCollapsed: isCollapsed }));
     return Promise.resolve();
-  };
+  }, []);
+
+  const actions = useMemo<IRefListItemGroupConfiguratorActionsContext>(() => ({
+    selectItem,
+    updateItem,
+    getItem,
+    updateChildItems,
+    storeSettings,
+  }), [selectItem, updateItem, getItem, updateChildItems, storeSettings]);
 
   return (
     <RefListItemGroupConfiguratorStateContext.Provider value={state}>
-      <RefListItemGroupConfiguratorActionsContext.Provider
-        value={{
-          selectItem,
-          updateItem,
-          getItem,
-          updateChildItems,
-          storeSettings,
-        }}
-      >
+      <RefListItemGroupConfiguratorActionsContext.Provider value={actions}>
         {children}
       </RefListItemGroupConfiguratorActionsContext.Provider>
     </RefListItemGroupConfiguratorStateContext.Provider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the properties panel behavior when switching between reference list items, ensuring the correct values are shown.
  * Prevented the properties panel from appearing when no item is selected.
* **Performance**
  * Reduced unnecessary re-renders in the reference list actions/provider by stabilizing handler identities and memoizing computed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->