### PR TITLE
refactor: enhance additionalProperties handling in EntityReference component

### DIFF
--- a/shesha-reactjs/src/components/entityReference/index.tsx
+++ b/shesha-reactjs/src/components/entityReference/index.tsx
@@ -275,8 +275,10 @@ export const EntityReference: FC<IEntityReferenceProps> = (props) => {
         buttons: props.buttons,
         footerButtons: props.footerButtons,
         additionalProperties:
-          isNonEmptyArray(props.additionalProperties) && props.additionalProperties.some((p) => p.key === 'id')
-            ? props.additionalProperties
+          isNonEmptyArray(props.additionalProperties)
+            ? props.additionalProperties.some((p) => p.key === 'id')
+              ? props.additionalProperties
+              : [{ key: 'id', value: '{{entityReference.id}}' }, ...props.additionalProperties]
             : [{ key: 'id', value: '{{entityReference.id}}' }],
         modalWidth: addPx(props.modalWidth, executionContext),
         skipFetchData: props.skipFetchData ?? false,


### PR DESCRIPTION
This pull request updates the logic for handling the `additionalProperties` prop in the `EntityReference` component. The main improvement ensures that an `'id'` property is always included in the `additionalProperties` array, even if it wasn't provided.

Enhancements to `additionalProperties` handling:

* Updated the logic to automatically prepend an `'id'` property to `additionalProperties` if it's missing, ensuring consistent inclusion of the entity ID in the modal. (`shesha-reactjs/src/components/entityReference/index.tsx`)

related to issue: #5086