### PR TITLE
Lihlumise/fix/dropdown tag variant

### DIFF
--- a/shesha-reactjs/src/components/dropdown/dropdown.tsx
+++ b/shesha-reactjs/src/components/dropdown/dropdown.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { CSSProperties, FC, ReactNode, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
 import { executeExpression } from '@/providers/form/utils';
 import { IDropdownProps, ILabelValue } from './model';
@@ -275,6 +275,13 @@ export const Dropdown: FC<IDropdownProps> = ({
     );
   }
 
+  /* A single-select tag hugs its content, but only on axes Dimensions leaves unset: `useStyles`
+     emits those as CSS, and an inline value would beat them and collapse a 100%-wide dropdown. */
+  const tagFitStyle: CSSProperties = {
+    ...(isDefined(styleValue?.dimensions?.width) ? {} : { width: 'max-content' }),
+    ...(isDefined(styleValue?.dimensions?.height) ? {} : { height: 'max-content' }),
+  };
+
   if (mode !== 'multiple' && mode !== 'tags' && displayStyle === 'tags') {
     return (
       <Select
@@ -291,7 +298,7 @@ export const Dropdown: FC<IDropdownProps> = ({
         placeholder={placeholder}
         size={size}
         popupMatchSelectWidth={false}
-        style={{ width: 'max-content', height: 'max-content' }}
+        style={{ ...tagFitStyle, ...style }}
         labelRender={(props) => {
           const option = options.find((o) => o.value === props.value);
           return option

--- a/shesha-reactjs/src/components/dropdown/dropdown.tsx
+++ b/shesha-reactjs/src/components/dropdown/dropdown.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, FC, ReactNode, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { FC, ReactNode, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
 import { executeExpression } from '@/providers/form/utils';
 import { IDropdownProps, ILabelValue } from './model';
@@ -275,13 +275,6 @@ export const Dropdown: FC<IDropdownProps> = ({
     );
   }
 
-  /* A single-select tag hugs its content, but only on axes Dimensions leaves unset: `useStyles`
-     emits those as CSS, and an inline value would beat them and collapse a 100%-wide dropdown. */
-  const tagFitStyle: CSSProperties = {
-    ...(isDefined(styleValue?.dimensions?.width) ? {} : { width: 'max-content' }),
-    ...(isDefined(styleValue?.dimensions?.height) ? {} : { height: 'max-content' }),
-  };
-
   if (mode !== 'multiple' && mode !== 'tags' && displayStyle === 'tags') {
     return (
       <Select
@@ -298,7 +291,7 @@ export const Dropdown: FC<IDropdownProps> = ({
         placeholder={placeholder}
         size={size}
         popupMatchSelectWidth={false}
-        style={{ ...tagFitStyle, ...style }}
+        {...(style ? { style } : {})}
         labelRender={(props) => {
           const option = options.find((o) => o.value === props.value);
           return option

--- a/shesha-reactjs/src/components/dropdown/styles.ts
+++ b/shesha-reactjs/src/components/dropdown/styles.ts
@@ -83,6 +83,14 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
         ${isDefined(model.dimensions?.height) ? '' : 'height: 100%;'}
       }
 
+      /* A single-select tag hugs its content, on the axes Dimensions leaves unset. Scoped by antd's
+         own single-select class so the mode does not have to be recomputed here. */
+      ${model.displayStyle === 'tags' ? `
+      &&&.${prefixCls}-select-single {
+        ${isDefined(model.dimensions?.width) ? '' : 'width: max-content;'}
+        ${isDefined(model.dimensions?.height) ? '' : 'height: max-content;'}
+      }` : ''}
+
       /* The visible box is the selector element, not the root. A rule scoped to select-content
          matches nothing: that is a semantic classNames slot, emitted only when a caller passes
          classNames.content, which this component never does. */

--- a/shesha-reactjs/src/components/dropdown/styles.ts
+++ b/shesha-reactjs/src/components/dropdown/styles.ts
@@ -2,6 +2,7 @@ import { createStyles } from '@/styles';
 import { IDropdownComponentProps } from '@/designer-components/dropdown/model';
 import { backgroundStyles, borderRadiusStyles, borderStyles, cssPropertiesToString, dimensionsStyles, fontStyles, marginStyles, paddingStyles, popupAppearanceStyles, shadowStyles, splitBackgroundProperties } from '@/designer-components/_common/styles/utils';
 import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
+import { addPx } from '@/utils/style';
 import { CSSProperties } from 'react';
 
 /**
@@ -62,11 +63,22 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
     .map((colour) => `:not(.${prefixCls}-tag-${colour})`)
     .join('')}`;
 
-  /* Only Filled is borderless. Outlined's border *is* the variant, so it keeps both antd's border
-     and the configured one; Solid draws its own transparent border and likewise keeps it. */
+  /* Only Filled is borderless. Outlined's border *is* the variant, so selecting it draws a line
+     without the Border panel being filled in; Solid keeps whatever the panel configured. */
   const tagVariant = model.tagVariant ?? 'solid';
   const hidesBorder = tagVariant === 'filled';
-  const configuredTagBorder = hidesBorder ? '' : borderStyles(tag?.border);
+  /* Written from the parts rather than through `borderStyles`, whose `border` shorthand collapses an
+     unset width or style to `0px none` — so setting only a colour used to erase the line. */
+  const outlinedLine = tag?.border?.border?.all;
+  const outlinedTagBorder = `
+    border-width: ${addPx(outlinedLine?.width) ?? `${token.lineWidth}px`};
+    border-style: ${isNullOrWhiteSpace(outlinedLine?.style) ? 'solid' : outlinedLine.style};
+    ${isNullOrWhiteSpace(outlinedLine?.color) ? '' : `border-color: ${outlinedLine.color};`}
+    ${borderRadiusStyles(tag?.border)}
+  `;
+  const configuredTagBorder = hidesBorder
+    ? ''
+    : tagVariant === 'outlined' ? outlinedTagBorder : borderStyles(tag?.border);
 
   /* The Font colour is split out for the same reason the background is: emitted at `&&&&` it beats
      the colour each Variant paints. The rest of the font is unrelated and stays on the base rule. */

--- a/shesha-reactjs/src/components/dropdown/styles.ts
+++ b/shesha-reactjs/src/components/dropdown/styles.ts
@@ -1,7 +1,7 @@
 import { createStyles } from '@/styles';
 import { IDropdownComponentProps } from '@/designer-components/dropdown/model';
 import { backgroundStyles, borderRadiusStyles, borderStyles, cssPropertiesToString, dimensionsStyles, fontStyles, marginStyles, paddingStyles, popupAppearanceStyles, shadowStyles, splitBackgroundProperties } from '@/designer-components/_common/styles/utils';
-import { isDefined } from '@/utils/nullables';
+import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 import { CSSProperties } from 'react';
 
 /**
@@ -62,11 +62,16 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
     .map((colour) => `:not(.${prefixCls}-tag-${colour})`)
     .join('')}`;
 
-  /* Filled and Outlined are borderless variants, so the configured Border is not emitted for them
-     and any border antd would otherwise draw is removed below. Solid keeps the configured border. */
+  /* Only Filled is borderless. Outlined's border *is* the variant, so it keeps both antd's border
+     and the configured one; Solid draws its own transparent border and likewise keeps it. */
   const tagVariant = model.tagVariant ?? 'solid';
-  const hidesBorder = tagVariant === 'filled' || tagVariant === 'outlined';
+  const hidesBorder = tagVariant === 'filled';
   const configuredTagBorder = hidesBorder ? '' : borderStyles(tag?.border);
+
+  /* The Font colour is split out for the same reason the background is: emitted at `&&&&` it beats
+     the colour each Variant paints. The rest of the font is unrelated and stays on the base rule. */
+  const tagFontWithoutColour = fontStyles(isDefined(tag?.font) ? { ...tag.font, color: undefined } : undefined);
+  const tagFontColour = isNullOrWhiteSpace(tag?.font?.color) ? '' : `color: ${tag.font.color};`;
 
   const dropdown = cx('sha-dropdown', css`
       ${marginStyles(model.stylingBoxJson)}
@@ -131,6 +136,9 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
       }
 
       &&&& .${prefixCls}-tag {
+        /* .ant-select-selection-item zeroes --ant-line-width, and custom properties inherit — so
+           without restoring it the tag's own border resolves to 0 and Outlined looks like Filled. */
+        --ant-line-width: ${token.lineWidth}px;
         display: inline-flex;
         align-items: center;
         overflow: hidden;
@@ -140,15 +148,15 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
         ${shadowStyles(tag?.shadow)}
         ${dimensionsStyles(tag?.dimensions)}
         ${paddingStyles(tag?.stylingBoxJson)}
-        ${fontStyles(tag?.font)}
+        ${tagFontWithoutColour}
         ${marginStyles(tag?.stylingBoxJson)}
         ${cssPropertiesToString(tagCustomStyle.rest)}
 
-        /* The label and icon inside the tag carry their own font rules, so the configured font has
-           to be restated here or the tag box resizes without its text following. */
+        /* Restated or the tag box resizes without its text following. Colour is left off so the
+           label keeps inheriting whichever colour won on the tag itself. */
         .anticon,
         span {
-          ${fontStyles(tag?.font)}
+          ${tagFontWithoutColour}
         }
       }
 
@@ -158,13 +166,13 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
          overwrite it. */
       &&&& ${tagColourSelector} {
         ${configuredTagBorder}
+        ${tagFontColour}
         ${backgroundStyles(tag?.background)}
         ${cssPropertiesToString(tagCustomStyle.background)}
       }
 
-      /* Filled and Outlined are borderless by intent, so the tag shows no border regardless of the
-         option colour. (For a colour-carrying tag antd sets its own borderColor on outlined and
-         solid but none on filled, so without this the base border would leak through on filled.) */
+      /* Filled is borderless by intent. antd sets no borderColor for it, so without this the base
+         border would leak through regardless of the option colour. */
       ${hidesBorder ? `
       &&&& .${prefixCls}-tag {
         border: none;

--- a/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
+++ b/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
@@ -1,7 +1,7 @@
 import { Empty, Select, SelectProps, Spin } from 'antd';
 import { ValidationErrors } from '@/components/validationErrors';
 import { useReferenceList } from '@/providers/referenceListDispatcher';
-import { CSSProperties, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 import { ReferenceListItemDto } from '@/apis/referenceList';
 import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
@@ -162,20 +162,13 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
     value: wrapValue(value, options),
   };
 
-  /* A single-select tag hugs its content, but only on axes Dimensions leaves unset: `useStyles`
-     emits those as CSS, and an inline value would beat them and collapse a 100%-wide dropdown. */
-  const tagFitStyle: CSSProperties = {
-    ...(isDefined(styleValue?.dimensions?.width) ? {} : { width: 'max-content' }),
-    ...(isDefined(styleValue?.dimensions?.height) ? {} : { height: 'max-content' }),
-  };
-
   if (mode !== 'multiple' && mode !== 'tags' && displayStyle === 'tags') {
     return (
       <Select<CustomLabeledValue<TValue> | CustomLabeledValue<TValue>[]>
         ref={selectRef}
         {...commonSelectProps}
         popupMatchSelectWidth={false}
-        style={{ ...tagFitStyle, ...style }}
+        {...(style ? { style } : {})}
         placeholder={placeholder}
         labelRender={(props) => {
           const option = options.find((o) => o.value === props.value);

--- a/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
+++ b/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
@@ -1,7 +1,7 @@
 import { Empty, Select, SelectProps, Spin } from 'antd';
 import { ValidationErrors } from '@/components/validationErrors';
 import { useReferenceList } from '@/providers/referenceListDispatcher';
-import { useCallback, useMemo } from 'react';
+import { CSSProperties, useCallback, useMemo } from 'react';
 import * as React from 'react';
 import { ReferenceListItemDto } from '@/apis/referenceList';
 import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
@@ -162,13 +162,20 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
     value: wrapValue(value, options),
   };
 
+  /* A single-select tag hugs its content, but only on axes Dimensions leaves unset: `useStyles`
+     emits those as CSS, and an inline value would beat them and collapse a 100%-wide dropdown. */
+  const tagFitStyle: CSSProperties = {
+    ...(isDefined(styleValue?.dimensions?.width) ? {} : { width: 'max-content' }),
+    ...(isDefined(styleValue?.dimensions?.height) ? {} : { height: 'max-content' }),
+  };
+
   if (mode !== 'multiple' && mode !== 'tags' && displayStyle === 'tags') {
     return (
       <Select<CustomLabeledValue<TValue> | CustomLabeledValue<TValue>[]>
         ref={selectRef}
         {...commonSelectProps}
         popupMatchSelectWidth={false}
-        style={{ width: 'max-content', height: 'max-content' }}
+        style={{ ...tagFitStyle, ...style }}
         placeholder={placeholder}
         labelRender={(props) => {
           const option = options.find((o) => o.value === props.value);

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -17,7 +17,7 @@ import { Dropdown } from '@/components/dropdown/dropdown';
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { getSettings } from './settingsForm';
 import { migratePrevStyles, migrateStyles } from '../_common-migrations/migrateStyles';
-import { defaultStyles, defaultTagStyles } from './utils';
+import { defaultStyles, defaultTagStyles, SEEDED_TAG_BACKGROUND, SEEDED_TAG_BORDER, SEEDED_TAG_FONT_COLOUR } from './utils';
 import { useStyles } from '@/components/dropdown/styles';
 import { getBooleanPropertyOrUndefined } from '@/utils/object';
 import { isDefined, isNotNullOrWhiteSpace, isNullOrWhiteSpace } from '@/utils/nullables';
@@ -28,11 +28,6 @@ import { useActualContextExecution } from '@/hooks/formComponentHooks';
 import { ALL_INPUT_EVENTS_WITHOUT_CHANGE_AND_DOUBLE_CLICK, getComponentEvents } from '../_common/events';
 
 import apiCode from "../../componentsApi/componentApi.ts?raw";
-
-/* The colours step 10 seeded into `tag` before the Variant owned them. Migration 15 clears these. */
-const SEEDED_TAG_BACKGROUND = '#f0f0f0';
-const SEEDED_TAG_BORDER = { width: '1px', style: 'solid', color: '#d9d9d9' };
-const SEEDED_TAG_FONT_COLOUR = '#000';
 
 const DropdownComponent: DropdownComponentDefinition = {
   allowInherit: true,

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -29,6 +29,11 @@ import { ALL_INPUT_EVENTS_WITHOUT_CHANGE_AND_DOUBLE_CLICK, getComponentEvents } 
 
 import apiCode from "../../componentsApi/componentApi.ts?raw";
 
+/* The colours step 10 seeded into `tag` before the Variant owned them. Migration 15 clears these. */
+const SEEDED_TAG_BACKGROUND = '#f0f0f0';
+const SEEDED_TAG_BORDER = { width: '1px', style: 'solid', color: '#d9d9d9' } as const;
+const SEEDED_TAG_FONT_COLOUR = '#000';
+
 const DropdownComponent: DropdownComponentDefinition = {
   allowInherit: true,
   type: 'dropdown',
@@ -225,6 +230,49 @@ const DropdownComponent: DropdownComponentDefinition = {
       model.tagVariant = prev.tagVariant ?? (prev.solidColor === false ? 'outlined' : 'solid');
 
       return model;
+    })
+    /* Step 10 seeded tag colours that beat antd's Variant rules, and saved forms still carry them.
+       Only values still equal to those seeds are cleared — a restyled tag keeps what the user set. */
+    .add<IDropdownComponentProps>(15, (prev) => {
+      const clearSeededTagColours = (style: IStyleValue | undefined): IStyleValue | undefined => {
+        if (!isDefined(style)) return style;
+
+        const result: IStyleValue = { ...style };
+
+        if (result.background?.type === 'color' && result.background.color === SEEDED_TAG_BACKGROUND)
+          result.background = { ...result.background, color: '' };
+
+        const sides = result.border?.border;
+        const line = sides?.all;
+        if (isDefined(sides) && isDefined(line) && line.width === SEEDED_TAG_BORDER.width && line.style === SEEDED_TAG_BORDER.style && line.color === SEEDED_TAG_BORDER.color) {
+          const { all: _cleared, ...otherSides } = sides;
+          result.border = { ...result.border, border: otherSides };
+        }
+
+        if (result.font?.color === SEEDED_TAG_FONT_COLOUR) {
+          const { color: _cleared, ...otherFont } = result.font;
+          result.font = otherFont;
+        }
+
+        return result;
+      };
+
+      // The per-device models nest their own `tag` set, the same shape step 10 seeded.
+      const clearDeviceTagColours = (device: IStyleValue | undefined): IStyleValue | undefined => {
+        if (!isDefined(device)) return device;
+        const nested = device as INestedStyleValue<'tag'>;
+        return isDefined(nested.tag)
+          ? { ...nested, tag: clearSeededTagColours(nested.tag) } as IStyleValue
+          : device;
+      };
+
+      return {
+        ...prev,
+        tag: clearSeededTagColours(prev.tag),
+        desktop: clearDeviceTagColours(prev.desktop),
+        tablet: clearDeviceTagColours(prev.tablet),
+        mobile: clearDeviceTagColours(prev.mobile),
+      };
     }),
   settingsFormMarkup: getSettings,
 

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -233,7 +233,9 @@ const DropdownComponent: DropdownComponentDefinition = {
     })
     /* Step 10 seeded tag colours that beat antd's Variant rules, and saved forms still carry them.
        Only values still equal to those seeds are cleared — a restyled tag keeps what the user set. */
-    .add<IDropdownComponentProps>(15, (prev) => {
+    .add<IDropdownComponentProps>(15, (prev, context) => {
+      if (context.isNew === true) return prev;
+
       const clearSeededTagColours = (style: IStyleValue | undefined): IStyleValue | undefined => {
         if (!isDefined(style)) return style;
 

--- a/shesha-reactjs/src/designer-components/dropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/dropdown/index.tsx
@@ -31,7 +31,7 @@ import apiCode from "../../componentsApi/componentApi.ts?raw";
 
 /* The colours step 10 seeded into `tag` before the Variant owned them. Migration 15 clears these. */
 const SEEDED_TAG_BACKGROUND = '#f0f0f0';
-const SEEDED_TAG_BORDER = { width: '1px', style: 'solid', color: '#d9d9d9' } as const;
+const SEEDED_TAG_BORDER = { width: '1px', style: 'solid', color: '#d9d9d9' };
 const SEEDED_TAG_FONT_COLOUR = '#000';
 
 const DropdownComponent: DropdownComponentDefinition = {
@@ -171,8 +171,8 @@ const DropdownComponent: DropdownComponentDefinition = {
       const initTagStyle = migrateStyles({}, defaultTagStyles());
       // The per-device style models are typed as the flat `IStyleValue`; the dropdown additionally
       // nests a `tag` set under each of them.
-      const deviceTag = (device: IStyleValue | undefined): IStyleValue | undefined =>
-        (device as INestedStyleValue<'tag'> | undefined)?.tag;
+      const deviceTag = (device: INestedStyleValue<'tag'> | undefined): IStyleValue | undefined =>
+        device?.tag;
 
       // Seeded only where nothing is configured yet — a form that already styled its tags keeps
       // those values rather than being reset to the defaults on every upgrade.
@@ -258,12 +258,9 @@ const DropdownComponent: DropdownComponentDefinition = {
       };
 
       // The per-device models nest their own `tag` set, the same shape step 10 seeded.
-      const clearDeviceTagColours = (device: IStyleValue | undefined): IStyleValue | undefined => {
-        if (!isDefined(device)) return device;
-        const nested = device as INestedStyleValue<'tag'>;
-        return isDefined(nested.tag)
-          ? { ...nested, tag: clearSeededTagColours(nested.tag) } as IStyleValue
-          : device;
+      const clearDeviceTagColours = (device: INestedStyleValue<'tag'> | undefined): INestedStyleValue<'tag'> | undefined => {
+        if (!isDefined(device) || !isDefined(device.tag)) return device;
+        return { ...device, tag: clearSeededTagColours(device.tag) };
       };
 
       return {

--- a/shesha-reactjs/src/designer-components/dropdown/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dropdown/settingsForm.ts
@@ -151,6 +151,9 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                         .stdMarginPaddingPanel('tag.stylingBoxJson')
                         .stdCustomStylePanel('tag.style'),
                       true,
+                      /* Plain text hands antd the raw label, so nothing in this panel reaches the
+                         DOM — hidden rather than left inert, like Show Item Name / Show Icon. */
+                      tagsVisibleJs,
                       )
                       .toJson()],
                 })

--- a/shesha-reactjs/src/designer-components/dropdown/utils.ts
+++ b/shesha-reactjs/src/designer-components/dropdown/utils.ts
@@ -86,24 +86,21 @@ export const defaultStyles = (): INestedStyleValue<'tag'> => {
   };
 };
 
+/**
+ * The colour-bearing slots are left empty so the Variant decides them — seeded, they are emitted at
+ * `&&&&` and beat antd's variant rules. `border` drops `all` for the same reason: `borderLinesStyles`
+ * emits a border for any present `all`, so even an empty one erases the Variant's border.
+ */
 export const defaultTagStyles = (): IStyleValue => {
   return {
-    background: BACKGROUND_DEFAULTS('#f0f0f0'),
+    background: BACKGROUND_DEFAULTS(''),
     font: {
       weight: '400',
       size: 14,
-      color: '#000',
       type: 'Segoe UI',
       align: 'center',
     },
     border: {
-      border: {
-        all: {
-          width: '1px',
-          style: 'solid',
-          color: '#d9d9d9',
-        },
-      },
       radius: { all: 4 },
       borderType: 'all',
       radiusType: 'all',

--- a/shesha-reactjs/src/designer-components/dropdown/utils.ts
+++ b/shesha-reactjs/src/designer-components/dropdown/utils.ts
@@ -86,6 +86,11 @@ export const defaultStyles = (): INestedStyleValue<'tag'> => {
   };
 };
 
+/* The colours seeded into `tag` before the Variant owned them. Migration 15 clears these. */
+export const SEEDED_TAG_BACKGROUND = '#f0f0f0';
+export const SEEDED_TAG_BORDER = { width: '1px', style: 'solid', color: '#d9d9d9' };
+export const SEEDED_TAG_FONT_COLOUR = '#000';
+
 /**
  * The colour-bearing slots are left empty so the Variant decides them — seeded, they are emitted at
  * `&&&&` and beat antd's variant rules. `border` drops `all` for the same reason: `borderLinesStyles`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown tag sizing while preserving configured dimensions and style overrides.
  * Restored consistent borders, font colors, labels, and icons across dropdown variants.
  * Prevented tag styling options from appearing when plain-text display is selected.

* **Improvements**
  * Preserved customized tag colors during configuration updates.
  * Refined default tag styling to follow the selected visual variant.
  * Improved tag appearance across global and device-specific dropdown configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->