### PR TITLE
Add guard against empty URL parameters in calendar data fetching

### DIFF
--- a/shesha-reactjs/src/components/calendar/hooks.ts
+++ b/shesha-reactjs/src/components/calendar/hooks.ts
@@ -11,7 +11,7 @@ import { IEntityTypeIdentifier } from '@/providers/sheshaApplication/publicApi/e
 import { isDefined } from '@/utils/nullables';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { View } from 'react-big-calendar';
-import { evaluateFilters, getCalendarDataUrl, getLayerEventsData, isLayerFetchable } from './utils';
+import { evaluateFilters, getCalendarDataUrl, getLayerEventsData, hasEmptyUrlParameters, isLayerFetchable } from './utils';
 import { ILayerWithMetadata } from './interfaces';
 
 interface IGetData {
@@ -83,6 +83,12 @@ export const useCalendarLayers = (layers: ICalendarLayersProps[] | undefined): I
 
           const filter = await evaluateFilters(item, formData, globalState, item.metadata);
           const evalCustomUrl = evaluateString(item.customUrl, { data: formData, globalState });
+
+          // Guard: skip the API call if the custom URL still has empty parameters.
+          // On first render formData may not be populated yet, which would produce a
+          // URL like ?id= and trigger a backend validation error.
+          if (item.dataSource === 'custom' && hasEmptyUrlParameters(evalCustomUrl))
+            return null;
 
           const url = getCalendarDataUrl({ ...item, customUrl: evalCustomUrl, overfetch: item.overfetch }, filter);
           const response = await httpClient.get<IAjaxResponse<LayerDataResponse>>(url);

--- a/shesha-reactjs/src/components/calendar/utils.ts
+++ b/shesha-reactjs/src/components/calendar/utils.ts
@@ -104,20 +104,23 @@ export const isLayerFetchable = (layer: ICalendarLayersProps): boolean =>
     ? !isNullOrWhiteSpace(layer.customUrl)
     : !isEntityTypeIdEmpty(layer.entityType);
 
-// Checks whether a custom URL still contains unresolved or empty parameters.
+// Checks whether an evaluated custom URL still contains unresolved or empty parameters.
 // This happens on calendar initialisation when form data is not yet available,
-// causing mustache templates like {{data.taskId}} to evaluate to an empty string.
+// causing mustache templates like {{data.taskId}} to evaluate to an empty/whitespace
+// string, or, when a tag can't be resolved at all, to survive as literal {{...}} text.
 // Firing the request with empty parameters (e.g. ?id=) causes a backend validation error.
 export const hasEmptyUrlParameters = (url: string): boolean => {
-  if (!url) return true;
+  if (isNullOrWhiteSpace(url)) return true;
+  if (/{{.*?}}/.test(url)) return true;
+
   try {
     const urlObj = new URL(url, 'http://placeholder');
     for (const [, value] of urlObj.searchParams.entries()) {
-      if (!value || value === 'null' || value === 'undefined') return true;
+      if (isNullOrWhiteSpace(value)) return true;
     }
   } catch {
     // Fallback for URLs that cannot be parsed — check for empty query values with regex
-    if (/[?&][^=]+=(?:null|undefined|)(&|$)/.test(url)) return true;
+    if (/[?&][^=]+=(?:&|$)/.test(url)) return true;
   }
   return false;
 };

--- a/shesha-reactjs/src/components/calendar/utils.ts
+++ b/shesha-reactjs/src/components/calendar/utils.ts
@@ -111,12 +111,17 @@ export const isLayerFetchable = (layer: ICalendarLayersProps): boolean =>
 // Firing the request with empty parameters (e.g. ?id=) causes a backend validation error.
 export const hasEmptyUrlParameters = (url: string): boolean => {
   if (isNullOrWhiteSpace(url)) return true;
-  if (/{{.*?}}/.test(url)) return true;
+
+  const hasUnresolvedTag = (value: string): boolean => /{{.*?}}/.test(value);
+
+  if (hasUnresolvedTag(url)) return true;
 
   try {
     const urlObj = new URL(url, 'http://placeholder');
     for (const [, value] of urlObj.searchParams.entries()) {
-      if (isNullOrWhiteSpace(value)) return true;
+      // URLSearchParams decodes percent-encoded values (e.g. %7B%7B...%7D%7D),
+      // so an unresolved tag can only surface here after decoding.
+      if (isNullOrWhiteSpace(value) || hasUnresolvedTag(value)) return true;
     }
   } catch {
     // Fallback for URLs that cannot be parsed — check for empty query values with regex

--- a/shesha-reactjs/src/components/calendar/utils.ts
+++ b/shesha-reactjs/src/components/calendar/utils.ts
@@ -104,6 +104,24 @@ export const isLayerFetchable = (layer: ICalendarLayersProps): boolean =>
     ? !isNullOrWhiteSpace(layer.customUrl)
     : !isEntityTypeIdEmpty(layer.entityType);
 
+// Checks whether a custom URL still contains unresolved or empty parameters.
+// This happens on calendar initialisation when form data is not yet available,
+// causing mustache templates like {{data.taskId}} to evaluate to an empty string.
+// Firing the request with empty parameters (e.g. ?id=) causes a backend validation error.
+export const hasEmptyUrlParameters = (url: string): boolean => {
+  if (!url) return true;
+  try {
+    const urlObj = new URL(url, 'http://placeholder');
+    for (const [, value] of urlObj.searchParams.entries()) {
+      if (!value || value === 'null' || value === 'undefined') return true;
+    }
+  } catch {
+    // Fallback for URLs that cannot be parsed — check for empty query values with regex
+    if (/[?&][^=]+=(?:null|undefined|)(&|$)/.test(url)) return true;
+  }
+  return false;
+};
+
 export const getCalendarDataUrl = (param: ICalendarLayersProps, filter: string): string => {
   const { customUrl, dataSource, entityType, overfetch } = param;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented calendar custom-layer requests when URLs contain missing or incomplete query parameters.
  * Improved handling of invalid, empty, or unparsable layer URLs to avoid failed or unnecessary requests.
  * Existing calendar layers continue to load and display through the normal process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->