### PR TITLE
fix: stop auto-format applying to non-text text field types

### DIFF
--- a/shesha-reactjs/src/designer-components/textField/textField.tsx
+++ b/shesha-reactjs/src/designer-components/textField/textField.tsx
@@ -81,9 +81,11 @@ const TextFieldComponent: TextFieldComponentDefinition = {
     const passwordComplexity = usePasswordComplexitySettings();
     const formatConfig = isDefined(model.textType) ? TEXT_TYPE_FORMATS[model.textType] : undefined;
 
+    // Auto-format is only configurable for the 'text' type, so ignore any leftover
+    // formatting settings when the type has been switched to email/url/phone/password.
     const formatGroupLengths = useMemo(
-      () => model.enableFormatting === true ? parseGroupLengths(model.formatGroups) : [],
-      [model.enableFormatting, model.formatGroups],
+      () => model.textType === 'text' && model.enableFormatting === true ? parseGroupLengths(model.formatGroups) : [],
+      [model.textType, model.enableFormatting, model.formatGroups],
     );
     const formatSeparator = model.formatSeparator ?? '-';
 


### PR DESCRIPTION
The Auto-format settings panel is only shown when the text field's Type is Text, but the component read enableFormatting and formatGroups regardless of the selected type. Configuring auto-format as Text and then switching to Email, URL, Phone Number or Password left the separator display and the group length clamp active with no way to see or turn them off in the designer.

Gate the group lengths on textType === 'text', matching how the equally text-only Regular expression setting already guards itself. The saved auto-format values are kept, so switching back to Text restores them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Formatting length settings are now applied only to text fields.
  * Email, URL, phone, and password fields no longer inherit leftover formatting settings after switching field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->