### PR TITLE
fix DataList multiple-selection checkboxes never rendered as checked

### DIFF
--- a/shesha-core/src/Shesha.Framework/DynamicEntities/Binder/EntityModelBinder.cs
+++ b/shesha-core/src/Shesha.Framework/DynamicEntities/Binder/EntityModelBinder.cs
@@ -700,7 +700,18 @@ namespace Shesha.DynamicEntities.Binder
                     var child = prop.GetValue(entity, null);
                     if (child != null)
                     {
-                        result |= await DeleteUnreferencedEntityAsync(child, entity);
+                        var deleted = await DeleteUnreferencedEntityAsync(child, entity);
+                        if (deleted && prop.CanWrite)
+                        {
+                            // Break the association before the session is flushed. The parent is often
+                            // soft-deleted, so its row survives holding this reference, while the child
+                            // may be hard-deleted. Many-to-one references are mapped with Cascade.Persist,
+                            // so leaving the reference in place makes NHibernate try to re-save the child
+                            // that was just deleted and fail the flush with
+                            // "deleted object would be re-saved by cascade".
+                            prop.SetValue(entity, null, null);
+                        }
+                        result |= deleted;
                     }
                 }
             }

--- a/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20260820120000.cs
+++ b/shesha-functional-tests/backend/src/Module/Boxfusion.SheshaFunctionalTests.Common.Domain/Migrations/M20260820120000.cs
@@ -1,0 +1,55 @@
+using FluentMigrator;
+using Shesha.FluentMigrator;
+
+namespace Boxfusion.SheshaFunctionalTests.Common.Domain.Migrations
+{
+    /// <summary>
+    /// Turns off "cascade delete unreferenced" on MembershipPayment.Member and Member.Bank.
+    ///
+    /// DeleteCascadeAsync walks these flags recursively, so deleting a MembershipPayment deleted the
+    /// Member and then the Member's Bank. Member is soft-deleted (its row survives holding the Bank
+    /// reference) while Bank is hard-deleted, so the flush failed with
+    /// "deleted object would be re-saved by cascade".
+    ///
+    /// Neither cascade is wanted in the first place: a payment should not delete the member who made
+    /// it, and banks are shared reference data.
+    /// </summary>
+    [Migration(20260820120000)]
+    public class M20260820120000 : OneWayMigration
+    {
+        public override void Up()
+        {
+            IfDatabase("SqlServer").Execute.Sql(@"update
+	ep
+set
+	cascade_delete_unreferenced = 0
+from
+	frwk.entity_properties ep
+	inner join frwk.entity_configs ec on ec.id = ep.entity_config_id
+where
+	ec.namespace = 'Boxfusion.SheshaFunctionalTests.Common.Domain.Domain'
+	and ep.cascade_delete_unreferenced = 1
+	and (
+		ec.class_name = 'MembershipPayment' and ep.name = 'Member'
+		or
+		ec.class_name = 'Member' and ep.name = 'Bank'
+	)");
+
+            IfDatabase("PostgreSql").Execute.Sql(@"UPDATE
+	frwk.entity_properties ep
+SET
+	cascade_delete_unreferenced = false
+FROM
+	frwk.entity_configs ec
+WHERE
+	ec.id = ep.entity_config_id
+	AND ec.namespace = 'Boxfusion.SheshaFunctionalTests.Common.Domain.Domain'
+	AND ep.cascade_delete_unreferenced = true
+	AND (
+		ec.class_name = 'MembershipPayment' AND ep.name = 'Member'
+		OR
+		ec.class_name = 'Member' AND ep.name = 'Bank'
+	)");
+        }
+    }
+}

--- a/shesha-reactjs/src/components/dataList/crudActionButtons.tsx
+++ b/shesha-reactjs/src/components/dataList/crudActionButtons.tsx
@@ -55,14 +55,28 @@ export const CrudActionButtons = (): React.JSX.Element => {
   const onSaveCreateClick = async (): Promise<void> => {
     try {
       await performCreate();
-      await reset();
     } catch (error) {
       notifyError(error, 'Create failed');
+      return;
+    }
+
+    // The row exists by this point, so a `reset` failure must not be reported as a create failure -
+    // the user would retry and create a duplicate.
+    try {
+      await reset();
+    } catch (error) {
+      notifyError(error, 'Failed to reset the form');
     }
   };
 
   const onCancelEditClick = async (): Promise<void> => {
-    await reset();
+    try {
+      await reset();
+    } catch (error) {
+      // `reset` throws when there is no form in scope; without this the rejection escapes unhandled
+      // and `switchMode` below never runs, leaving the row stuck in edit mode.
+      notifyError(error, 'Failed to reset the form');
+    }
     switchMode('read');
   };
 

--- a/shesha-reactjs/src/components/dataList/crudActionButtons.tsx
+++ b/shesha-reactjs/src/components/dataList/crudActionButtons.tsx
@@ -1,7 +1,10 @@
 import { useDataListCrud } from '@/providers/dataListCrudContext/index';
 import { CloseCircleOutlined, DeleteOutlined, EditOutlined, PlusCircleOutlined, SaveOutlined } from '@ant-design/icons';
+import { App } from 'antd';
 import * as React from 'react';
+import { extractErrorInfo } from '@/utils/errors';
 import ActionButton, { IActionButtonProps } from '../actionButton/index';
+import ValidationErrors from '../validationErrors';
 import { useStyles } from './styles/styles';
 
 export const CrudActionButtons = (): React.JSX.Element => {
@@ -23,6 +26,16 @@ export const CrudActionButtons = (): React.JSX.Element => {
   } = useDataListCrud();
 
   const { styles } = useStyles();
+  const { notification } = App.useApp();
+
+  // the inline CRUD errors are otherwise only reachable by hovering the action button, so a failed
+  // operation looks like nothing happened - surface it explicitly.
+  const notifyError = (error: unknown, fallbackMessage: string): void => {
+    console.error(fallbackMessage, error);
+    notification.error({
+      message: <ValidationErrors error={extractErrorInfo(error)} renderMode="raw" />,
+    });
+  };
 
   const onEditClick = (): void => {
     switchMode('update');
@@ -33,7 +46,7 @@ export const CrudActionButtons = (): React.JSX.Element => {
       await performUpdate();
       switchMode('read');
     } catch (error) {
-      console.error('Update failed: ', error);
+      notifyError(error, 'Update failed: ');
     }
   };
 
@@ -42,7 +55,7 @@ export const CrudActionButtons = (): React.JSX.Element => {
       await performCreate();
       await reset();
     } catch (error) {
-      console.error('Create failed: ', error);
+      notifyError(error, 'Create failed: ');
     }
   };
 
@@ -53,8 +66,9 @@ export const CrudActionButtons = (): React.JSX.Element => {
 
   const onDeleteClick = (): void => {
     performDelete().catch((error) => {
-      console.error('Failed to delete row', error);
-      throw error;
+      // don't rethrow - performDelete already recorded the error on the crud context, and rethrowing
+      // here escapes as an unhandled promise rejection.
+      notifyError(error, 'Failed to delete row');
     });
   };
 

--- a/shesha-reactjs/src/components/dataList/crudActionButtons.tsx
+++ b/shesha-reactjs/src/components/dataList/crudActionButtons.tsx
@@ -30,10 +30,12 @@ export const CrudActionButtons = (): React.JSX.Element => {
 
   // the inline CRUD errors are otherwise only reachable by hovering the action button, so a failed
   // operation looks like nothing happened - surface it explicitly.
-  const notifyError = (error: unknown, fallbackMessage: string): void => {
-    console.error(fallbackMessage, error);
+  const notifyError = (error: unknown, title: string): void => {
+    console.error(title, error);
     notification.error({
-      message: <ValidationErrors error={extractErrorInfo(error)} renderMode="raw" />,
+      // `message` is deprecated in antd 6 in favour of `title`
+      title,
+      description: <ValidationErrors error={extractErrorInfo(error)} renderMode="raw" />,
     });
   };
 
@@ -46,7 +48,7 @@ export const CrudActionButtons = (): React.JSX.Element => {
       await performUpdate();
       switchMode('read');
     } catch (error) {
-      notifyError(error, 'Update failed: ');
+      notifyError(error, 'Update failed');
     }
   };
 
@@ -55,7 +57,7 @@ export const CrudActionButtons = (): React.JSX.Element => {
       await performCreate();
       await reset();
     } catch (error) {
-      notifyError(error, 'Create failed: ');
+      notifyError(error, 'Create failed');
     }
   };
 

--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -22,7 +22,7 @@ import { getClassNameOrUndefined } from '@/utils/entity';
 import { isDefined, isNotNullOrWhiteSpace, isNullOrWhiteSpace } from '@/utils/nullables';
 import { toCamelCase } from '@/utils/string';
 import { PlusOutlined } from '@ant-design/icons';
-import { Button, Checkbox, Collapse, Divider, Typography } from 'antd';
+import { Button, Checkbox, Collapse, Divider, Radio, Typography } from 'antd';
 import classNames from 'classnames';
 import { isEqual } from 'lodash';
 import moment from 'moment';
@@ -81,6 +81,19 @@ const isInteractiveTarget = (target: EventTarget | null): boolean => {
     !!target.closest('[contenteditable="true"]')
   );
 };
+
+/**
+ * Match a selected row against a rendered item. Prefers `id` so that sorting, filtering or paging
+ * can't shift the match onto the wrong row, and falls back to the positional index for rows that
+ * have no id yet (e.g. newly added, unsaved items).
+ */
+const isSameRow = (
+  selectedId: string | undefined,
+  selectedIndex: number | undefined,
+  itemId: string | undefined,
+  itemIndex: number,
+): boolean =>
+  isDefined(selectedId) && isDefined(itemId) ? selectedId === itemId : selectedIndex === itemIndex;
 
 interface EntityForm {
   entityType: string | IEntityTypeIdentifier;
@@ -218,8 +231,11 @@ export const DataList: FC<IDataListProps> = ({
         onSelectionChange(selectedItems, selectedIndices);
       }
     } else {
-      // Single selection mode
-      const isCurrentlySelected = selectedRow?.index === index;
+      // Single selection mode. Match on id where possible so the toggle agrees with the `selected`
+      // flag used for rendering - matching purely on index disagrees with it once rows are sorted,
+      // filtered or paged.
+      const isCurrentlySelected =
+        isDefined(selectedRow) && isSameRow(selectedRow.id, selectedRow.index, row.id, index);
 
       if (isCurrentlySelected) {
         // Deselecting - don't trigger onListItemSelect
@@ -289,7 +305,11 @@ export const DataList: FC<IDataListProps> = ({
   const getFormIdFromExpression = (item: ITableRowData): FormFullName | undefined => {
     if (!formIdExpression) return undefined;
 
-    return executeScriptSync(formIdExpression, { ...allData, item });
+    // `data` on the application context is the host form's data, which is empty when the DataList
+    // is the page content - expose the row under `data` so per-row expressions work, matching the
+    // context shape used by DataTable and the DataList designer component. `item` is kept for
+    // backwards compatibility with existing expressions.
+    return executeScriptSync(formIdExpression, { ...allData, item, data: item });
   };
 
   const { formInfoBlockVisible } = useAppConfigurator();
@@ -687,10 +707,13 @@ export const DataList: FC<IDataListProps> = ({
       });
     };
 
-    const selected = isDefined(selectedRow) && (
-      (selectedRow.index === index && !(selectedRows.length > 0)) ||
-      (selectedRows.length > 0 && selectedRows.some(({ id }) => id === item.id))
-    );
+    // Read the same state the toggle in `onSelectRowLocal` writes, per mode. The previous version
+    // gated both branches on `selectedRow`, which is only ever set in single mode - in multiple mode
+    // it left every checkbox permanently unchecked while `selectedIds` tracked the selection
+    // correctly underneath, so rows never appeared to tick but Select All still reacted to them.
+    const selected = selectionMode === 'multiple'
+      ? selectedIds.includes(item.id)
+      : isDefined(selectedRow) && isSameRow(selectedRow.id, selectedRow.index, item.id, index);
 
 
     const itemStyles: CSSProperties = {
@@ -715,18 +738,33 @@ export const DataList: FC<IDataListProps> = ({
     return (
       <div key={`row-${index}`} style={wrapperStyle}>
         <ConditionalWrap
-          condition={selectionMode === 'multiple'}
-          wrap={(children) => (
-            <Checkbox
-              className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}
-              checked={selected}
-              onChange={() => {
-                onSelectRowLocal(index, item);
-              }}
-            >
-              {children}
-            </Checkbox>
-          )}
+          condition={selectionMode === 'single' || selectionMode === 'multiple'}
+          wrap={(children) => selectionMode === 'single'
+            ? (
+              <Radio
+                className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}
+                checked={selected}
+                // Radio raises onChange only when it becomes checked, so clicking the already
+                // selected row would never deselect it. onClick fires either way, and antd's bubble
+                // lock keeps it to one call whether the click lands on the control or the row body.
+                onClick={() => {
+                  onSelectRowLocal(index, item);
+                }}
+              >
+                {children}
+              </Radio>
+            )
+            : (
+              <Checkbox
+                className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}
+                checked={selected}
+                onChange={() => {
+                  onSelectRowLocal(index, item);
+                }}
+              >
+                {children}
+              </Checkbox>
+            )}
         >
           <div
             className={classNames(
@@ -735,16 +773,17 @@ export const DataList: FC<IDataListProps> = ({
             )}
             onClick={(e) => {
               // Skip selection/click events when interacting with form fields (dropdown, picker, etc.)
-              // or content rendered in portals — otherwise inline-editing clicks toggle row selection
-              // and, in multiple-select mode, double-toggle via the wrapping Checkbox label.
+              // or content rendered in portals — otherwise inline-editing clicks toggle row selection.
               if (isInteractiveTarget(e.target)) {
+                // preventDefault is what actually suppresses the selection: this item is nested in the
+                // wrapping Checkbox's <label>, and label activation is a default action that
+                // stopPropagation does not cancel.
+                e.preventDefault();
                 e.stopPropagation();
                 return;
               }
-              // In multiple mode the wrapping Checkbox handles selection via onChange
-              if (selectionMode === 'single') {
-                onSelectRowLocal(index, item);
-              }
+              // Selection itself is driven by the wrapping Checkbox's onChange in both single and
+              // multiple mode - calling onSelectRowLocal here as well would toggle twice and cancel out.
               if (onListItemClick) {
                 onListItemClick(index, item);
               }

--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -185,9 +185,12 @@ export const DataList: FC<IDataListProps> = ({
     createFormInfo.current = undefined;
   }, [formId, formType, createFormId, createFormType, entityType, formSelectionMode]);
 
+  // `selectedIds` has to be here: in multiple mode the rendered `selected` flag is derived from it,
+  // and it can change without `selectedRows` changing (a controlled update from the parent, or a
+  // direct `changeSelectedIds` call), which would otherwise leave every checkbox stale.
   useDeepCompareEffect(() => {
     updateContent();
-  }, [selectedRow, selectedRows, selectionMode]);
+  }, [selectedRow, selectedRows, selectedIds, selectionMode]);
 
   const allData = useAvailableConstantsData();
   const { executeAction, useActionDynamicContext } = useConfigurableActionDispatcher();
@@ -715,6 +718,8 @@ export const DataList: FC<IDataListProps> = ({
       ? selectedIds.includes(item.id)
       : isDefined(selectedRow) && isSameRow(selectedRow.id, selectedRow.index, item.id, index);
 
+    const isSelectable = selectionMode === 'single' || selectionMode === 'multiple';
+
 
     const itemStyles: CSSProperties = {
       ...(stylesAsCSS),
@@ -738,33 +743,36 @@ export const DataList: FC<IDataListProps> = ({
     return (
       <div key={`row-${index}`} style={wrapperStyle}>
         <ConditionalWrap
-          condition={selectionMode === 'single' || selectionMode === 'multiple'}
-          wrap={(children) => selectionMode === 'single'
-            ? (
-              <Radio
-                className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}
-                checked={selected}
-                // Radio raises onChange only when it becomes checked, so clicking the already
-                // selected row would never deselect it. onClick fires either way, and antd's bubble
-                // lock keeps it to one call whether the click lands on the control or the row body.
-                onClick={() => {
-                  onSelectRowLocal(index, item);
-                }}
-              >
-                {children}
-              </Radio>
-            )
-            : (
-              <Checkbox
-                className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}
-                checked={selected}
-                onChange={() => {
-                  onSelectRowLocal(index, item);
-                }}
-              >
-                {children}
-              </Checkbox>
-            )}
+          condition={isSelectable}
+          // The selection control is a *sibling* of the row content, not its parent. Wrapping the
+          // content in antd's <label> made every click inside the row a label activation, which could
+          // only be suppressed with preventDefault - and that cancelled the default action of nested
+          // controls too, so checkboxes/radios/switches inside a row stopped toggling. Keeping them
+          // as siblings means there is nothing to suppress.
+          wrap={(children) => (
+            <div className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}>
+              {selectionMode === 'single'
+                ? (
+                  <Radio
+                    checked={selected}
+                    // Radio raises onChange only when it becomes checked, so clicking the already
+                    // selected row would never deselect it. onClick fires either way.
+                    onClick={() => {
+                      onSelectRowLocal(index, item);
+                    }}
+                  />
+                )
+                : (
+                  <Checkbox
+                    checked={selected}
+                    onChange={() => {
+                      onSelectRowLocal(index, item);
+                    }}
+                  />
+                )}
+              {children}
+            </div>
+          )}
         >
           <div
             className={classNames(
@@ -774,16 +782,15 @@ export const DataList: FC<IDataListProps> = ({
             onClick={(e) => {
               // Skip selection/click events when interacting with form fields (dropdown, picker, etc.)
               // or content rendered in portals — otherwise inline-editing clicks toggle row selection.
-              if (isInteractiveTarget(e.target)) {
-                // preventDefault is what actually suppresses the selection: this item is nested in the
-                // wrapping Checkbox's <label>, and label activation is a default action that
-                // stopPropagation does not cancel.
-                e.preventDefault();
-                e.stopPropagation();
-                return;
+              // Just bail out: the row is no longer nested in the control's <label>, so there is no
+              // default action to cancel and nested controls keep working normally.
+              if (isInteractiveTarget(e.target)) return;
+
+              // The control is a sibling now, so clicking the row body no longer activates it via the
+              // label - drive the selection explicitly to keep the whole row clickable.
+              if (isSelectable) {
+                onSelectRowLocal(index, item);
               }
-              // Selection itself is driven by the wrapping Checkbox's onChange in both single and
-              // multiple mode - calling onSelectRowLocal here as well would toggle twice and cancel out.
               if (onListItemClick) {
                 onListItemClick(index, item);
               }

--- a/shesha-reactjs/src/components/dataList/styles/styles.ts
+++ b/shesha-reactjs/src/components/dataList/styles/styles.ts
@@ -58,6 +58,14 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
                     flex-grow: 1;
                 }
             }
+
+            /* The row content is a sibling of the selection control now, not a child of its <label>,
+               so it is a div rather than antd's trailing <span> - make it take the remaining width. */
+            > .${shaDatalistComponentItem},
+            > .${shaDatalistCard} {
+                flex-grow: 1;
+                min-width: 0;
+            }
         }
     
         .${shaDatalistComponentDivider} {

--- a/shesha-reactjs/src/providers/configurationItemsLoader/configurationLoader.ts
+++ b/shesha-reactjs/src/providers/configurationItemsLoader/configurationLoader.ts
@@ -436,13 +436,16 @@ export class ConfigurationLoader implements IConfigurationLoader {
     const requests = this.getExistingRequests(type);
     const key = this.getExistingConfigRequestKey(id, topLevelModule);
     requests[key] = promise;
-    promise.catch((e) => {
+    // This handler exists only to evict the failed request from the cache - callers get the
+    // rejection from `promise` itself, which is what's stored and returned. Rethrowing here would
+    // reject the promise derived by `.catch()`, which nothing holds, so it surfaced as an unhandled
+    // rejection on every failed lookup.
+    promise.catch(() => {
       // schedule removal of current request from cache after 10 seconds
       setTimeout(() => {
         if (requests[key] === promise)
           requests[key] = undefined;
       }, 10000);
-      throw e;
     });
   };
 


### PR DESCRIPTION
This pull request includes several improvements and bug fixes across both backend and frontend components, focusing on safer entity deletion, improved error feedback in CRUD operations, and more robust row selection logic in the DataList component. Key themes include preventing unintended cascading deletes, making UI selection behavior more reliable (especially after sorting/filtering), and surfacing errors more clearly to users.

**Entity Deletion and Cascade Behavior:**
* Added logic in `EntityModelBinder.cs` to break parent-child associations before session flush when a child entity is hard-deleted, preventing NHibernate from attempting to re-save deleted objects due to lingering references.
* Introduced a migration to disable "cascade delete unreferenced" for specific entity relationships (`MembershipPayment.Member` and `Member.Bank`), avoiding unintended deletions and flush errors.

**DataList Row Selection Improvements:**
* Refactored row selection logic to prefer matching rows by `id` rather than index, ensuring correct selection even after sorting, filtering, or paging. This affects both single and multiple selection modes. [[1]](diffhunk://#diff-ca171826ac6fce502a08109ba93a077f0f87e961708ab00707a7fea60ddef967R85-R97) [[2]](diffhunk://#diff-ca171826ac6fce502a08109ba93a077f0f87e961708ab00707a7fea60ddef967L221-R238) [[3]](diffhunk://#diff-ca171826ac6fce502a08109ba93a077f0f87e961708ab00707a7fea60ddef967L690-R716)
* Updated the DataList UI to use a `Radio` button for single selection (in addition to `Checkbox` for multiple), and streamlined event handling to ensure consistent selection/deselection behavior and prevent double toggling. [[1]](diffhunk://#diff-ca171826ac6fce502a08109ba93a077f0f87e961708ab00707a7fea60ddef967L718-R757) [[2]](diffhunk://#diff-ca171826ac6fce502a08109ba93a077f0f87e961708ab00707a7fea60ddef967L738-R786)

**CRUD Error Feedback and Handling:**
* Enhanced CRUD action buttons to display validation and operation errors as notifications using Ant Design's notification system, ensuring users are explicitly informed when an operation fails. [[1]](diffhunk://#diff-58ab706cb748fe1180f3e6ae9719e936ba443be65400be78129b36542dfd9dddR3-R7) [[2]](diffhunk://#diff-58ab706cb748fe1180f3e6ae9719e936ba443be65400be78129b36542dfd9dddR29-R38) [[3]](diffhunk://#diff-58ab706cb748fe1180f3e6ae9719e936ba443be65400be78129b36542dfd9dddL36-R49) [[4]](diffhunk://#diff-58ab706cb748fe1180f3e6ae9719e936ba443be65400be78129b36542dfd9dddL45-R58) [[5]](diffhunk://#diff-58ab706cb748fe1180f3e6ae9719e936ba443be65400be78129b36542dfd9dddL56-R71)
* Improved error handling in configuration loader cache logic to avoid unhandled promise rejections on failed configuration lookups.

**Other DataList Enhancements:**
* Ensured that row data is available under both `item` and `data` keys in form ID expressions, improving compatibility and flexibility for custom logic.
* Added `Radio` import to support single-selection mode in DataList.

Related to issue: #5071 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion handling and parent-reference cleanup after successful child deletion.
  * Added clearer error notifications for create, update, reset, cancel, and delete actions.
  * Prevented unhandled errors during failed configuration requests.
  * Improved row selection reliability across sorting, filtering, and paging.

* **Enhancements**
  * Added radio-button selection for single-select lists and retained checkboxes for multi-select lists.
  * Form expressions now receive the current row data consistently.
  * Improved selected-row layout and content sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->