### PR TITLE
Fix OTP per-user cooldown not being applied (#4773)

### DIFF
--- a/shesha-core/src/Shesha.Application/Otp/OtpManager.cs
+++ b/shesha-core/src/Shesha.Application/Otp/OtpManager.cs
@@ -120,6 +120,9 @@ namespace Shesha.Otp
             };
 
             // send otp
+            // record the send-attempt time regardless of the outcome so that the per-user OTP
+            // cooldown works even when IgnoreOtpValidation is on (dev/QA) or the gateway fails.
+            otp.SentOn = DateTime.Now;
             if (settings.IgnoreOtpValidation)
             {
                 otp.SendStatus = OtpSendStatus.Ignored;
@@ -128,8 +131,6 @@ namespace Shesha.Otp
             {
                 try
                 {
-                    otp.SentOn = DateTime.Now;
-
                     await SendInternalAsync(otp);
 
                     otp.SendStatus = OtpSendStatus.Sent;


### PR DESCRIPTION
## Issue
#4773 — QA feedback: the 60s per-user OTP cooldown was not applied; only the 5/min IP rate limit fired (tested with `yulianew` via Postman).

## Root cause
`EnforceOtpCooldownAsync` (password reset, `UserAppService`) and `EnforceLoginOtpCooldownAsync` (OTP login, `ShaLoginManager`) both gate the cooldown on `Otp.SentOn`. But `OtpManager.SendPinAsync` set `SentOn` **only** in the real-send branch. When `IgnoreOtpValidation` is on — the usual dev/QA setup with no live SMS gateway — the OTP is marked `Ignored` and `SentOn` stays `null`, so the cooldown check bails at `if (existingOtp?.SentOn == null) return;` and only the per-IP rate limit remains.

## Fix
Set `otp.SentOn = DateTime.Now` at the start of the send attempt, regardless of outcome (ignored / sent / failed). The send-attempt timestamp is now always recorded, so the 60s per-user cooldown works in every environment. Single change covers **both** cooldown call sites.

## Testing
- Set `Shesha.Otp.IgnoreOtpValidation = true`.
- Call `SendSmsOtp` (or `ResetPasswordSendOtp` / OTP login) twice within 60s for the same user → 2nd call now returns "An OTP was recently sent. Please wait N seconds..." instead of dispatching another OTP.
- After the cooldown window elapses, a new send succeeds.

Note: build not run locally (branch targets .NET 10; local SDK is 8.0.125). Change is a pure statement hoist — no new symbols or type changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTP send attempts now consistently record their timestamp, including when validation is bypassed or delivery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->