### PR TITLE
fix: remove permissioned objects of endpoints that no longer exist (#4655)

### DIFF
--- a/ISSUE-4655-TESTING.md
+++ b/ISSUE-4655-TESTING.md
@@ -1,0 +1,77 @@
+# Issue #4655 — ghost endpoint in Permissioned Objects
+
+Branch: `fix/4655-form-and-permission-write-auth` (based on `main`)
+
+## Scope
+
+The authorization part of #4655 is already on `main`: `PermissionAppService`'s write methods
+(`Create`, `Update`, `UpdateParent`, `Delete`) and the class-level restriction on
+`FormConfigurationAppService` both require `app:Configurator` there, and
+`Shesha.Tests/Security/PermissionAndFormServiceAuth_Tests.cs` covers them. Nothing to redo.
+
+What is left is @yuliaGradova's follow-up: **`FormConfiguration → GetByNameAsync` appears in
+Permissioned Objects but not in Swagger.**
+
+That endpoint no longer exists on `main` — it was removed by the configuration-items refactor
+(runtime form loading now goes through `ConfigurationItem/Get` / `GetCurrent`). Swagger is correct;
+the Permissioned Objects screen was wrong: the bootstrapper only ever added and updated rows, it
+never removed the rows of endpoints that disappeared from the code, so
+`...FormConfigurationAppService@GetByName` stayed behind as a ghost entry. Such an entry cannot be
+configured meaningfully — nothing reads it — and it makes the security screen untrustworthy.
+
+## What changed
+
+| File | Change |
+|---|---|
+| `Shesha.Framework/Permissions/PermissionedObjectsBootstrapper.cs` | deletes web-api action rows whose endpoint no longer exists |
+| `Shesha.Tests/Security/PermissionAndFormServiceAuth_Tests.cs` | the "must not be `[AllowAnonymous]`" theory also covers `Create`, `Update`, `Delete` and `GetJson` |
+| `PermissionAppService.cs`, `FormConfigurationAppService.cs` | `"app:Configurator"` literals replaced by `ShaPermissionNames.Application_Configurator` — same value, no behaviour change (this is how the merge conflict with `main` was resolved) |
+
+Cleanup rules (deliberately conservative):
+
+- only rows of type `Shesha.WebApi.Action`;
+- only actions whose **service was scanned in this run** — the provider skips services in unchanged
+  assemblies, so a skipped service never loses its actions;
+- service ("parent") rows themselves are never deleted;
+- entity and form permissioned objects are untouched;
+- each deletion is written to the bootstrapper log.
+
+Because the scan skips unchanged assemblies, the cleanup happens on the first startup after a
+deployment that changes the assembly — which is the case when this branch is deployed.
+
+## Test 1 — ghost endpoint is gone (the reported comment)
+
+- [ ] Before deploying, note in **Configuration → Permissioned Objects → FormConfiguration** that
+      `GetByName` is listed.
+- [ ] Deploy this branch (the app must start, so the bootstrapper runs).
+- [ ] Re-open the screen: `GetByName` is **no longer listed**.
+- [ ] Every endpoint still listed for `FormConfiguration` also appears in Swagger, and vice versa
+      (`Get`, `GetAll`, `Create`, `Update`, `Delete`, `UpdateMarkup`, `ImportJson`, `GetJson`,
+      `CheckPermissions`, `GetAnonymousForms`).
+- [ ] Spot-check several other services — the endpoint lists match Swagger, nothing legitimate
+      disappeared.
+- [ ] Check the bootstrapper log (startup log / `Frwk_BootstrapperStartups`) — every deleted object
+      is listed there.
+
+## Test 2 — configured endpoints survive
+
+- [ ] Pick an endpoint that still exists, set its Access to **Requires permissions** with some
+      permission, save.
+- [ ] Restart the app.
+- [ ] The configuration is still there — the cleanup must not touch endpoints that exist.
+
+## Test 3 — the authorization already on `main` still holds
+
+As an ordinary user (no permissions):
+
+- [ ] `POST /api/services/app/Permission/Create`, `PUT .../Update`, `PUT .../UpdateParent`,
+      `DELETE .../Delete` → **403**
+- [ ] `PUT /api/services/Shesha/FormConfiguration/UpdateMarkup` → **403 / 401**
+- [ ] `POST /api/services/Shesha/FormConfiguration/ImportJson` → **403 / 401**
+- [ ] Log in and open the pages they normally use — main menu renders
+      (`FormConfiguration/CheckPermissions` stays anonymous), forms load and save data.
+
+As a configurator:
+
+- [ ] Form designer: open, edit, save, publish, export, import, delete.
+- [ ] Permission tree: create, rename, re-parent, delete a test permission.

--- a/shesha-core/src/Shesha.Application/Permissions/PermissionAppService.cs
+++ b/shesha-core/src/Shesha.Application/Permissions/PermissionAppService.cs
@@ -111,7 +111,7 @@ namespace Shesha.Permissions
         }
 
         [HttpPost]
-        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, ShaPermissionNames.Application_Configurator)]
         public async Task<PermissionDto> CreateAsync(PermissionDto permission)
         {
             var dbp = new PermissionDefinition()
@@ -130,7 +130,7 @@ namespace Shesha.Permissions
         }
 
         [HttpPut, HttpPost]
-        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, ShaPermissionNames.Application_Configurator)]
         public async Task<PermissionDto> UpdateAsync(PermissionDto permission)
         {
             if (permission.Id == emptyId)
@@ -154,7 +154,7 @@ namespace Shesha.Permissions
         }
 
         [HttpPut] 
-        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, ShaPermissionNames.Application_Configurator)]
         public async Task UpdateParentAsync(PermissionDto permission)
         {
             var module = permission.Module != null ? await _moduleRepository.GetAsync(permission.Module.Id) : null;
@@ -162,7 +162,7 @@ namespace Shesha.Permissions
         }
 
         [HttpDelete]
-        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
+        [SheshaAuthorize(Domain.Enums.RefListPermissionedAccess.RequiresPermissions, ShaPermissionNames.Application_Configurator)]
         public Task DeleteAsync(string name)
         {
             return _shaPermissionManager.DeletePermissionAsync(name);

--- a/shesha-core/src/Shesha.Framework/Permissions/PermissionedObjectsBootstrapper.cs
+++ b/shesha-core/src/Shesha.Framework/Permissions/PermissionedObjectsBootstrapper.cs
@@ -11,6 +11,7 @@ using Shesha.Permissions;
 using Shesha.Services.VersionedFields;
 using Shesha.Startup;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -97,7 +98,45 @@ namespace Shesha.Permission
                             await _versionedFieldManager.SetVersionedFieldValueAsync<PermissionedObject, Guid>(dbItem, parameter.Key, parameter.Value, false);
                         }
                     }
+
+                    // Remove the items of endpoints that do not exist anymore
+                    if (objectType == ShaPermissionedObjectsTypes.WebApi)
+                        await RemoveMissingActionsAsync(items, dbItems);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Deletes rows of the actions that are not exposed by the application anymore, they are shown
+        /// as non-existing endpoints in the configurator otherwise (see issue #4655).
+        /// Services of unchanged assemblies are skipped by the provider, so only the actions of the
+        /// services that were scanned in this run are taken into account.
+        /// </summary>
+        private async Task RemoveMissingActionsAsync(List<PermissionedObjectDto> items, List<PermissionedObject> dbItems)
+        {
+            var scannedServices = items
+                .Where(i => i.Type == ShaPermissionedObjectsTypes.WebApi)
+                .Select(i => i.Object)
+                .ToHashSet();
+
+            if (!scannedServices.Any())
+                return;
+
+            var existingActions = items
+                .Where(i => i.Type == ShaPermissionedObjectsTypes.WebApiAction)
+                .Select(i => i.Object)
+                .ToHashSet();
+
+            var missingActions = dbItems
+                .Where(dbi => dbi.Type == ShaPermissionedObjectsTypes.WebApiAction
+                    && scannedServices.Contains(dbi.Parent)
+                    && !existingActions.Contains(dbi.Object))
+                .ToList();
+
+            foreach (var dbItem in missingActions)
+            {
+                LogInfo($"Permissioned object `{dbItem.Object}` is removed, the endpoint does not exist anymore");
+                await _permissionedObjectRepository.DeleteAsync(dbItem);
             }
         }
     }

--- a/shesha-core/src/Shesha.Web.FormsDesigner/Services/FormConfigurationAppService.cs
+++ b/shesha-core/src/Shesha.Web.FormsDesigner/Services/FormConfigurationAppService.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace Shesha.Web.FormsDesigner.Services
 {
-    [SheshaAuthorize(RefListPermissionedAccess.RequiresPermissions, "app:Configurator")]
+    [SheshaAuthorize(RefListPermissionedAccess.RequiresPermissions, ShaPermissionNames.Application_Configurator)]
     public class FormConfigurationAppService : SheshaCrudServiceBase<FormConfiguration, FormConfigurationDto, Guid, FilteredPagedAndSortedResultRequestDto, CreateFormConfigurationRequest, UpdateFormConfigurationDto, GetFormByIdInput>
     {
         private readonly IRepository<ConfigurationItemFolder, Guid> _folderRepository;

--- a/shesha-core/test/Shesha.Tests/Security/PermissionAndFormServiceAuth_Tests.cs
+++ b/shesha-core/test/Shesha.Tests/Security/PermissionAndFormServiceAuth_Tests.cs
@@ -96,6 +96,10 @@ namespace Shesha.Tests.Security
         [Theory]
         [InlineData("UpdateMarkupAsync")]
         [InlineData("ImportJsonAsync")]
+        [InlineData("CreateAsync")]
+        [InlineData("UpdateAsync")]
+        [InlineData("DeleteAsync")]
+        [InlineData("GetJsonAsync")]
         public void FormConfigurationAppService_write_methods_should_not_be_AllowAnonymous(string methodName)
         {
             var method = typeof(FormConfigurationAppService)


### PR DESCRIPTION
Resolves the follow-up comment on #4655 (@yuliaGradova: `FormConfiguration -> GetByNameAsync` is missing in Swagger though it exists in Permissioned Objects).

Rebased onto current `main`; the three merge conflicts are resolved.

## Scope after the rebase
The authorization part of #4655 landed on `main` in the meantime (class-level `app:Configurator` on `FormConfigurationAppService`, method-level attributes on `PermissionAppService`, plus `PermissionAndFormServiceAuth_Tests`). This PR no longer re-applies any of that — it carries the part that is still missing.

## The reported problem
`GetByNameAsync` no longer exists on `main`: it was removed by the configuration-items refactor (runtime form loading goes through `ConfigurationItem/Get` / `GetCurrent`). Swagger was right; the Permissioned Objects screen was wrong. `PermissionedObjectsBootstrapper` only ever added and updated rows and never removed rows of endpoints that disappeared from the code, so `...FormConfigurationAppService@GetByName` stayed behind as a ghost entry that nothing reads.

## Changes
- `PermissionedObjectsBootstrapper` deletes web-api **action** rows whose endpoint no longer exists. Conservative on purpose:
  - only rows of type `Shesha.WebApi.Action`;
  - only actions whose service was actually scanned in the run (the provider skips services in unchanged assemblies, so a skipped service never loses its actions);
  - service ("parent") rows are never deleted; entity and form objects are untouched;
  - every deletion is written to the bootstrapper log.
- `PermissionAndFormServiceAuth_Tests`: the "must not be `[AllowAnonymous]`" theory now also covers `CreateAsync`, `UpdateAsync`, `DeleteAsync` and `GetJsonAsync`.
- Conflict resolution kept `main`'s attributes and swapped the `"app:Configurator"` literals for `ShaPermissionNames.Application_Configurator` — same value, no behaviour change. Happy to flip those 5 lines back to literals if you prefer.

Testing steps: `ISSUE-4655-TESTING.md`.

Verified: `dotnet build` (net10 SDK) clean, `Shesha.Tests` security suite 63/63.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Standardized authorization for application configuration operations.
  * Applied consistent configurator permission requirements to form configuration management.

* **Bug Fixes**
  * Removed obsolete API action permissions when corresponding endpoints are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->