### PR TITLE
Add exports for generic document definitions and dummy editor props

### DIFF
--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -35,7 +35,7 @@ import { AttachmentsEditorComponentDefinition, IAttachmentsEditorDeviceStyles, I
 import { swapContainerAndThumbnailStyles } from './migrations/migrate-style-sets';
 import { useStyles } from './styles';
 import { useActualContextExecution } from '@/hooks';
-import { useComponentApi } from '@/providers/componentApi/provider';
+import { useComponentApiProvider } from '@/providers/componentApi/provider';
 import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { FileListApi, StoredFileApiModel } from '../../componentsApi/componentApi';
 
@@ -236,7 +236,7 @@ const AttachmentsEditor: AttachmentsEditorComponentDefinition = {
       [styleDownloadedFiles, model.downloadedFileStyles?.font, downloadedFileStyleCss],
     );
 
-    const componentApi = useComponentApi();
+    const componentApi = useComponentApiProvider();
     useEffect(() => {
       componentApi?.updateApi<FileListApi>({
         id: model.id,

--- a/shesha-reactjs/src/designer-components/fileUpload/index.tsx
+++ b/shesha-reactjs/src/designer-components/fileUpload/index.tsx
@@ -26,7 +26,7 @@ import { isDefined, isNotNullOrWhiteSpace, isNullOrWhiteSpace } from '@/utils/nu
 import { getIdOrUndefined } from '@/utils/entity';
 import { getFirstNonEmptyStringPropertyOrUndefined, getStringPropertyOrUndefined } from '@/utils/object';
 import { FileUploadValue } from '@/providers/storedFile/models';
-import { useComponentApi } from '@/providers/componentApi/provider';
+import { useComponentApiProvider } from '@/providers/componentApi/provider';
 import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { FileUploadApi } from '../../componentsApi/componentApi';
 import { FILE_EVENTS_WITHOUT_CHANGE, getComponentEvents } from '../_common/events';
@@ -65,7 +65,7 @@ const FileUploadComponent: FileUploadComponentDefinition = {
     const allowReplace = enabled && model.allowReplace === true;
     const allowDelete = enabled && model.allowDelete === true;
 
-    const componentApi = useComponentApi();
+    const componentApi = useComponentApiProvider();
     useEffect(() => {
       componentApi?.updateApi<FileUploadApi>({
         id: model.id,

--- a/shesha-reactjs/src/index.tsx
+++ b/shesha-reactjs/src/index.tsx
@@ -34,3 +34,8 @@ export { type DocumentDefinition, type IDocumentInstance } from './configuration
 export { DocumentInstance } from './configuration-studio/cs/documentInstance';
 export { DocumentDefinitionRegistration } from './configuration-studio/document-definitions/documentDefinitionRegistration';
 export { useConfigurationStudio } from './configuration-studio/cs/contexts';
+export {
+  getGenericDefinition,
+  getUnknownDocumentDefinition,
+  type DummyEditorProps,
+} from './configuration-studio/document-definitions/configurable-editor/genericDefinition';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable document-definition helpers for configuring generic and unknown document types.
  * Exposed editor property types to support improved package integration.

* **Improvements**
  * Improved component API access for attachment editing and file uploads, supporting more reliable editor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->