### PR TITLE
enable note editor with tooltip in the designer

### DIFF
--- a/shesha-reactjs/src/components/notesRenderer/index.tsx
+++ b/shesha-reactjs/src/components/notesRenderer/index.tsx
@@ -3,7 +3,7 @@ import { useNotesEditorActions, useNotesEditorState } from '@/providers';
 import NotesRendererBase from '@/components/notesRendererBase';
 import { useStyles } from './styles/styles';
 
-const DESIGNER_HINT = 'Notes are read-only in the form designer.';
+const DESIGNER_HINT = 'Notes cannot be posted from the form designer.';
 const UNSAVED_OWNER_HINT = 'Notes can be added only after the record has been saved.';
 
 export interface INotesRendererProps {
@@ -45,6 +45,8 @@ export const NotesRenderer: FC<INotesRendererProps> = ({
         isPostingNotes={isPostingNotes}
 
         disabled={!canPostNotes}
+        // the text area stays usable in the designer so the component can be laid out and tested, only posting is blocked
+        inputDisabled={!canPostNotes && !isDesignerMode}
         disabledHint={isDesignerMode ? DESIGNER_HINT : UNSAVED_OWNER_HINT}
 
         allowCreate={allowCreate}

--- a/shesha-reactjs/src/components/notesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/notesRendererBase/index.tsx
@@ -28,6 +28,11 @@ export interface INotesRendererBaseProps {
    */
   disabled?: boolean | undefined;
   /**
+   * Makes the text area non-interactive. Defaults to `disabled`, set it to `false` to let the user type a note
+   * that can't be posted yet
+   */
+  inputDisabled?: boolean | undefined;
+  /**
    * Explanation shown to the user when the editor is disabled
    */
   disabledHint?: string | undefined;
@@ -63,6 +68,7 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
   isPostingNotes,
 
   disabled = false,
+  inputDisabled = disabled,
   disabledHint,
 
   allowCreate: showCommentBox = true,
@@ -138,7 +144,7 @@ export const NotesRendererBase: FC<INotesRendererBaseProps> = ({
               rows={2}
               value={newComment}
               onChange={({ target: { value } }) => handleTextChange(value)}
-              disabled={disabled || (isPostingNotes ?? false)}
+              disabled={inputDisabled || (isPostingNotes ?? false)}
               onPressEnter={handleSaveNotes}
               autoSize={autoSize ? { minRows: 2 } : false}
               maxLength={maxLength}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notes behavior in designer mode: text entry remains available while posting is disabled.
  - Preserved input disabling for other unavailable states and during note submission.
  - Updated the designer-mode guidance text.

- **Enhancements**
  - Added independent control over text-area interactivity without affecting note editing, deletion, or saving actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->