### PR TITLE
Fix reflist inheritance issue

### DIFF
--- a/shesha-reactjs/src/designer-components/checkboxGroup/checkboxGroup.tsx
+++ b/shesha-reactjs/src/designer-components/checkboxGroup/checkboxGroup.tsx
@@ -88,7 +88,7 @@ const CheckboxGroupComponent: IToolboxComponent<IEnhancedICheckboxGroupProps, IC
     // options' labels rather than their raw values.
     const { data: refList } = useReferenceList(model.referenceListId);
     const options = useMemo(
-      () => getDataSourceList(model.dataSourceType, model.items ?? [], refList?.items),
+      () => getDataSourceList(model.dataSourceType ?? 'values', model.items ?? [], refList?.items),
       [model.dataSourceType, model.items, refList?.items],
     );
 
@@ -133,29 +133,33 @@ const CheckboxGroupComponent: IToolboxComponent<IEnhancedICheckboxGroupProps, IC
   settingsFormMarkup: getSettings,
   validateSettings: (model) => validateConfigurableComponentSettings(getSettings, model),
   validateModel: (model, addModelError) => {
-    if (model.dataSourceType === 'referenceList' && !isDefined(model.referenceListId))
+    const dataSourceType = model.dataSourceType ?? 'values';
+    if (dataSourceType === 'referenceList' && !isDefined(model.referenceListId))
       addModelError('referenceListId', 'Select `Reference List` on the settings panel');
-    if (model.dataSourceType === 'values' && (model.items ?? []).length === 0)
+    if (dataSourceType === 'values' && (model.items ?? []).length === 0)
       addModelError('items', 'Add `Items` on the settings panel, or select a different `Data Source Type`');
-    if (model.dataSourceType === 'url' && isNullOrWhiteSpace(model.dataSourceUrl))
+    if (dataSourceType === 'url' && isNullOrWhiteSpace(model.dataSourceUrl))
       addModelError('dataSourceUrl', 'Enter a `Data Source URL` on the settings panel');
   },
   getDefaultStyles: () => defaultStyles(),
   initModel: (model) => {
     const customProps: IEnhancedICheckboxGroupProps = {
       ...model,
-      dataSourceType: 'values',
       direction: 'horizontal',
     };
     return customProps;
   },
   migrator: (m) =>
     m
-      .add<IEnhancedICheckboxGroupProps>(0, (prev) => ({
-        ...prev,
-        dataSourceType: getStringEnumOrDefault<DataSourceType>(prev, "dataSourceType", DATA_SOURCE_TYPES) ?? "values",
-        direction: getStringEnumOrDefault<DirectionType>(prev, "direction", DIRECTION_TYPE) ?? "horizontal",
-      }))
+      .add<IEnhancedICheckboxGroupProps>(0, (prev, context) => {
+        const configured = getStringEnumOrDefault<DataSourceType>(prev, "dataSourceType", DATA_SOURCE_TYPES);
+
+        return {
+          ...prev,
+          dataSourceType: configured ?? (context.isNew === true ? undefined : "values"),
+          direction: getStringEnumOrDefault<DirectionType>(prev, "direction", DIRECTION_TYPE) ?? "horizontal",
+        };
+      })
       .add<IEnhancedICheckboxGroupProps>(1, (prev) => {
         return {
           ...prev,

--- a/shesha-reactjs/src/designer-components/checkboxGroup/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/checkboxGroup/interfaces.ts
@@ -25,7 +25,7 @@ export type CheckboxGroupCommonProps = IInputStyles & INestedStyleValue<'checkbo
    */
   referenceListName?: string | undefined;
   referenceListId?: IReferenceListIdentifier | undefined;
-  dataSourceType: DataSourceType;
+  dataSourceType?: DataSourceType | undefined;
   /** Endpoint backing the `url` data source. */
   dataSourceUrl?: string | undefined;
   /** Script mapping the `url` response to `{ label, value }` pairs. */

--- a/shesha-reactjs/src/designer-components/checkboxGroup/multiCheckbox.tsx
+++ b/shesha-reactjs/src/designer-components/checkboxGroup/multiCheckbox.tsx
@@ -32,7 +32,7 @@ const MultiCheckbox: FC<ICheckboxGroupProps> = (model) => {
   const urlData = useUrlDataSource(model);
 
   const options = useMemo<CheckboxOptionType[]>(() => {
-    const list = getDataSourceList(model.dataSourceType, items, refList?.items, urlData);
+    const list = getDataSourceList(model.dataSourceType ?? 'values', items, refList?.items, urlData);
     return list.map<CheckboxOptionType>((item) => (item.id ? item : { ...item, id: nanoid(), key: nanoid() }));
   }, [model.dataSourceType, items, refList?.items, urlData]);
 

--- a/shesha-reactjs/src/designer-components/checkboxGroup/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/checkboxGroup/settingsForm.ts
@@ -42,7 +42,8 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                       labelTitle: 'Label', labelName: 'label', valueTitle: 'Value', valueName: 'value',
                       mode: 'dialog', jsSetting: true,
                     }],
-                    visibleJs: 'return getSettingValue(data?.dataSourceType) === "values";',
+                    // An unset data source renders as `values`, so the Items editor stays visible for it.
+                    visibleJs: 'return (getSettingValue(data?.dataSourceType) ?? "values") === "values";',
                   })
                   .addSettingsInputRow({
                     inputs: [{ type: 'referenceListAutocomplete', propertyName: 'referenceListId', label: 'Reference List', jsSetting: true }],

--- a/shesha-reactjs/src/designer-components/radio/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/radio/interfaces.ts
@@ -8,7 +8,7 @@ import { IInputStyles, INestedStyleValue } from '@/providers/form/models';
 export interface IRadioOptionsSource {
   items?: ILabelValue[] | undefined;
   referenceListId?: IReferenceListIdentifier | undefined;
-  dataSourceType: DataSourceType;
+  dataSourceType?: DataSourceType | undefined;
   /** Endpoint backing the `url` data source. */
   dataSourceUrl?: string | undefined;
   /** Script mapping the `url` response to `{ label, value }` pairs. */

--- a/shesha-reactjs/src/designer-components/radio/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/radio/interfaces.ts
@@ -4,6 +4,10 @@ import { CSSProperties } from 'react';
 import { DataSourceType, ILabelValue } from '@/designer-components/dropdown/model';
 import { ComponentDefinition, IConfigurableFormComponent } from '@/interfaces';
 import { IInputStyles, INestedStyleValue } from '@/providers/form/models';
+
+export type DirectionType = 'horizontal' | 'vertical';
+export const DIRECTION_TYPE: readonly DirectionType[] = ['horizontal', 'vertical'];
+
 /** The subset of the model that determines which options a radio group displays. */
 export interface IRadioOptionsSource {
   items?: ILabelValue[] | undefined;

--- a/shesha-reactjs/src/designer-components/radio/radio.tsx
+++ b/shesha-reactjs/src/designer-components/radio/radio.tsx
@@ -19,9 +19,10 @@ import { migratePermissionsToVisiblePermissions } from '../_common-migrations/mi
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { migrateStyles } from '../_common-migrations/migrateStyles';
 import { getSettings } from './settingsForm';
-import { IRadioComponentProps, RadioComponentDefinition } from './interfaces';
+import { DIRECTION_TYPE, DirectionType, IRadioComponentProps, RadioComponentDefinition } from './interfaces';
 import { isDefined, isNotNullOrWhiteSpace, isNullOrWhiteSpace } from '@/utils/nullables';
-import { DataSourceType } from '../dropdown/model';
+import { DATA_SOURCE_TYPES, DataSourceType } from '../dropdown/model';
+import { getStringEnumOrDefault } from '@/utils/object';
 import { getNumberOrUndefined } from '@/utils/string';
 import { defaultStyles } from './utils';
 import { useStyles } from './styles';
@@ -143,16 +144,12 @@ const RadioComponent: RadioComponentDefinition = {
   migrator: (m) =>
     m
       .add<IRadioComponentProps>(0, (prev, context) => {
-        const configured = "dataSourceType" in prev && typeof (prev.dataSourceType) === 'string'
-          ? (prev.dataSourceType as DataSourceType)
-          : undefined;
+        const configured = getStringEnumOrDefault<DataSourceType>(prev, "dataSourceType", DATA_SOURCE_TYPES);
 
         return {
           ...prev,
           dataSourceType: configured ?? (context.isNew === true ? undefined : 'values'),
-          direction: "direction" in prev && typeof (prev.direction) === 'string'
-            ? prev.direction as "horizontal" | "vertical"
-            : 'horizontal',
+          direction: getStringEnumOrDefault<DirectionType>(prev, "direction", DIRECTION_TYPE) ?? 'horizontal',
         };
       })
       .add<IRadioComponentProps>(1, (prev) => {

--- a/shesha-reactjs/src/designer-components/radio/radio.tsx
+++ b/shesha-reactjs/src/designer-components/radio/radio.tsx
@@ -131,25 +131,30 @@ const RadioComponent: RadioComponentDefinition = {
   settingsFormMarkup: getSettings,
   validateSettings: (model) => validateConfigurableComponentSettings(getSettings, model),
   validateModel: (model, addModelError) => {
-    if (model.dataSourceType === 'referenceList' && !isDefined(model.referenceListId))
+    const dataSourceType = model.dataSourceType ?? 'values';
+    if (dataSourceType === 'referenceList' && !isDefined(model.referenceListId))
       addModelError('referenceListId', 'Select `Reference List` on the settings panel');
-    if (model.dataSourceType === 'values' && (model.items ?? []).length === 0)
+    if (dataSourceType === 'values' && (model.items ?? []).length === 0)
       addModelError('items', 'Add `Items` on the settings panel, or select a different `Data Source Type`');
-    if (model.dataSourceType === 'url' && isNullOrWhiteSpace(model.dataSourceUrl))
+    if (dataSourceType === 'url' && isNullOrWhiteSpace(model.dataSourceUrl))
       addModelError('dataSourceUrl', 'Enter a `Data Source URL` on the settings panel');
   },
   getDefaultStyles: () => defaultStyles(),
   migrator: (m) =>
     m
-      .add<IRadioComponentProps>(0, (prev) => ({
-        ...prev,
-        dataSourceType: "dataSourceType" in prev && typeof (prev.dataSourceType) === 'string'
+      .add<IRadioComponentProps>(0, (prev, context) => {
+        const configured = "dataSourceType" in prev && typeof (prev.dataSourceType) === 'string'
           ? (prev.dataSourceType as DataSourceType)
-          : 'values',
-        direction: "direction" in prev && typeof (prev.direction) === 'string'
-          ? prev.direction as "horizontal" | "vertical"
-          : 'horizontal',
-      }))
+          : undefined;
+
+        return {
+          ...prev,
+          dataSourceType: configured ?? (context.isNew === true ? undefined : 'values'),
+          direction: "direction" in prev && typeof (prev.direction) === 'string'
+            ? prev.direction as "horizontal" | "vertical"
+            : 'horizontal',
+        };
+      })
       .add<IRadioComponentProps>(1, (prev) => {
         return {
           ...prev,

--- a/shesha-reactjs/src/designer-components/radio/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/radio/settingsForm.ts
@@ -47,7 +47,8 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                       labelTitle: 'Label', labelName: 'label', valueTitle: 'Value', valueName: 'value',
                       mode: 'dialog', jsSetting: true,
                     }],
-                    visibleJs: 'return getSettingValue(data?.dataSourceType) === "values";',
+                    // An unset data source renders as `values`, so the Items editor stays visible for it.
+                    visibleJs: 'return (getSettingValue(data?.dataSourceType) ?? "values") === "values";',
                   })
                   .addSettingsInputRow({
                     inputs: [{ type: 'referenceListAutocomplete', propertyName: 'referenceListId', label: 'Reference List', jsSetting: true }],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Checkbox and radio controls now default to manually entered values when no data source is selected.
  - Items editors remain available by default for easier option management.
  - Existing configurations retain their selected data sources and migrate correctly.
  - Validation now applies the appropriate default before checking data-source-specific requirements.
  - Radio controls now preserve valid settings and default their layout direction to horizontal when needed.

- **Improvements**
  - Data-source settings can be left unset without causing configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->