### PR TITLE
Lihlumise/fix/address

### DIFF
--- a/shesha-reactjs/src/components/googlePlacesAutocomplete/index.tsx
+++ b/shesha-reactjs/src/components/googlePlacesAutocomplete/index.tsx
@@ -32,8 +32,8 @@ interface ISuggestion {
   description: string;
 }
 
-/** antd `Input` props a caller may pass through; props owned by the component (value, onChange, onKeyDown, tabIndex, allowClear, etc.) are omitted so they cannot conflict. */
-export type GooglePlacesAutocompleteInputProps = Omit<InputProps, 'value' | 'onChange' | 'prefix' | 'disabled' | 'placeholder' | 'style' | 'size' | 'className' | 'onKeyDown' | 'tabIndex' | 'allowClear'>;
+/** antd `Input` props a caller may pass through; props owned by the component (value, onChange, tabIndex, allowClear, etc.) are omitted so they cannot conflict. `onKeyDown`, `onFocus` and `onBlur` are allowed: the component composes them with its own handlers rather than replacing them. */
+export type GooglePlacesAutocompleteInputProps = Omit<InputProps, 'value' | 'onChange' | 'prefix' | 'disabled' | 'placeholder' | 'style' | 'size' | 'className' | 'tabIndex' | 'allowClear'>;
 
 export interface IGooglePlacesAutocompleteProps {
   disableGoogleEvent?: ((value: string) => boolean) | undefined;
@@ -255,9 +255,15 @@ const GooglePlacesAutocomplete: FC<IGooglePlacesAutocompleteProps> = ({
                 disabled={disabled ?? false}
                 readOnly={readOnly ?? false}
                 tabIndex={tabIndex}
+                // Composed rather than assigned, so a handler supplied through `inputProps`
+                // (the standard event set) is not silently dropped by the dedicated prop.
                 // Arrow-key navigation of the suggestions is pointless when nothing can be
-                // selected, so key handling is skipped entirely while read-only.
-                onKeyDown={readOnly === true ? undefined : onKeyDown}
+                // selected, so the internal half is skipped while read-only — the caller's half
+                // still runs, since a read-only field can legitimately react to key presses.
+                onKeyDown={(e) => {
+                  if (readOnly !== true) onKeyDown(e);
+                  extraInputProps?.onKeyDown?.(e);
+                }}
                 // Closing the suggestions dropdown is this component's own concern, so a
                 // caller-supplied onBlur is composed with it rather than replacing it.
                 onBlur={(e) => {

--- a/shesha-reactjs/src/components/googlePlacesAutocomplete/index.tsx
+++ b/shesha-reactjs/src/components/googlePlacesAutocomplete/index.tsx
@@ -276,10 +276,12 @@ const GooglePlacesAutocomplete: FC<IGooglePlacesAutocompleteProps> = ({
             );
           })()}
           {/* The dropdown stays hidden in both non-editable states — a suggestion list the user
-              cannot act on would otherwise cover the surrounding form. */}
+              cannot act on would otherwise cover the surrounding form — and while there is nothing
+              to suggest. The container carries the configured background, border and padding, so an
+              empty one is not invisible: it paints as a stray box under the input. */}
           <div
             className={classNames(styles.dropdownContainer, {
-              hidden: !showSuggestionsDropdownContainer || disabled === true || readOnly === true,
+              hidden: suggestions.length === 0 || !showSuggestionsDropdownContainer || disabled === true || readOnly === true,
             })}
           >
             {suggestions.map((suggestion) => {

--- a/shesha-reactjs/src/designer-components/address/index.tsx
+++ b/shesha-reactjs/src/designer-components/address/index.tsx
@@ -12,7 +12,7 @@ import { getSettings } from './formSettings';
 import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
 import { migratePrevStyles } from '../_common-migrations/migrateStyles';
 import { migratePermissionsToVisiblePermissions } from '../_common-migrations/migratePermissionsToVisiblePermissions';
-import { defaultStyles } from './utils';
+import { defaultStyles, getAddressValue } from './utils';
 import { useStyles } from './styles';
 import { isIAddressAndCoords } from '@/components/googlePlacesAutocomplete';
 import { DataTypes } from '@/interfaces/dataTypes';
@@ -62,7 +62,7 @@ const AddressCompoment: AddressComponentDefinition = {
           return model.readOnly === true
             ? (
               <ReadOnlyDisplayFormItem
-                value={value}
+                value={getAddressValue(value)}
                 enableFullStyle={model.enableStyleOnReadonly}
                 styleValue={styleValue}
                 // The Custom style, so read-only matches the editable control. It lands inline on

--- a/shesha-reactjs/src/designer-components/address/utils.ts
+++ b/shesha-reactjs/src/designer-components/address/utils.ts
@@ -8,7 +8,7 @@ import { getDisplayNameOrUndefined } from '@/utils/object';
 /** Google's Places API accepts at most 5 entries in `componentRestrictions.country`. */
 const MAX_COUNTRY_RESTRICTIONS = 5;
 
-export const getAddressValue = (value: string | IEntityReferenceDto | undefined): string => {
+export const getAddressValue = (value: string | IEntityReferenceDto | null | undefined): string => {
   if (!isDefined(value)) return '';
 
   return typeof value === "string"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in the Google Places autocomplete field while preserving custom key actions.
  * Prevented the suggestions dropdown from appearing when no suggestions are available.
  * Improved read-only address display for empty or missing values.
  * Added support for displaying address fields with null values without showing unwanted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->