### PR TITLE
Hide the date field UTC conversion switch where it cannot apply

### DIFF
--- a/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
@@ -70,6 +70,16 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
   const isDateTimeJs = 'return ["dateTimeHours", "dateTimeMinutes", "dateTimeSeconds"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
   // Minute steps only make sense once minutes are actually shown.
   const hasMinutesJs = 'return ["dateTimeMinutes", "dateTimeSeconds"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
+  // Converting to/from UTC only means anything when a time of day is stored and the value is
+  // actually persisted as UTC — a calendar unit (week/month/quarter/year) or a bare date would just
+  // be shifted across a day boundary by the conversion.
+  const isUtcConvertibleJs = [
+    // Mirrors getBindingFormat(): pre-migration markup carries the old boolean and no Binding Format,
+    // and hiding the switch there would strand a setting that is still driving the behaviour.
+    'var bindingFormat = getSettingValue(data?.bindingFormat) ?? (getSettingValue(data?.resolveToUTC) === true ? "utc" : "isoLocal");',
+    'return bindingFormat === "utc"',
+    '  && ["dateTimeHours", "dateTimeMinutes", "dateTimeSeconds"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");',
+  ].join('\r\n');
   // Date Format applies to every selection except the calendar-unit pickers, which have their own.
   const isDateBasedJs = 'return !["week", "month", "quarter", "year"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
   // Inverse of the above: hides the whole row rather than leaving an empty one behind when only the
@@ -133,7 +143,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                   dropdownOptions: minuteStepOptions,
                   visibleJs: hasMinutesJs,
                 })
-                .addSettingsInput({ inputType: 'switch', propertyName: 'resolveToUTC', label: 'Convert to/from UTC', size: 'small', layout: 'horizontal', jsSetting: true })
+                .addSettingsInput({ inputType: 'switch', propertyName: 'resolveToUTC', label: 'Convert to/from UTC', size: 'small', layout: 'horizontal', jsSetting: true, visibleJs: isUtcConvertibleJs })
                 .addSettingsInput({ inputType: 'switch', propertyName: 'defaultToMidnight', label: 'Default time to midnight', size: 'small', layout: 'horizontal', jsSetting: true, visibleJs: isDateTimeJs })
                 .addSettingsInput({
                   inputType: 'dropdown', propertyName: 'dateRestriction', label: 'Date Restriction', size: 'small', jsSetting: true,

--- a/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dateField/settingsForm.ts
@@ -73,13 +73,10 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
   // Converting to/from UTC only means anything when a time of day is stored and the value is
   // actually persisted as UTC — a calendar unit (week/month/quarter/year) or a bare date would just
   // be shifted across a day boundary by the conversion.
-  const isUtcConvertibleJs = [
-    // Mirrors getBindingFormat(): pre-migration markup carries the old boolean and no Binding Format,
-    // and hiding the switch there would strand a setting that is still driving the behaviour.
-    'var bindingFormat = getSettingValue(data?.bindingFormat) ?? (getSettingValue(data?.resolveToUTC) === true ? "utc" : "isoLocal");',
-    'return bindingFormat === "utc"',
-    '  && ["dateTimeHours", "dateTimeMinutes", "dateTimeSeconds"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");',
-  ].join('\r\n');
+  // Deliberately reads only bindingFormat, never resolveToUTC: a switch whose visibility depends on
+  // its own value can be switched off but never back on. Migrator step 8 always writes bindingFormat,
+  // so there is no saved markup where the old boolean is the only thing left to read.
+  const isUtcConvertibleJs = 'return getSettingValue(data?.bindingFormat) === "utc" && ["dateTimeHours", "dateTimeMinutes", "dateTimeSeconds"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
   // Date Format applies to every selection except the calendar-unit pickers, which have their own.
   const isDateBasedJs = 'return !["week", "month", "quarter", "year"].includes(getSettingValue(data?.selectionType) ?? "dateTimeMinutes");';
   // Inverse of the above: hides the whole row rather than leaving an empty one behind when only the


### PR DESCRIPTION
Convert to/from UTC was always shown, even for selections it has no effect on. It now appears only when the value is actually persisted as UTC and the selection carries a time of day.

The binding format check mirrors getBindingFormat() rather than reading bindingFormat directly, so markup that still carries only the legacy resolveToUTC boolean keeps the switch visible instead of stranding the setting that is driving its behaviour. Week, month, quarter, year and bare date selections are excluded because a conversion there can only shift the value across a day boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the UTC conversion setting visibility so it appears only when the binding format is set to UTC and the selected type includes a time component.
  * Preserved existing UTC conversion behavior when no binding format is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->