### PR TITLE
fix QueryBuilderContent to use JsonLogicTree type and improve value tracking

### DIFF
--- a/shesha-reactjs/src/components/queryBuilder/interfaces.ts
+++ b/shesha-reactjs/src/components/queryBuilder/interfaces.ts
@@ -1,6 +1,7 @@
 import { ITableColumn } from '@/interfaces';
 import {
   JsonLogicResult,
+  JsonLogicTree,
   FieldSettings,
   Widgets,
 } from '@react-awesome-query-builder/antd';
@@ -25,7 +26,14 @@ export interface IQueryBuilderColumn extends ITableColumn {
 }
 
 export interface IQueryBuilderProps {
-  value?: JsonLogicResult | undefined;
+  /**
+   * The JsonLogic expression tree to display.
+   *
+   * Note the deliberate asymmetry with `onChange`: this is the bare tree (the same shape as
+   * `JsonLogicResult.logic`), whereas `onChange` emits the full result including `data` and `errors`.
+   * Consumers are expected to unwrap `.logic` before feeding a value back in.
+   */
+  value?: JsonLogicTree | undefined;
   onChange?: (result: JsonLogicResult) => void;
   columns?: IQueryBuilderColumn[];
   showActionBtnOnHover?: boolean;

--- a/shesha-reactjs/src/components/queryBuilder/queryBuilderContent.tsx
+++ b/shesha-reactjs/src/components/queryBuilder/queryBuilderContent.tsx
@@ -12,6 +12,7 @@ import {
   Config,
   BuilderProps,
   Utils,
+  JsonLogicTree,
 } from '@react-awesome-query-builder/antd';
 
 interface IQueryBuilderContentProps extends IQueryBuilderProps {
@@ -34,7 +35,9 @@ export const QueryBuilderContent: FC<IQueryBuilderContentProps> = ({
   qbConfig,
 }) => {
   const { styles } = useStyles();
-  const lastLocallyChangedValue = useRef(value);
+  // `value` is the JsonLogic tree, while `onChange` emits a full JsonLogicResult.
+  // Track the tree (not the result) so a locally-originated change isn't mistaken for an external one.
+  const lastLocallyChangedValue = useRef<JsonLogicTree | object | undefined>(value);
   const changedOutside = value !== lastLocallyChangedValue.current;
   const prevValue = usePrevious(value);
   const prevTree = useRef<ImmutableTree | undefined>(undefined);
@@ -72,7 +75,7 @@ export const QueryBuilderContent: FC<IQueryBuilderContentProps> = ({
     if (onChange) {
       const jsonLogicResult = QbUtils.jsonLogicFormat(_tree, _config);
 
-      lastLocallyChangedValue.current = jsonLogicResult;
+      lastLocallyChangedValue.current = jsonLogicResult.logic;
       onChange(jsonLogicResult);
     }
   };

--- a/shesha-reactjs/src/components/queryBuilder/queryBuilderContent.tsx
+++ b/shesha-reactjs/src/components/queryBuilder/queryBuilderContent.tsx
@@ -19,7 +19,7 @@ interface IQueryBuilderContentProps extends IQueryBuilderProps {
   qbConfig: Config;
 }
 
-const loadJsonLogic = (jlValue: object, config: Config): ImmutableTree | undefined => {
+const loadJsonLogic = (jlValue: JsonLogicTree, config: Config): ImmutableTree | undefined => {
   try {
     return QbUtils.loadFromJsonLogic(jlValue, config);
   } catch (error) {
@@ -37,7 +37,7 @@ export const QueryBuilderContent: FC<IQueryBuilderContentProps> = ({
   const { styles } = useStyles();
   // `value` is the JsonLogic tree, while `onChange` emits a full JsonLogicResult.
   // Track the tree (not the result) so a locally-originated change isn't mistaken for an external one.
-  const lastLocallyChangedValue = useRef<JsonLogicTree | object | undefined>(value);
+  const lastLocallyChangedValue = useRef(value);
   const changedOutside = value !== lastLocallyChangedValue.current;
   const prevValue = usePrevious(value);
   const prevTree = useRef<ImmutableTree | undefined>(undefined);


### PR DESCRIPTION
This pull request makes improvements to the `QueryBuilderContent` component to ensure more accurate tracking of local versus external changes by distinguishing between the JsonLogic tree and the full JsonLogic result. The changes help prevent locally-originated changes from being mistaken for external ones, improving the component's reliability.

**Improvements to change tracking and type safety:**

* Updated the import statement to include `JsonLogicTree` from `@react-awesome-query-builder/antd` to improve type safety and clarity.
* Modified the `lastLocallyChangedValue` ref to explicitly track the JsonLogic tree (rather than the full JsonLogic result), ensuring that only the tree structure is used to determine if a change is local or external.
* Adjusted the assignment to `lastLocallyChangedValue.current` in the `handleChange` function to store only the `logic` property of the JsonLogic result, further clarifying the distinction between the tree and the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query builder change tracking to consistently return the query logic value.
  * Clarified the distinction between the configured value and change notifications for more predictable behavior.
  * Updated query builder value handling to accept query logic directly, while change events continue to provide the complete result.
  * Improved consistency when loading and editing existing query configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

related to #5080