### PR TITLE
Lihlumise/fix/datefield

### DIFF
--- a/shesha-reactjs/src/designer-components/dateField/dateField.tsx
+++ b/shesha-reactjs/src/designer-components/dateField/dateField.tsx
@@ -152,6 +152,16 @@ const DateField: DateFieldDefinition = {
       }
 
       return model;
+    })
+    /* The Today/Now shortcut is no longer configurable — the picker always shows it — so the two
+       properties that used to drive it are dropped rather than left as dead config. */
+    .add<IDateFieldProps>(9, (prev) => {
+      const model = { ...prev } as IDateFieldPropsV1;
+
+      delete model.showNow;
+      delete model.showToday;
+
+      return model;
     }),
   linkToModelMetadata: (model, metadata): IDateFieldProps => {
     return {

--- a/shesha-reactjs/src/designer-components/dateField/dateField.tsx
+++ b/shesha-reactjs/src/designer-components/dateField/dateField.tsx
@@ -176,11 +176,11 @@ const DateField: DateFieldDefinition = {
 
       return model;
     })
-    /* The Today/Now shortcut is no longer configurable — the picker always shows it — so the two
-       properties that used to drive it are dropped rather than left as dead config. */
     .add<IDateFieldProps>(9, (prev) => {
       const model = { ...prev } as IDateFieldPropsV1;
 
+      delete model.picker;
+      delete model.showTime;
       delete model.showNow;
       delete model.showToday;
 

--- a/shesha-reactjs/src/designer-components/dateField/dateField.tsx
+++ b/shesha-reactjs/src/designer-components/dateField/dateField.tsx
@@ -12,14 +12,17 @@ import { migratePermissionsToVisiblePermissions } from '../_common-migrations/mi
 import { DatePickerWrapper } from './datePickerWrapper';
 import { DateFieldDefinition, DateFieldValueType, DateSelectionType, IDateFieldProps, IDateFieldPropsV1, NoUndefinedRangeValueType } from './interfaces';
 import { getSettings } from './settingsForm';
-import { defaultStyles } from './utils';
+import { defaultStyles, getNumericBindingFormatWarning } from './utils';
 import { useComponentApi } from '@/providers/componentApi/provider';
+import { useMetadataOrUndefined } from '@/providers';
+import { useComponentValidation } from '@/providers/validationErrors';
+import { asPropertiesArray } from '@/interfaces/metadata';
 import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { DateFieldApi } from '../../componentsApi/componentApi';
 import { ALL_INPUT_EVENTS_WITHOUT_CHANGE_AND_DOUBLE_CLICK, getComponentEvents } from '../_common/events';
 
 import apiCode from "../../componentsApi/componentApi.ts?raw";
-import { isNotNullOrWhiteSpace } from '@/utils/nullables';
+import { isNotNullOrWhiteSpace, isNullOrWhiteSpace } from '@/utils/nullables';
 
 const toSelectionType = (picker: string | undefined, showTime: boolean | undefined): DateSelectionType => {
   switch (picker) {
@@ -45,6 +48,26 @@ const DateField: DateFieldDefinition = {
   Factory: ({ model }) => {
     const componentApi = useComponentApi();
     const inputRef = useRef<HTMLDivElement>(null);
+    const { properties: metaProperties } = useMetadataOrUndefined()?.metadata ?? {};
+
+    /* Ticks and Unix cannot bind to a date property — the value posts as a number and the backend
+       rejects it. Surface that in the designer, where it is a configuration mistake someone can
+       still fix, rather than leaving it to be found as a validation error at save time. */
+    useComponentValidation(() => {
+      const warning = getNumericBindingFormatWarning(model, asPropertiesArray(metaProperties, []));
+      return isNullOrWhiteSpace(warning)
+        ? undefined
+        : {
+          hasErrors: true,
+          componentId: model.id,
+          componentName: model.componentName,
+          componentType: model.type,
+          validationType: 'warning' as const,
+          errors: [{ propertyName: 'bindingFormat', error: warning }],
+        };
+      // Only the inputs the warning is derived from — `model` is a fresh object on every render, so
+      // depending on it would recompute continuously.
+    }, [model.bindingFormat, model.resolveToUTC, model.propertyName, model.id, model.componentName, model.type, metaProperties]);
 
     useEffect(() => {
       componentApi?.updateApi<DateFieldApi>({

--- a/shesha-reactjs/src/designer-components/dateField/datePickerWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/dateField/datePickerWrapper.tsx
@@ -28,12 +28,23 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
     hideBorder,
     range,
     value,
-    showNow,
     onChange,
     readOnly,
     defaultToMidnight,
     minuteStep,
   } = props;
+
+  /* antd's picker accepts only onFocus/onBlur, so the remaining handlers from `getComponentEvents`
+     are bound to the wrapper element. Click, mouse-move and both key events bubble up from the
+     inner input; enter/leave fire on the wrapper itself. */
+  const wrapperEvents = {
+    onClick: props.onClick,
+    onMouseEnter: props.onMouseEnter,
+    onMouseMove: props.onMouseMove,
+    onMouseLeave: props.onMouseLeave,
+    onKeyDown: props.onKeyDown,
+    onKeyUp: props.onKeyUp,
+  };
 
   const picker = getPicker(props);
   const showTime = hasTimePart(props);
@@ -197,7 +208,7 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
 
   if (range === true) {
     return (
-      <div ref={ref} style={{ marginRight: 1 }}>
+      <div ref={ref} style={{ marginRight: 1 }} {...wrapperEvents}>
         <RangePicker
           onCalendarChange={(dates) => {
             if (showTime && defaultToMidnight !== true) handleCalendarRangeChange(dates);
@@ -238,7 +249,7 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
   }
 
   return (
-    <div ref={ref} style={{ marginRight: 1 }}>
+    <div ref={ref} style={{ marginRight: 1 }} {...wrapperEvents}>
       <DatePicker
         className={styles.dateField}
         disabledDate={(e) => disabledDate(props, e, formData, globalState)}
@@ -246,7 +257,7 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
         onChange={handleDatePickerChange}
         {...(hideBorder === true ? { variant: 'borderless' } : {})}
         showTime={showTimeConfig}
-        showNow={showNow === true}
+        showNow
         picker={picker}
         format={pickerFormat}
         onCalendarChange={(dates) => {

--- a/shesha-reactjs/src/designer-components/dateField/datePickerWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/dateField/datePickerWrapper.tsx
@@ -32,19 +32,16 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
     readOnly,
     defaultToMidnight,
     minuteStep,
+    /* antd's picker accepts only onFocus/onBlur, so the remaining handlers from `getComponentEvents`
+       are bound to the wrapper element. Click, mouse-move and both key events bubble up from the
+       inner input; enter/leave fire on the wrapper itself. */
+    onClick,
+    onMouseEnter,
+    onMouseMove,
+    onMouseLeave,
+    onKeyDown,
+    onKeyUp,
   } = props;
-
-  /* antd's picker accepts only onFocus/onBlur, so the remaining handlers from `getComponentEvents`
-     are bound to the wrapper element. Click, mouse-move and both key events bubble up from the
-     inner input; enter/leave fire on the wrapper itself. */
-  const wrapperEvents = {
-    onClick: props.onClick,
-    onMouseEnter: props.onMouseEnter,
-    onMouseMove: props.onMouseMove,
-    onMouseLeave: props.onMouseLeave,
-    onKeyDown: props.onKeyDown,
-    onKeyUp: props.onKeyUp,
-  };
 
   const picker = getPicker(props);
   const showTime = hasTimePart(props);
@@ -208,7 +205,16 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
 
   if (range === true) {
     return (
-      <div ref={ref} style={{ marginRight: 1 }} {...wrapperEvents}>
+      <div
+        ref={ref}
+        style={{ marginRight: 1 }}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+      >
         <RangePicker
           onCalendarChange={(dates) => {
             if (showTime && defaultToMidnight !== true) handleCalendarRangeChange(dates);
@@ -249,7 +255,16 @@ export const DatePickerWrapper = forwardRef<HTMLDivElement, IDateFieldProps>((pr
   }
 
   return (
-    <div ref={ref} style={{ marginRight: 1 }} {...wrapperEvents}>
+    <div
+      ref={ref}
+      style={{ marginRight: 1 }}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+    >
       <DatePicker
         className={styles.dateField}
         disabledDate={(e) => disabledDate(props, e, formData, globalState)}

--- a/shesha-reactjs/src/designer-components/dateField/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/dateField/interfaces.ts
@@ -1,7 +1,7 @@
 import { DatePickerFocusEventHandler } from '@/components/antd/datepicker';
 import { ComponentDefinition } from '@/interfaces';
 import { IConfigurableFormComponent, IInputStyles } from '@/providers/form/models';
-import { CSSProperties } from 'react';
+import { CSSProperties, KeyboardEventHandler, MouseEventHandler } from 'react';
 
 export type RangeType = 'start' | 'end';
 
@@ -64,7 +64,6 @@ export interface IDateFieldProps extends IConfigurableFormComponent, IInputStyle
   minuteStep?: MinuteStep | undefined;
 
   defaultToMidnight?: boolean | undefined;
-  showNow?: boolean | undefined;
   timeFormat?: string | undefined;
   yearFormat?: string | undefined;
   quarterFormat?: string | undefined;
@@ -86,17 +85,25 @@ export interface IDateFieldProps extends IConfigurableFormComponent, IInputStyle
 
   onFocus?: DatePickerFocusEventHandler | undefined;
   onBlur?: DatePickerFocusEventHandler | undefined;
+  onClick?: MouseEventHandler<HTMLDivElement> | undefined;
+  onMouseEnter?: MouseEventHandler<HTMLDivElement> | undefined;
+  onMouseMove?: MouseEventHandler<HTMLDivElement> | undefined;
+  onMouseLeave?: MouseEventHandler<HTMLDivElement> | undefined;
+  onKeyDown?: KeyboardEventHandler<HTMLDivElement> | undefined;
+  onKeyUp?: KeyboardEventHandler<HTMLDivElement> | undefined;
 }
 
 /**
  * Pre-refactor shape. Kept so the early migrator steps stay typed against the model they actually
- * received: `picker` and `showTime` are gone from `IDateFieldProps`, but old saved forms still carry
- * them and step 8 is what folds them into `selectionType`.
+ * received: `picker`, `showTime`, `showToday` and `showNow` are gone from `IDateFieldProps`, but old
+ * saved forms still carry them — step 8 folds `picker`/`showTime` into `selectionType` and step 9
+ * strips the Today/Now pair, which the picker now always shows.
  */
 export interface IDateFieldPropsV1 extends Omit<IDateFieldProps, 'selectionType'> {
   picker?: 'time' | 'date' | 'week' | 'month' | 'quarter' | 'year' | undefined;
   showTime?: boolean | undefined;
   showToday?: boolean | undefined;
+  showNow?: boolean | undefined;
   selectionType?: DateSelectionType | undefined;
 }
 

--- a/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
@@ -130,7 +130,6 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                   visibleJs: hasMinutesJs,
                 })
                 .addSettingsInput({ inputType: 'switch', propertyName: 'resolveToUTC', label: 'Convert to/from UTC', size: 'small', layout: 'horizontal', jsSetting: true })
-                .addSettingsInput({ inputType: 'switch', propertyName: 'showNow', label: 'Show Today/Now', size: 'small', layout: 'horizontal', jsSetting: true })
                 .addSettingsInput({ inputType: 'switch', propertyName: 'defaultToMidnight', label: 'Default time to midnight', size: 'small', layout: 'horizontal', jsSetting: true, visibleJs: isDateTimeJs })
                 .addSettingsInput({
                   inputType: 'dropdown', propertyName: 'dateRestriction', label: 'Date Restriction', size: 'small', jsSetting: true,

--- a/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
@@ -72,6 +72,9 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
   const hasMinutesJs = 'return ["dateTimeMinutes", "dateTimeSeconds"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
   // Date Format applies to every selection except the calendar-unit pickers, which have their own.
   const isDateBasedJs = 'return !["week", "month", "quarter", "year"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
+  // Inverse of the above: hides the whole row rather than leaving an empty one behind when only the
+  // per-input conditions match, since exactly one of its four fields can ever apply.
+  const isCalendarUnitJs = 'return ["week", "month", "quarter", "year"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
 
   const json = {
     components: fbf('root')
@@ -122,6 +125,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                     { type: 'textField', propertyName: 'quarterFormat', label: 'Quarter Format', size: 'small', jsSetting: true, visibleJs: 'return getSettingValue(data?.selectionType) === "quarter";' },
                     { type: 'textField', propertyName: 'yearFormat', label: 'Year Format', size: 'small', jsSetting: true, visibleJs: 'return getSettingValue(data?.selectionType) === "year";' },
                   ],
+                  visibleJs: isCalendarUnitJs,
                 })
                 .addSettingsInput({
                   inputType: 'dropdown', propertyName: 'minuteStep', label: 'Minute steps', size: 'small', jsSetting: true,

--- a/shesha-reactjs/src/designer-components/dateField/utils.ts
+++ b/shesha-reactjs/src/designer-components/dateField/utils.ts
@@ -1,5 +1,6 @@
 import moment, { Moment } from 'moment';
 import { IPropertyMetadata } from '@/interfaces/metadata';
+import { DataTypes } from '@/interfaces/dataTypes';
 import { getDataProperty } from '@/utils/metadata';
 import { DateBindingFormat, DateSelectionType, DisabledDateTemplate, IDateFieldProps } from './interfaces';
 import { range } from 'lodash';
@@ -75,6 +76,43 @@ function legacyDisabledDate(props: IDateFieldProps, current: Moment, data: objec
 
 export const getBindingFormat = (props: IDateFieldProps): DateBindingFormat =>
   props.bindingFormat ?? (props.resolveToUTC === true ? 'utc' : 'isoLocal');
+
+const BINDING_FORMAT_LABELS: Record<DateBindingFormat, string> = {
+  utc: 'UTC',
+  isoLocal: 'ISO Local',
+  isoOffset: 'ISO with offset',
+  dateOnly: 'Date only',
+  ticks: 'Ticks',
+  unix: 'Unix',
+};
+
+const NUMERIC_BINDING_FORMATS: DateBindingFormat[] = ['ticks', 'unix'];
+
+/**
+ * Warns when the value would be posted as a number to a property that can only accept a date.
+ * Ticks and Unix stay available because they are the right choice for a numeric property (a `long`
+ * holding an epoch value, say) — this only fires where the metadata says the target is a date, the
+ * one combination that is guaranteed to be rejected by the backend.
+ *
+ * Returns `undefined` when the configuration is fine, or when there is no metadata to judge it by.
+ */
+export const getNumericBindingFormatWarning = (
+  props: IDateFieldProps,
+  properties: IPropertyMetadata[],
+): string | undefined => {
+  const bindingFormat = getBindingFormat(props);
+  if (!NUMERIC_BINDING_FORMATS.includes(bindingFormat)) return undefined;
+
+  const { propertyName } = props;
+  if (isNullOrWhiteSpace(propertyName)) return undefined;
+
+  const dataType = getDataProperty(properties, propertyName, 'dataType');
+  if (dataType !== DataTypes.date && dataType !== DataTypes.dateTime) return undefined;
+
+  return `Binding Format "${BINDING_FORMAT_LABELS[bindingFormat]}" stores the value as a number, ` +
+    `but "${propertyName}" is a ${dataType} property and will reject it when the form is saved. ` +
+    `Choose UTC, ISO Local, ISO with offset or Date only, or bind this field to a numeric property.`;
+};
 
 export const serializeValue = (value: Moment, props: IDateFieldProps): string => {
   switch (getBindingFormat(props)) {

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/date.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/date.tsx
@@ -16,7 +16,6 @@ export const DateWrapper: FCUnwrapped<IDateSettingsInputProps> = (props) => {
       hideBorder={false}
       range={false}
       selectionType="date"
-      showNow={false}
       defaultToMidnight={false}
       resolveToUTC={false}
       dateFormat={undefined}

--- a/shesha-reactjs/src/designer-components/settingsInput/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/settingsInput/interfaces.ts
@@ -47,7 +47,7 @@ export interface IHasModelType {
 
 // Base interface without type-specific properties
 export interface ISettingsInputBase<TValue = unknown> extends IComponentLabelProps,
-  Omit<IConfigurableFormComponent, 'id' | 'label' | 'layout' | 'readOnly' | 'style' | 'propertyName' | 'hidden'> {
+  Omit<IConfigurableFormComponent, 'id' | 'label' | 'layout' | 'readOnly' | 'style' | 'propertyName' | 'hidden' | 'visible'> {
   id?: string | undefined;
   label: string | React.ReactNode;
   propertyName: string;
@@ -66,7 +66,11 @@ export interface ISettingsInputBase<TValue = unknown> extends IComponentLabelPro
 
   /** @deprecated Use `visible` instead (inversion of `hidden`) */
   hidden?: boolean | IPropertySetting<boolean> | undefined;
-  visible?: boolean | undefined;
+  /**
+   * A code evaluator as well as a plain boolean: `addSettingsInputRow` converts a nested input's
+   * `visibleJs` into one, and `getActualModel` resolves it before the input is rendered.
+   */
+  visible?: ValueOrCodeEvaluator<boolean> | undefined;
   visibleJs?: string | undefined;
 
   width?: string | number | undefined;

--- a/shesha-reactjs/src/form-factory/implementation.ts
+++ b/shesha-reactjs/src/form-factory/implementation.ts
@@ -200,8 +200,23 @@ export class FormBuilderImplementation implements FormBuilder, StandardFormBuild
 
   addSettingsInput = (props: FluentSettings<SettingsInputComponentProps>, meta?: IPropertyMetadata): FormBuilder => this._addProperty(props, 'settingsInput', meta);
 
+  /**
+   * `_addProperty` converts `visibleJs` into a `visible` code evaluator, but only for the row
+   * component itself — the inputs inside it are plain objects it never walks, so their `visibleJs`
+   * was carried into the markup as an inert string and the input always rendered. Convert each one
+   * here instead: `getActualModel` resolves the evaluator when it recurses into the `inputs` array,
+   * and `SettingInput` already treats `visible === false` as hidden.
+   */
   addSettingsInputRow = (props: FluentSettings<ISettingsInputRowProps & IConfigurableFormComponent>, meta?: IPropertyMetadata): FormBuilder => {
-    return this._addProperty(props, 'settingsInputRow', meta);
+    const inputs = props.inputs?.map((input) => {
+      const { visibleJs, ...rest } = input;
+      return typeof visibleJs === 'string'
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        ? { ...rest, visible: { _code: visibleJs, _mode: 'code', _value: false } as any } as typeof input // eslint-disable-line @typescript-eslint/no-explicit-any
+        : input;
+    });
+
+    return this._addProperty(isDefined(inputs) ? { ...props, inputs } : props, 'settingsInputRow', meta);
   };
 
   stdPropertyLabelInputs = (): FormBuilder => {

--- a/shesha-reactjs/src/form-factory/implementation.ts
+++ b/shesha-reactjs/src/form-factory/implementation.ts
@@ -56,6 +56,7 @@ import { isPropertySettings } from "@/designer-components/_settings/utils/utils"
 import { getEventConfig, StandardEventHandler } from "@/designer-components/_common/events";
 import { ALIGN_ITEMS, ALIGN_ITEMS_GRID, ALIGN_SELF, FLEX_DIRECTION, FLEX_WRAP, JUSTIFY_CONTENT, JUSTIFY_ITEMS, JUSTIFY_SELF } from "@/designer-components/container/data";
 import { IContainerCheckerComponentProps } from "@/designer-components/containerChecker/interfaces";
+import { resolveInputVisibility } from "./inputVisibility";
 
 /**
  * Returns `true` when `propertyName`'s trailing segment (the part after the last `.`) is listed in
@@ -208,13 +209,7 @@ export class FormBuilderImplementation implements FormBuilder, StandardFormBuild
    * and `SettingInput` already treats `visible === false` as hidden.
    */
   addSettingsInputRow = (props: FluentSettings<ISettingsInputRowProps & IConfigurableFormComponent>, meta?: IPropertyMetadata): FormBuilder => {
-    const inputs = props.inputs?.map((input) => {
-      const { visibleJs, ...rest } = input;
-      return typeof visibleJs === 'string'
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        ? { ...rest, visible: { _code: visibleJs, _mode: 'code', _value: false } as any } as typeof input // eslint-disable-line @typescript-eslint/no-explicit-any
-        : input;
-    });
+    const inputs = isDefined(props.inputs) ? resolveInputVisibility(props.inputs) : undefined;
 
     return this._addProperty(isDefined(inputs) ? { ...props, inputs } : props, 'settingsInputRow', meta);
   };

--- a/shesha-reactjs/src/form-factory/inputVisibility.ts
+++ b/shesha-reactjs/src/form-factory/inputVisibility.ts
@@ -1,0 +1,23 @@
+import type { IPropertySetting } from '@/interfaces';
+import type { ISettingsInputProps } from '@/designer-components/settingsInput/interfaces';
+
+/**
+ * Converts each input's `visibleJs` into the `visible` code evaluator `_addProperty` produces for a
+ * component it adds directly.
+ *
+ * Inputs nested in a `settingsInputRow` are plain objects the builder never walks, so a `visibleJs`
+ * left on one reached the markup as an inert string and the input always rendered. `getActualModel`
+ * resolves the evaluator when it recurses into the `inputs` array, and `SettingInput` already treats
+ * `visible === false` as hidden, so converting here is all that is needed.
+ *
+ * Split out of `FormBuilderImplementation` so it can be tested without pulling in the component
+ * registry the builder depends on.
+ */
+export const resolveInputVisibility = (inputs: ISettingsInputProps[]): ISettingsInputProps[] =>
+  inputs.map((input) => {
+    const { visibleJs, ...rest } = input;
+    if (typeof visibleJs !== 'string') return input;
+
+    const visible: IPropertySetting<boolean> = { _code: visibleJs, _mode: 'code', _value: false };
+    return { ...rest, visible };
+  });

--- a/shesha-reactjs/src/providers/validationErrors/index.tsx
+++ b/shesha-reactjs/src/providers/validationErrors/index.tsx
@@ -117,7 +117,11 @@ export const FormComponentValidationProvider: FC<PropsWithChildren<IFormComponen
 
   const stateValue = useMemo<IValidationErrorsStateContext>(
     () => ({
-      errors: errorsRef.current,
+      /* A snapshot, not `errorsRef.current` itself. Consumers use this map as a memo dependency, so
+         handing out the same mutated instance left them unable to see that its contents had changed:
+         they re-rendered when `errorVersion` bumped but skipped recomputing, and kept displaying the
+         previous validation result until something else in their deps happened to change. */
+      errors: new Map(errorsRef.current),
       componentId,
       componentName,
       componentType,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date fields now consistently enable the Today/Now option.
  * Date field event interactions are supported through surrounding wrappers.
  * Calendar format settings are shown only for applicable selection types.
  * Dynamic visibility expressions are applied to nested settings inputs.

* **Bug Fixes**
  * Added warnings for incompatible numeric date binding formats.
  * Removed obsolete Today/Now configuration options from migrated date fields.
  * Preserved compatibility with legacy saved forms.
  * Validation updates now refresh reliably when errors change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->