### PR TITLE
Fix Windsor release-policy memory leak into main

### DIFF
--- a/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
@@ -50,9 +50,12 @@ namespace Shesha.Authorization
             }
 
             //TODO: Avoid using try/catch, use conditional checking
+            // ResolveAll registers every resolved helper (and its whole dependency graph: UserManager,
+            // RoleManager, stores, repositories, unit-of-work managers, loggers) with Windsor's release
+            // policy. It must be paired with Release, otherwise the graph leaks on every authorized request.
+            var authorizationHelpers = _iocManager.ResolveAll<ISheshaAuthorizationHelper>();
             try
             {
-                var authorizationHelpers = _iocManager.ResolveAll<ISheshaAuthorizationHelper>();
                 foreach (var authorization in authorizationHelpers)
                 {
                     await authorization.AuthorizeAsync(
@@ -99,6 +102,14 @@ namespace Shesha.Authorization
                 {
                     //TODO: How to return Error page?
                     context.Result = new StatusCodeResult((int)System.Net.HttpStatusCode.InternalServerError);
+                }
+            }
+            finally
+            {
+                // Release the ResolveAll'd helpers and their dependency graph (fixes the per-request leak).
+                foreach (var authorization in authorizationHelpers)
+                {
+                    _iocManager.Release(authorization);
                 }
             }
         }

--- a/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
@@ -50,12 +50,17 @@ namespace Shesha.Authorization
             }
 
             //TODO: Avoid using try/catch, use conditional checking
-            // ResolveAll registers every resolved helper (and its whole dependency graph: UserManager,
-            // RoleManager, stores, repositories, unit-of-work managers, loggers) with Windsor's release
-            // policy. It must be paired with Release, otherwise the graph leaks on every authorized request.
-            var authorizationHelpers = _iocManager.ResolveAll<ISheshaAuthorizationHelper>();
+            // Resolution happens inside the try so that a failure to construct a helper (or anything in its
+            // dependency graph) is handled the same way as a failure during AuthorizeAsync, rather than
+            // escaping the filter unhandled.
+            ISheshaAuthorizationHelper[]? authorizationHelpers = null;
             try
             {
+                // ResolveAll registers every resolved helper (and its whole dependency graph: UserManager,
+                // RoleManager, stores, repositories, unit-of-work managers, loggers) with Windsor's release
+                // policy. It must be paired with Release, otherwise the graph leaks on every authorized request.
+                authorizationHelpers = _iocManager.ResolveAll<ISheshaAuthorizationHelper>();
+
                 foreach (var authorization in authorizationHelpers)
                 {
                     await authorization.AuthorizeAsync(
@@ -107,9 +112,13 @@ namespace Shesha.Authorization
             finally
             {
                 // Release the ResolveAll'd helpers and their dependency graph (fixes the per-request leak).
-                foreach (var authorization in authorizationHelpers)
+                // Null when ResolveAll itself threw, in which case there is nothing to release.
+                if (authorizationHelpers != null)
                 {
-                    _iocManager.Release(authorization);
+                    foreach (var authorization in authorizationHelpers)
+                    {
+                        _iocManager.Release(authorization);
+                    }
                 }
             }
         }

--- a/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionChecker.cs
+++ b/shesha-core/src/Shesha.Framework/Authorization/ShaPermissionChecker.cs
@@ -118,25 +118,45 @@ namespace Shesha.Authorization
         public async Task<bool> IsGrantedCustomAsync(long userId, string permissionName)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (await customChecker.IsGrantedAsync(userId, permissionName))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (await customChecker.IsGrantedAsync(userId, permissionName))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         public async Task<bool> IsGrantedCustomAsync(long userId, string permissionName, EntityReferenceDto<string> permissionedEntity)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (await customChecker.IsGrantedAsync(userId, permissionName, permissionedEntity))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (await customChecker.IsGrantedAsync(userId, permissionName, permissionedEntity))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         /// <summary>
@@ -148,25 +168,45 @@ namespace Shesha.Authorization
         public bool IsGrantedCustom(long userId, string permissionName)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (customChecker.IsGranted(userId, permissionName))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (customChecker.IsGranted(userId, permissionName))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         public bool IsGrantedCustom(long userId, string permissionName, EntityReferenceDto<string> permissionedEntity)
         {
             var customCheckers = IocManager.ResolveAll<ICustomPermissionChecker>();
-            foreach (var customChecker in customCheckers)
+            try
             {
-                if (customChecker.IsGranted(userId, permissionName, permissionedEntity))
-                    return true;
-            }
+                foreach (var customChecker in customCheckers)
+                {
+                    if (customChecker.IsGranted(userId, permissionName, permissionedEntity))
+                        return true;
+                }
 
-            return false;
+                return false;
+            }
+            finally
+            {
+                // ResolveAll tracks each checker (and its repo / UserManager graph) in Windsor's release
+                // policy; release them or they leak on every permission check.
+                foreach (var customChecker in customCheckers)
+                    IocManager.Release(customChecker);
+            }
         }
 
         /// <summary>

--- a/shesha-core/src/Shesha.Framework/Extensions/SheshaMiddlewareExtensions.cs
+++ b/shesha-core/src/Shesha.Framework/Extensions/SheshaMiddlewareExtensions.cs
@@ -2,6 +2,7 @@
 using Shesha.ConfigurationItems;
 using Shesha.DynamicEntities.Middleware;
 using System.Threading.Tasks;
+using Shesha.Ioc;
 
 namespace Shesha.Extensions
 {
@@ -10,6 +11,24 @@ namespace Shesha.Extensions
     /// </summary>
     public static class SheshaMiddlewareExtensions
     {
+        /// <summary>
+        /// Releases, at the end of every request, the components that were resolved via the root container
+        /// during that request (see <see cref="ReleaseRequestScopeMiddleware"/>). Keeps Castle Windsor's
+        /// release-policy dictionary bounded, fixing the root-resolve memory leak and its lock-contention
+        /// slowdown.
+        /// <para>
+        /// REQUIRED opt-in for the <c>RequestScopedReleasePolicy</c> installed by <c>SheshaFrameworkModule</c>:
+        /// call this as the FIRST middleware in the host's Configure() pipeline (before Shesha middleware,
+        /// routing, authentication and endpoints) so its cleanup wraps MVC authorization filters and ABP
+        /// interceptors. If a host omits this call the policy harmlessly degrades to Castle's default
+        /// (tracked-but-not-released) behaviour — the leak is simply not fixed, nothing breaks.
+        /// </para>
+        /// </summary>
+        public static IApplicationBuilder UseSheshaRequestScopeRelease(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<ReleaseRequestScopeMiddleware>();
+        }
+
         public static IApplicationBuilder UseConfigurationFramework(this IApplicationBuilder app)
         {
             return app

--- a/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/ReleaseRequestScopeMiddleware.cs
@@ -1,0 +1,58 @@
+using Abp.Dependency;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Shesha.Ioc
+{
+    /// <summary>
+    /// Opens a <see cref="RequestReleaseScope"/> bucket for the duration of each HTTP request and, when the
+    /// request completes, releases every component that <see cref="RequestScopedReleasePolicy"/> tracked during
+    /// it. This is what bounds Castle Windsor's release-policy dictionary (fixing both the memory leak and the
+    /// lock-contention slowdown) while keeping normal disposal semantics.
+    ///
+    /// Register as early as possible in the pipeline (see <c>UseSheshaRequestScopeRelease</c>) so its release
+    /// runs after everything else in the request — including MVC authorization filters and ABP interceptors.
+    /// </summary>
+    public class ReleaseRequestScopeMiddleware : IMiddleware, ISingletonDependency
+    {
+        private readonly IIocManager _iocManager;
+
+        public ReleaseRequestScopeMiddleware(IIocManager iocManager)
+        {
+            _iocManager = iocManager;
+        }
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            var bucket = RequestReleaseScope.Begin();
+            try
+            {
+                await next(context);
+            }
+            finally
+            {
+                RequestReleaseScope.Clear();
+
+                // Atomically close the bucket and take its contents. Close() rejects any late enqueues from
+                // detached work that inherited this bucket (visible across inherited ExecutionContexts, unlike
+                // the AsyncLocal reference cleared above), so tracking and closure cannot race. Release happens
+                // outside the bucket's lock — disposal/decommission can be slow or re-entrant.
+                var container = _iocManager.IocContainer;
+                foreach (var instance in bucket.Close())
+                {
+                    // Release removes the burden from the policy dictionary and runs decommission/disposal.
+                    // It is idempotent (releasing an already-released or singleton instance is a safe no-op),
+                    // so double-release with the ASP.NET request scope / unit of work is harmless.
+                    try
+                    {
+                        container.Release(instance);
+                    }
+                    catch
+                    {
+                        // Best-effort cleanup: never let a release failure break the response.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/RequestReleaseScope.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Shesha.Ioc
+{
+    /// <summary>
+    /// Per-request bucket of component instances tracked by <see cref="RequestScopedReleasePolicy"/>, drained
+    /// (released) by <see cref="ReleaseRequestScopeMiddleware"/> at the end of the request.
+    ///
+    /// All access is guarded by a per-bucket lock so that closing the bucket is atomic with tracking: an
+    /// instance is either fully tracked before the request closes (and therefore released) or rejected after
+    /// (and left to the container's default tracking). This closes the race where a detached/fire-and-forget
+    /// task — which inherited this bucket via <see cref="ExecutionContext"/> — enqueues an instance in the
+    /// window between the drain-guard check and the enqueue. The lock is per request (one bucket per request),
+    /// so it only ever serialises a request against its own detached children, never across requests.
+    /// </summary>
+    public sealed class RequestReleaseBucket
+    {
+        private readonly object _gate = new object();
+        private readonly Queue<object> _items = new Queue<object>();
+        private bool _drained;
+
+        /// <summary>
+        /// Records an instance for release, atomically with respect to <see cref="Close"/>. Returns
+        /// <c>false</c> (and tracks nothing) if the bucket has already been closed by the request — the caller
+        /// then leaves the instance on the container's default tracking.
+        /// </summary>
+        public bool TryTrack(object instance)
+        {
+            lock (_gate)
+            {
+                if (_drained)
+                {
+                    return false;
+                }
+
+                _items.Enqueue(instance);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Atomically closes the bucket (rejecting any further <see cref="TryTrack"/> calls) and returns its
+        /// contents. Callers must <c>Release</c> the returned instances OUTSIDE any lock (disposal/decommission
+        /// can be slow or re-entrant).
+        /// </summary>
+        public object[] Close()
+        {
+            lock (_gate)
+            {
+                _drained = true;
+                if (_items.Count == 0)
+                {
+                    return Array.Empty<object>();
+                }
+
+                var items = _items.ToArray();
+                _items.Clear();
+                return items;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Holds, per logical request (async flow), the set of component instances that were tracked by
+    /// <see cref="RequestScopedReleasePolicy"/> so they can be released at the end of the request.
+    ///
+    /// Background: components resolved via the root container (ABP <c>IIocResolver</c>/<c>IIocManager</c> and
+    /// ABP's own authorization / unit-of-work / session interceptors) are tracked by Castle Windsor's release
+    /// policy and are never <c>Release()</c>d — they accumulate in the policy's internal dictionary forever.
+    /// That is both a memory leak and (because the dictionary is lock-guarded and grows unbounded) a
+    /// performance problem. Draining this per-request bucket at request end keeps the dictionary bounded to the
+    /// in-flight working set while preserving normal disposal semantics (unlike a global NoTrackingReleasePolicy).
+    ///
+    /// Fire-and-forget note: a detached task started during the request inherits this AsyncLocal (and thus the
+    /// bucket reference). Tracking is closed atomically at request end (see <see cref="RequestReleaseBucket"/>),
+    /// so such work cannot enqueue into an abandoned bucket. Detached work must still not USE request-scoped
+    /// resolutions after the request completes — the same rule as ASP.NET Core request-scoped services; it
+    /// should open its own IoC scope (or capture the values it needs) instead.
+    /// </summary>
+    public static class RequestReleaseScope
+    {
+        private static readonly AsyncLocal<RequestReleaseBucket?> _bucket = new AsyncLocal<RequestReleaseBucket?>();
+
+        /// <summary>
+        /// Starts a new per-request bucket on the current async flow and returns it so the caller
+        /// (the request middleware) can drain it when the request ends.
+        /// </summary>
+        public static RequestReleaseBucket Begin()
+        {
+            var bucket = new RequestReleaseBucket();
+            _bucket.Value = bucket;
+            return bucket;
+        }
+
+        /// <summary>
+        /// Clears the current async flow's bucket reference (called once the request has been drained).
+        /// </summary>
+        public static void Clear()
+        {
+            _bucket.Value = null;
+        }
+
+        /// <summary>
+        /// Records an instance for release at the end of the current request. No-op when there is no active
+        /// request bucket (e.g. resolves during app startup or on background/scheduler threads) or when the
+        /// bucket has already been closed (e.g. a detached task that outlived its request), which safely leaves
+        /// those on the default tracking behaviour.
+        /// </summary>
+        public static void Track(object instance)
+        {
+            _bucket.Value?.TryTrack(instance);
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/Ioc/RequestScopedReleasePolicy.cs
+++ b/shesha-core/src/Shesha.Framework/Ioc/RequestScopedReleasePolicy.cs
@@ -1,0 +1,34 @@
+using Castle.MicroKernel;
+using Castle.MicroKernel.Releasers;
+
+namespace Shesha.Ioc
+{
+    /// <summary>
+    /// Castle Windsor release policy that behaves exactly like the default
+    /// <see cref="LifecycledComponentsReleasePolicy"/> (so normal tracking, decommission and disposal are all
+    /// preserved) but ALSO records every tracked instance in the current request's <see cref="RequestReleaseScope"/>
+    /// bucket. The request middleware then releases that bucket when the request completes, which keeps the
+    /// policy's internal <c>instance2Burden</c> dictionary bounded to the in-flight working set instead of
+    /// growing without limit.
+    ///
+    /// This is the broad fix for the root-container resolve leak: it catches EVERY component resolved during a
+    /// request (ABP interceptors, <c>IIocResolver</c>, and any <c>ResolveAll</c> sites) without editing ABP and
+    /// without a blanket non-tracking policy.
+    /// </summary>
+    public class RequestScopedReleasePolicy : LifecycledComponentsReleasePolicy
+    {
+        public RequestScopedReleasePolicy(IKernel kernel)
+            : base(kernel)
+        {
+        }
+
+        public override void Track(object instance, Burden burden)
+        {
+            // Preserve the default behaviour (needed so Release() later runs decommission/disposal correctly).
+            base.Track(instance, burden);
+
+            // Remember it for release at the end of the current request (no-op outside a request).
+            RequestReleaseScope.Track(instance);
+        }
+    }
+}

--- a/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
+++ b/shesha-core/src/Shesha.Framework/SheshaFrameworkModule.cs
@@ -53,6 +53,20 @@ namespace Shesha
 
         public override void PreInitialize()
         {
+            // Broad memory-leak / performance fix: replace Castle Windsor's default release policy with one
+            // that records every tracked instance in the current request's bucket (see RequestScopedReleasePolicy
+            // / RequestReleaseScope). The ReleaseRequestScopeMiddleware then releases that bucket at request end,
+            // which keeps the release policy's internal dictionary bounded instead of accumulating every
+            // root-container resolve forever.
+            //
+            // OPT-IN REQUIRED: every web host must call app.UseSheshaRequestScopeRelease() at the very start of
+            // its Configure() pipeline for this to take effect (Shesha.Web.Host does). The policy is intentionally
+            // safe if a host forgets: with no middleware there is no per-request bucket, RequestScopedReleasePolicy
+            // falls through to base LifecycledComponentsReleasePolicy behaviour, i.e. the framework default — the
+            // fix simply does nothing rather than causing any new harm.
+            IocManager.IocContainer.Kernel.ReleasePolicy =
+                new Shesha.Ioc.RequestScopedReleasePolicy(IocManager.IocContainer.Kernel);
+
             IocManager.Register<IPermissionManager, IShaPermissionManager, IPermissionDefinitionContext, ShaPermissionManager>();
 
             Configuration.ReplaceService(typeof(IExceptionFilter),

--- a/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
@@ -154,9 +154,11 @@ namespace Shesha.Web.Host.Startup
 
         public void Configure(IApplicationBuilder app, IBackgroundJobClient backgroundJobs)
         {
+            // Must be first: releases per-request root-container resolutions at request end. Required to make
+            // SheshaFrameworkModule's RequestScopedReleasePolicy actually bound the release-policy dictionary.
+            app.UseSheshaRequestScopeRelease();
             // Security headers (registered first so they apply to all responses)
             app.UseSecurityHeaders();
-
             app.UseSheshaElmah();
 
             // note: already registered in the ABP


### PR DESCRIPTION
This is the main merge for a fix for #5222 

Fix Windsor release-policy memory leak (request-scoped release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of dependency-injection components at the end of each web request.
  * Added request-scope middleware to release resolved components safely without interrupting responses.
  * Added application pipeline configuration for request-scoped cleanup.

* **Bug Fixes**
  * Improved cleanup of authorization and permission-checking components, including when errors occur.
  * Ensured cleanup failures do not disrupt request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->