### PR TITLE
fix: keep properties panel populated after exiting preview mode (#4223)

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
+++ b/shesha-reactjs/src/components/formDesigner/designerMainArea/index.tsx
@@ -1,6 +1,6 @@
 import ConditionalWrap from '@/components/conditionalWrapper';
 import { ConditionalMetadataProvider, useShaFormInstance } from '@/providers';
-import { useFormDesigner, useFormDesignerFormMode, useFormDesignerReadOnly, useFormDesignerSettings } from '@/providers/formDesigner';
+import { useFormDesigner, useFormDesignerFormMode, useFormDesignerReadOnly, useFormDesignerSettings, useFormDesignerSettingsPanelElement } from '@/providers/formDesigner';
 import React, { FC, useMemo, useEffect, useCallback } from 'react';
 import { ComponentPropertiesPanel } from '../componentPropertiesPanel';
 import { ComponentPropertiesTitle } from '../componentPropertiesTitle';
@@ -22,7 +22,8 @@ export const DesignerMainArea: FC<{ viewType?: IViewType }> = ({ viewType = 'con
   const formMode = useFormDesignerFormMode();
   const { antdForm } = useShaFormInstance();
   const { styles } = useStyles();
-  const { deleteSelectedComponent, settingsPanelElement } = useFormDesigner();
+  const { deleteSelectedComponent } = useFormDesigner();
+  const settingsPanelElement = useFormDesignerSettingsPanelElement();
 
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
     if (readOnly || formMode !== 'designer' || event.repeat) return;

--- a/shesha-reactjs/src/components/formDesigner/formComponent/designerFormComponent.tsx
+++ b/shesha-reactjs/src/components/formDesigner/formComponent/designerFormComponent.tsx
@@ -11,7 +11,7 @@ import { Tooltip } from "antd";
 import { EyeInvisibleOutlined, FunctionOutlined } from "@ant-design/icons";
 import DragWrapper from "../configurableFormComponent/dragWrapper";
 import ValidationIcon from "../configurableFormComponent/validationIcon";
-import { useFormDesigner, useFormDesignerSelectedComponentId } from "@/providers/formDesigner";
+import { useFormDesigner, useFormDesignerSelectedComponentId, useFormDesignerSettingsPanelElement } from "@/providers/formDesigner";
 import KnownFormComponent from "./knownFormComponent";
 import FormComponentErrorWrapper from "./formComponentErrorWrapper";
 import { FormComponentModelPreparer } from "./formComponentModelPreparer";
@@ -38,7 +38,8 @@ const DesignerFormComponentInner: FC<IDesignerFormComponentProps> = ({
 }) => {
   const { styles } = useStyles();
   const { styles: shaComponentStyles } = useShaComponentStyles({ componentModel, toolboxComponent });
-  const { settingsPanelElement, readOnly } = useFormDesigner();
+  const { readOnly } = useFormDesigner();
+  const settingsPanelElement = useFormDesignerSettingsPanelElement();
   const getToolboxComponent = useFormDesignerComponentGetter();
   // Memoize component lookup to prevent unnecessary re-renders
   const component = useMemo(() => getToolboxComponent(componentModel.type), [getToolboxComponent, componentModel.type]);

--- a/shesha-reactjs/src/providers/formDesigner/contexts.tsx
+++ b/shesha-reactjs/src/providers/formDesigner/contexts.tsx
@@ -124,7 +124,8 @@ export type FormDesignerActions = {
 
   getCachedComponentEditor: <TModel extends IConfigurableFormComponent = IConfigurableFormComponent>(type: string, evaluator: () => ISettingsFormFactory<TModel> | undefined) => (IComponentSettingsFormFactory<TModel> | undefined);
 
-  subscribe: (type: FormDesignerSubscriptionType, callback: FormDesignerSubscription) => void;
+  /** Returns a function that cancels the subscription */
+  subscribe: (type: FormDesignerSubscriptionType, callback: FormDesignerSubscription) => () => void;
   loadAsync: () => Promise<void>;
   saveAsync: () => Promise<void>;
 

--- a/shesha-reactjs/src/providers/formDesigner/index.tsx
+++ b/shesha-reactjs/src/providers/formDesigner/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useContext, useEffect, useState } from 'react';
+import React, { FC, PropsWithChildren, useCallback, useContext, useEffect, useState, useSyncExternalStore } from 'react';
 import { useFormDesignerComponentGroups } from '../form/hooks';
 import { FormMode, IConfigurableFormComponent, IFlatComponentsStructure, IFormSettings, isConfigurableFormComponent } from '../form/models';
 import {
@@ -112,6 +112,26 @@ export const useFormDesignerSubscription = (subscriptionType: FormDesignerSubscr
   return dummy;
 };
 
+const getSettingsPanelServerSnapshot = (): null => null;
+
+/**
+ * Element of the properties panel to render the settings of the selected component into.
+ * Note: the element is assigned by a ref callback during the commit phase, i.e. after the components are rendered.
+ * `useSyncExternalStore` re-reads it right after subscribing, a plain subscription would miss that assignment
+ * on mount and the components would keep rendering with the stale `null` (#4223)
+ */
+const useFormDesignerSettingsPanelElement = (): HTMLDivElement | null => {
+  const formDesigner = useFormDesigner();
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => formDesigner.subscribe('selection', onStoreChange),
+    [formDesigner],
+  );
+  const getSnapshot = useCallback(() => formDesigner.settingsPanelElement, [formDesigner]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSettingsPanelServerSnapshot);
+};
+
 const useFormDesignerMarkup = (): IFlatComponentsStructure => {
   useFormDesignerSubscription('markup');
   return useFormDesigner().state.formFlatMarkup;
@@ -179,6 +199,7 @@ export {
   useFormDesignerSettings,
   useFormDesignerSelectedComponentId,
   useFormDesignerSelectedComponent,
+  useFormDesignerSettingsPanelElement,
   useFormDesignerReadOnly,
   useFormDesignerIsDebug,
   useFormDesignerFormMode,

--- a/shesha-reactjs/src/providers/formDesigner/models.ts
+++ b/shesha-reactjs/src/providers/formDesigner/models.ts
@@ -125,7 +125,8 @@ export type FormDesignerActions = {
 
   getCachedComponentEditor: (type: string, evaluator: () => ISettingsFormFactory) => ISettingsFormFactory | undefined;
 
-  subscribe: (type: FormDesignerSubscriptionType, callback: FormDesignerSubscription) => void;
+  /** Returns a function that cancels the subscription */
+  subscribe: (type: FormDesignerSubscriptionType, callback: FormDesignerSubscription) => () => void;
 
   setSettingsPanelElement: (element: HTMLDivElement | null) => void;
 };


### PR DESCRIPTION
#4223 

Toggling preview mode remounts both the properties panel and the designer components: DesignerMainArea only wraps the canvas in SidebarContainer while `formMode === 'designer'`, so the element type at that position changes.

On the way out the components render first and read `settingsPanelElement` while it is still null, then the panel's ref callback assigns it and notifies subscribers - but the components subscribe in a passive effect, which runs after the commit, so they miss that notification. They kept the stale null, rendered no settings editor, and the panel stayed empty until the component was re-selected or the page reloaded.

Read the element through `useFormDesignerSettingsPanelElement`, backed by `useSyncExternalStore`. It re-reads the snapshot immediately after subscribing and re-renders when it has changed, so the components pick the element up regardless of the order in which they and the panel are committed.

The same staleness applied to the delete-key guard in DesignerMainArea, which now uses the hook as well. `subscribe` is typed as returning its unsubscribe function, which `useFormDesignerSubscription` already relied on at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved tracking of the form designer’s settings panel, including support for server-rendered environments.
  * Added the ability to cancel form designer event subscriptions.

* **Bug Fixes**
  * Improved settings panel state handling across the form designer interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->