### PR TITLE
update entity reference settings, change component to get entity url …

### DIFF
--- a/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
@@ -117,14 +117,17 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                 })
                 .addSettingsInput({
                   id: nanoid(),
-                  inputType: 'autocomplete',
+                  inputType: 'endpointsAutocomplete',
                   allowClear: true,
                   propertyName: 'getEntityUrl',
                   label: 'Get Entity URL',
                   labelAlign: 'right',
                   parentId: dataTabId,
                   hidden: false,
-                  dataSourceType: 'url',
+                  size: 'small',
+                  mode: 'url',
+                  httpVerb: 'get',
+                  jsSetting: true,
                   validate: {
                     required: {
                       _code: 'return !getSettingValue(data?.entityType);',
@@ -133,9 +136,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                     },
                   },
                   validationDependencies: ['entityType'],
-                  dataSourceUrl: '/api/services/app/Api/Endpoints',
                   settingsValidationErrors: [],
-                  useRawValues: true,
                 })
                 .addSettingsInputRow({
                   id: nanoid(),


### PR DESCRIPTION
…to endpointsAutocomplete

#5086 

Addressed the last comment: Get entity URL property broken. The list is empty and also not possible to manually past any URL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated entity reference URL settings with a more focused autocomplete experience.
  * URL suggestions now use the appropriate GET request and compact sizing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->