### PR TITLE
reorder posted notes, show disabled in designer and preview mode

### DIFF
--- a/shesha-reactjs/src/components/notesRenderer/index.tsx
+++ b/shesha-reactjs/src/components/notesRenderer/index.tsx
@@ -3,6 +3,9 @@ import { useNotesEditorActions, useNotesEditorState } from '@/providers';
 import NotesRendererBase from '@/components/notesRendererBase';
 import { useStyles } from './styles/styles';
 
+const DESIGNER_HINT = 'Notes are read-only in the form designer.';
+const UNSAVED_OWNER_HINT = 'Notes can be added only after the record has been saved.';
+
 export interface INotesRendererProps {
   allowCreate?: boolean | undefined;
   allowUpdate?: boolean | undefined;
@@ -27,7 +30,7 @@ export const NotesRenderer: FC<INotesRendererProps> = ({
   maxLength,
 }) => {
   const { deleteNoteAsync, createNoteAsync, updateNoteAsync } = useNotesEditorActions();
-  const { notes, isFetchingNotes, isPostingNotes } = useNotesEditorState();
+  const { notes, isFetchingNotes, isPostingNotes, canPostNotes, isDesignerMode } = useNotesEditorState();
   const { styles } = useStyles();
 
   return (
@@ -40,6 +43,9 @@ export const NotesRenderer: FC<INotesRendererProps> = ({
         notes={notes}
         isFetchingNotes={isFetchingNotes}
         isPostingNotes={isPostingNotes}
+
+        disabled={!canPostNotes}
+        disabledHint={isDesignerMode ? DESIGNER_HINT : UNSAVED_OWNER_HINT}
 
         allowCreate={allowCreate}
         allowEdit={allowUpdate}

--- a/shesha-reactjs/src/components/notesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/notesRendererBase/index.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useState, useEffect, CSSProperties, useRef } from 'react';
-import { Skeleton, Card, List, Empty, Input, Button, GetRef } from 'antd';
+import React, { FC, useState, useEffect, CSSProperties, useRef, useMemo } from 'react';
+import { Skeleton, Card, List, Empty, Input, Button, GetRef, Tooltip } from 'antd';
 import { CheckOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import classNames from 'classnames';
@@ -22,6 +22,15 @@ export interface INotesRendererBaseProps {
 
   isFetchingNotes?: boolean | undefined;
   isPostingNotes?: boolean | undefined;
+
+  /**
+   * Makes the editor non-interactive. Notes are still listed, but they can't be created, edited or deleted
+   */
+  disabled?: boolean | undefined;
+  /**
+   * Explanation shown to the user when the editor is disabled
+   */
+  disabledHint?: string | undefined;
 
   showSaveBtn?: boolean | undefined;
   allowCreate?: boolean | undefined;
@@ -53,6 +62,9 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
   isFetchingNotes,
   isPostingNotes,
 
+  disabled = false,
+  disabledHint,
+
   allowCreate: showCommentBox = true,
   commentListStyles,
   className,
@@ -65,6 +77,9 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
   minLength,
   maxLength,
 }) => {
+  // the backend returns notes oldest-first, and newly created ones are appended - render them newest-first
+  const orderedNotes = useMemo(() => notes ? [...notes].reverse() : EMPTY_NOTES, [notes]);
+
   const [newComment, setNewComment] = useState('');
   const [charCount, setCharCount] = useState(0);
   const [validationError, setValidationError] = useState('');
@@ -94,6 +109,8 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
   };
 
   const handleSaveNotes = async (): Promise<void> => {
+    if (disabled) return;
+
     const error = getNoteValidationError(newComment, minLength, maxLength);
     if (!isNullOrWhiteSpace(error)) {
       setValidationError(error);
@@ -114,34 +131,36 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
   return (
     <div className={classNames(styles.notes, className)} style={style}>
       {showCommentBox && (
-        <div className={styles.notesTextarea}>
-          <Input.TextArea
-            ref={textRef}
-            rows={2}
-            value={newComment}
-            onChange={({ target: { value } }) => handleTextChange(value)}
-            disabled={isPostingNotes}
-            onPressEnter={handleSaveNotes}
-            autoSize={autoSize ? { minRows: 2 } : false}
-            maxLength={maxLength}
-            showCount={false} // We'll implement our own counter
-          />
-          {showCharCount && <CharCounter count={charCount} maxLength={maxLength} error={validationError} />}
-          {showSaveBtn && (
-            <div className={classNames(styles.saveBtn, { right: buttonFloatRight })}>
-              <Button
-                size="small"
-                type="primary"
-                disabled={isNullOrWhiteSpace(newComment) || !isNullOrWhiteSpace(validationError)}
-                onClick={handleSaveNotes}
-                loading={isPostingNotes ?? false}
-                icon={<CheckOutlined />}
-              >
-                Save
-              </Button>
-            </div>
-          )}
-        </div>
+        <Tooltip title={disabled ? disabledHint : undefined}>
+          <div className={styles.notesTextarea}>
+            <Input.TextArea
+              ref={textRef}
+              rows={2}
+              value={newComment}
+              onChange={({ target: { value } }) => handleTextChange(value)}
+              disabled={disabled || (isPostingNotes ?? false)}
+              onPressEnter={handleSaveNotes}
+              autoSize={autoSize ? { minRows: 2 } : false}
+              maxLength={maxLength}
+              showCount={false} // We'll implement our own counter
+            />
+            {showCharCount && <CharCounter count={charCount} maxLength={maxLength} error={validationError} />}
+            {showSaveBtn && (
+              <div className={classNames(styles.saveBtn, { right: buttonFloatRight })}>
+                <Button
+                  size="small"
+                  type="primary"
+                  disabled={disabled || isNullOrWhiteSpace(newComment) || !isNullOrWhiteSpace(validationError)}
+                  onClick={handleSaveNotes}
+                  loading={isPostingNotes ?? false}
+                  icon={<CheckOutlined />}
+                >
+                  Save
+                </Button>
+              </div>
+            )}
+          </div>
+        </Tooltip>
       )}
 
       <Skeleton loading={isFetchingNotes ?? false} active>
@@ -151,12 +170,12 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
             className={`${styles.commentList} scroll scroll-y`}
             style={{ ...commentListStyles }}
             itemLayout="horizontal"
-            dataSource={notes ?? EMPTY_NOTES}
+            dataSource={orderedNotes}
             renderItem={(note) => (
               <NoteRenderer
                 note={note}
-                allowEdit={allowEdit}
-                allowDelete={allowDelete ?? false}
+                allowEdit={allowEdit && !disabled}
+                allowDelete={(allowDelete ?? false) && !disabled}
                 updateNoteAsync={updateNoteAsync}
                 deleteNoteAsync={deleteNoteAsync}
                 minLength={minLength}

--- a/shesha-reactjs/src/providers/notes/contexts.ts
+++ b/shesha-reactjs/src/providers/notes/contexts.ts
@@ -26,6 +26,11 @@ export type INotesEditorState = {
   readonly notes: NoteModel[];
   readonly isFetchingNotes: boolean;
   readonly isPostingNotes: boolean;
+  /**
+   * Indicates whether notes can be created, updated or deleted. Is false in designer mode and when the owner reference is incomplete (e.g. the owner entity is not saved yet)
+   */
+  readonly canPostNotes: boolean;
+  readonly isDesignerMode: boolean;
 };
 
 export type INotesEditorInstance = INotesEditorActions & INotesEditorState;

--- a/shesha-reactjs/src/providers/notes/index.tsx
+++ b/shesha-reactjs/src/providers/notes/index.tsx
@@ -69,6 +69,8 @@ const useNotesEditorState = (): INotesEditorState => {
     notes: instance.notes,
     isFetchingNotes: instance.isFetchingNotes,
     isPostingNotes: instance.isPostingNotes,
+    canPostNotes: instance.canPostNotes,
+    isDesignerMode: instance.isDesignerMode,
   };
 };
 

--- a/shesha-reactjs/src/providers/notes/instance.ts
+++ b/shesha-reactjs/src/providers/notes/instance.ts
@@ -35,6 +35,8 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
 
   #fetchNotesRequestId = 0;
 
+  #canPostNotes = false;
+
   constructor(args: NotesEditorInstanceArgs) {
     this.#httpClient = args.httpClient;
     this.#isDesignerMode = args.isDesignerMode ?? false;
@@ -42,9 +44,13 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
 
   setDesignerMode = (isDesignerMode: boolean): void => {
     const wasDesignerMode = this.#isDesignerMode;
-    this.#isDesignerMode = isDesignerMode;
+    if (wasDesignerMode === isDesignerMode) return;
 
-    if (wasDesignerMode && !isDesignerMode && isDefined(this.#notesReference) && isOwnerReferenceValid(this.#notesReference))
+    this.#isDesignerMode = isDesignerMode;
+    this.updateCanPostNotes();
+    this.notifySubscribers();
+
+    if (wasDesignerMode && isDefined(this.#notesReference) && isOwnerReferenceValid(this.#notesReference))
       this.fetchNotesAsync()
         .catch((error) => {
           console.error('Failed to fetch notes', error);
@@ -56,6 +62,8 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
       return;
 
     this.#notesReference = notesReference;
+    this.updateCanPostNotes();
+    this.notifySubscribers();
     // Skip API calls in designer/config mode to prevent errors from incomplete data
     if (!this.#isDesignerMode && isOwnerReferenceValid(this.#notesReference))
       this.fetchNotesAsync()
@@ -101,7 +109,13 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
     return this.#notesReference;
   }
 
+  private updateCanPostNotes = (): void => {
+    this.#canPostNotes = !this.#isDesignerMode && isDefined(this.#notesReference) && isOwnerReferenceValid(this.#notesReference);
+  };
+
   createNoteAsync = async (args: CreateNoteArgs): Promise<void> => {
+    if (!this.#canPostNotes) return;
+
     const reference = this.getValidNoteReference();
     const payload: CreateNoteDto = {
       ownerId: reference.ownerId,
@@ -126,6 +140,8 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
   };
 
   updateNoteAsync = async (args: UpdateNoteArgs): Promise<void> => {
+    if (!this.#canPostNotes) return;
+
     const note = this.#notes.find((n) => n.id === args.id);
     if (!note)
       throw new Error('Note not found.');
@@ -146,6 +162,8 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
   };
 
   deleteNoteAsync = async (args: DeleteNoteArgs): Promise<void> => {
+    if (!this.#canPostNotes) return;
+
     const deletedNote = this.#notes.find((n) => n.id === args.id);
     const url = buildUrl(NOTES_URLS.NOTE_DELETE, { id: args.id });
     await this.runPostingNotes(async () => {
@@ -221,5 +239,13 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
 
   get isPostingNotes(): boolean {
     return this.#isPostingNotes;
+  }
+
+  get canPostNotes(): boolean {
+    return this.#canPostNotes;
+  }
+
+  get isDesignerMode(): boolean {
+    return this.#isDesignerMode;
   }
 }

--- a/shesha-reactjs/src/providers/notes/instance.ts
+++ b/shesha-reactjs/src/providers/notes/instance.ts
@@ -62,6 +62,11 @@ export class NotesEditorInstance implements INotesEditorActions, INotesEditorSta
       return;
 
     this.#notesReference = notesReference;
+    // drop the previous owner's notes and invalidate any fetch still in flight for it, otherwise
+    // they stay visible under the new owner when the new reference doesn't trigger a fetch
+    this.#fetchNotesRequestId += 1;
+    this.#notes = [];
+    this.#isFetchingNotes = false;
     this.updateCanPostNotes();
     this.notifySubscribers();
     // Skip API calls in designer/config mode to prevent errors from incomplete data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes can now be disabled when posting isn’t available, with a tooltip explaining the reason (including designer mode).
  * In disabled state, users can’t add, edit, or delete notes, and the editor/save actions are blocked.
  * Notes are displayed newest first.
  * Notes automatically become available when leaving designer mode and a valid owner reference is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->