### PR TITLE
migrate empty static loader endpoint

### DIFF
--- a/shesha-reactjs/src/designer-components/_common-migrations/migrateEmptyStaticLoaderEndpoint.ts
+++ b/shesha-reactjs/src/designer-components/_common-migrations/migrateEmptyStaticLoaderEndpoint.ts
@@ -1,0 +1,36 @@
+import { IFormSettings } from "@/interfaces";
+import { GqlLoaderSettings, isGqlLoaderSettings } from "@/providers/form/loaders/interfaces";
+import { isNullOrWhiteSpace } from "@/utils/nullables";
+
+/**
+ * Repairs form settings that were saved with a `static` loader endpoint but no endpoint url.
+ *
+ * The lifecycle migration used to assign `endpointType: 'static'` when the legacy `getUrl` was
+ * empty (the condition was inverted), so forms migrated in that period were persisted as
+ * `Custom: static` with an undefined `staticEndpoint`. Such a form has no read endpoint at all,
+ * and a valid static configuration always carries a url, so it's safe to restore the default.
+ */
+export const migrateEmptyStaticLoaderEndpoint = (prev: IFormSettings): IFormSettings => {
+  const { dataLoadersSettings, ...restProps } = prev;
+  const gql = dataLoadersSettings?.['gql'];
+  if (!isGqlLoaderSettings(gql))
+    return prev;
+
+  const isBroken = gql.endpointType === 'static' && isNullOrWhiteSpace(gql.staticEndpoint?.url);
+  if (!isBroken)
+    return prev;
+
+  const gqlLoaderSettings: GqlLoaderSettings = {
+    ...gql,
+    endpointType: 'default',
+    staticEndpoint: undefined,
+  };
+
+  return {
+    ...restProps,
+    dataLoadersSettings: {
+      ...dataLoadersSettings,
+      gql: gqlLoaderSettings,
+    },
+  };
+};

--- a/shesha-reactjs/src/designer-components/_common-migrations/migrateFormLifecycle.ts
+++ b/shesha-reactjs/src/designer-components/_common-migrations/migrateFormLifecycle.ts
@@ -125,7 +125,7 @@ export const migrateFormLifecycle = (settings: IFormSettings): IFormSettings => 
   const gqlLoaderSettings: GqlLoaderSettings = {
     // url: getUrl,
     fieldsToFetch,
-    endpointType: isNullOrWhiteSpace(getUrl) ? 'static' : 'default',
+    endpointType: isNullOrWhiteSpace(getUrl) ? 'default' : 'static',
     staticEndpoint: !isNullOrWhiteSpace(getUrl) ? { httpVerb: 'get', url: getUrl } : undefined,
   };
 

--- a/shesha-reactjs/src/providers/form/loaders/formDataLoadersProvider.tsx
+++ b/shesha-reactjs/src/providers/form/loaders/formDataLoadersProvider.tsx
@@ -15,7 +15,7 @@ export const FormDataLoadersProvider: FC<PropsWithChildren> = ({ children }) => 
   const gqlLoader = useGqlLoader();
   const [customLoader] = useState(() => new CustomLoader());
 
-  const getFormDataLoader = (type: string): IFormDataLoader | undefined => {
+  const getFormDataLoader = (type: string): IFormDataLoader | undefined => {  
     switch (type) {
       case 'gql':
         return gqlLoader;

--- a/shesha-reactjs/src/providers/form/loaders/formDataLoadersProvider.tsx
+++ b/shesha-reactjs/src/providers/form/loaders/formDataLoadersProvider.tsx
@@ -15,7 +15,7 @@ export const FormDataLoadersProvider: FC<PropsWithChildren> = ({ children }) => 
   const gqlLoader = useGqlLoader();
   const [customLoader] = useState(() => new CustomLoader());
 
-  const getFormDataLoader = (type: string): IFormDataLoader | undefined => {  
+  const getFormDataLoader = (type: string): IFormDataLoader | undefined => {
     switch (type) {
       case 'gql':
         return gqlLoader;

--- a/shesha-reactjs/src/providers/form/migration/formSettingsMigrations.ts
+++ b/shesha-reactjs/src/providers/form/migration/formSettingsMigrations.ts
@@ -5,6 +5,7 @@ import { migrateDefaults, migrateFormLifecycle } from "@/designer-components/_co
 import { migrateDefaultApiEndpoints } from "@/designer-components/_common-migrations/migrateDefaultApiEndpoints";
 import { migrateFieldsToFetchAndOnDataLoad } from "@/designer-components/_common-migrations/migrateFieldsToFetchAndOnDataLoad";
 import { migrateGqlCustomEndpoint } from "@/designer-components/_common-migrations/migrateGqlCustomEndpoint";
+import { migrateEmptyStaticLoaderEndpoint } from "@/designer-components/_common-migrations/migrateEmptyStaticLoaderEndpoint";
 import { IToolboxComponents } from "@/interfaces";
 import { IFormMigrationContext } from "@/designer-components/_common-migrations/models";
 import { isDefined, isNullOrWhiteSpace } from "@/utils/nullables";
@@ -31,6 +32,7 @@ const formSettingsMigrations = (migrator: Migrator<IFormSettings, IFormSettings,
       labelCol: isDefined(prev.labelCol) ? prev.labelCol : { span: 6 },
       wrapperCol: isDefined(prev.wrapperCol) ? prev.wrapperCol : { span: 18 },
     }))
+    .add(9, (prev) => migrateEmptyStaticLoaderEndpoint(prev))
   ;
 
 export const migrateFormSettings = (form: IFormDto, designerComponents: IToolboxComponents): Omit<IFormDto, 'settings'> & { settings: IFormSettings } => {


### PR DESCRIPTION
#5338 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected form data loader endpoint selection for forms with and without configured URLs.
  * Automatically repairs affected forms with an empty static loader endpoint by restoring the default endpoint.
  * Applies the repair during form settings migration so existing configurations are updated seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->