### PR TITLE
Lihlumise/fix/reference list status

### DIFF
--- a/shesha-reactjs/src/components/refListDisplaySelector/__tests__/models.test.ts
+++ b/shesha-reactjs/src/components/refListDisplaySelector/__tests__/models.test.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_REF_LIST_DISPLAY_MODE, resolveRefListDisplay, toRefListDisplayMode } from '../models';
+
+describe('resolveRefListDisplay', () => {
+  it.each([
+    ['name', { showName: true, showIcon: false }],
+    ['icon', { showName: false, showIcon: true }],
+    ['both', { showName: true, showIcon: true }],
+  ] as const)('maps the %s mode to its flags', (mode, expected) => {
+    expect(resolveRefListDisplay(mode)).toEqual(expected);
+  });
+
+  it('takes the flags a JS setting returns as they are', () => {
+    expect(resolveRefListDisplay({ showName: false, showIcon: true })).toEqual({ showName: false, showIcon: true });
+  });
+
+  // At least one of the two is always shown. The selector cannot express "neither", but an
+  // expression can, and an empty tag is not a useful thing to render.
+  it('falls back to the default mode when a JS setting turns both off', () => {
+    expect(resolveRefListDisplay({ showName: false, showIcon: false }))
+      .toEqual(resolveRefListDisplay(DEFAULT_REF_LIST_DISPLAY_MODE));
+  });
+
+  it('falls back to the default mode when nothing has been configured', () => {
+    expect(resolveRefListDisplay(undefined)).toEqual(resolveRefListDisplay(DEFAULT_REF_LIST_DISPLAY_MODE));
+  });
+});
+
+describe('toRefListDisplayMode', () => {
+  it.each([
+    [{ showName: true, showIcon: true }, 'both'],
+    [{ showName: false, showIcon: true }, 'icon'],
+    [{ showName: true, showIcon: false }, 'name'],
+  ] as const)('reports %p as the %s mode, so the selector shows it as chosen', (value, expected) => {
+    expect(toRefListDisplayMode(value)).toBe(expected);
+  });
+});

--- a/shesha-reactjs/src/components/refListDisplaySelector/index.tsx
+++ b/shesha-reactjs/src/components/refListDisplaySelector/index.tsx
@@ -1,0 +1,62 @@
+import { isNotNullOrWhiteSpace } from '@/utils/nullables';
+import { Radio } from 'antd';
+import { SizeType } from 'antd/lib/config-provider/SizeContext';
+import { FC } from 'react';
+import { isRefListDisplayMode, RefListDisplayMode, RefListDisplayValue, toRefListDisplayMode } from './models';
+
+export interface IRefListDisplaySelectorProps {
+  value?: RefListDisplayValue | undefined;
+  readOnly?: boolean | undefined;
+  onChange?: ((value: RefListDisplayMode) => void) | undefined;
+  /** Reports the hovered option to the inheritance popover, as the edit mode selector does. */
+  onGetAdditionalInfo?: ((info: string) => void) | undefined;
+  size?: SizeType | undefined;
+  className?: string | undefined;
+}
+
+/**
+ * Labelled with words rather than glyphs: the shared `Icon` set carries nothing that reads as "name"
+ * or "icon", and a three-state control is not worth inventing iconography for.
+ */
+const OPTIONS: { mode: RefListDisplayMode; label: string; hint: string }[] = [
+  { mode: 'name', label: 'Name', hint: 'Show the reference list item name' },
+  { mode: 'icon', label: 'Icon', hint: 'Show the reference list item icon' },
+  { mode: 'both', label: 'Both', hint: 'Show the reference list item icon and name' },
+];
+
+/**
+ * Chooses between showing a reference list item's name, its icon, or both. One of the three is
+ * always selected - the control has no way to express "neither".
+ */
+const RefListDisplaySelector: FC<IRefListDisplaySelectorProps> = (props) => {
+  return (
+    <Radio.Group
+      buttonStyle="solid"
+      value={toRefListDisplayMode(props.value)}
+      /* antd types the event value as `any`. Bringing it into the type system by conversion and then
+         narrowing keeps a value from outside these three options away from the caller, without
+         coercing anything. */
+      onChange={(e) => {
+        const selected = String(e.target.value);
+        if (isRefListDisplayMode(selected))
+          props.onChange?.(selected);
+      }}
+      size={props.size}
+      disabled={props.readOnly ?? false}
+      {...(isNotNullOrWhiteSpace(props.className) ? { className: props.className } : {})}
+    >
+      {OPTIONS.map(({ mode, label, hint }) => (
+        <Radio.Button
+          key={mode}
+          value={mode}
+          title={hint}
+          onMouseEnter={() => props.onGetAdditionalInfo?.(label)}
+        >
+          {label}
+        </Radio.Button>
+      ))}
+    </Radio.Group>
+  );
+};
+
+export default RefListDisplaySelector;

--- a/shesha-reactjs/src/components/refListDisplaySelector/models.ts
+++ b/shesha-reactjs/src/components/refListDisplaySelector/models.ts
@@ -1,0 +1,63 @@
+import { isDefined } from '@/utils/nullables';
+
+/**
+ * What a reference list value shows: the item's name, its icon, or both.
+ *
+ * There is deliberately no fourth "neither" mode. A status that draws nothing is not a configuration
+ * worth offering, so the selector has no state for it and the invariant holds by construction.
+ */
+export type RefListDisplayMode = 'name' | 'icon' | 'both';
+
+/**
+ * Resolved form of {@link RefListDisplayValue}, and the shape a JS setting is expected to return -
+ * flags rather than a mode, so an expression can decide each one independently from the row's data.
+ */
+export interface IRefListDisplay {
+  showName: boolean;
+  showIcon: boolean;
+}
+
+/** A mode chosen in the selector, or the flags a JS setting returned in its place. */
+export type RefListDisplayValue = RefListDisplayMode | IRefListDisplay;
+
+const MODES: Record<RefListDisplayMode, IRefListDisplay> = {
+  name: { showName: true, showIcon: false },
+  icon: { showName: false, showIcon: true },
+  both: { showName: true, showIcon: true },
+};
+
+/** Matches what the component showed before the selector existed: the name, and no icon. */
+export const DEFAULT_REF_LIST_DISPLAY_MODE: RefListDisplayMode = 'name';
+
+/** Accepts a bare string too, for callers narrowing a value that arrived from outside the type. */
+export const isRefListDisplayMode = (value: RefListDisplayValue | string | undefined): value is RefListDisplayMode =>
+  value === 'name' || value === 'icon' || value === 'both';
+
+const isRefListDisplay = (value: RefListDisplayValue | undefined): value is IRefListDisplay =>
+  isDefined(value) && typeof value === 'object' && ('showName' in value || 'showIcon' in value);
+
+/**
+ * Normalises either form into the flags the component renders from.
+ *
+ * Two cases fall back to the default mode rather than to an empty tag: a value that is neither a
+ * mode nor the expected object - a JS setting that returned nothing usable, the declared type being
+ * no guarantee there - and one that turns both flags off. The selector cannot produce that second
+ * case, but an expression can, and the invariant it enforces structurally has to hold here too.
+ */
+export const resolveRefListDisplay = (value: RefListDisplayValue | undefined): IRefListDisplay => {
+  if (isRefListDisplayMode(value))
+    return MODES[value];
+
+  if (isRefListDisplay(value)) {
+    const resolved = { showName: value.showName === true, showIcon: value.showIcon === true };
+    return resolved.showName || resolved.showIcon ? resolved : MODES[DEFAULT_REF_LIST_DISPLAY_MODE];
+  }
+
+  return MODES[DEFAULT_REF_LIST_DISPLAY_MODE];
+};
+
+/** The mode a value corresponds to, for the selector to show as chosen. */
+export const toRefListDisplayMode = (value: RefListDisplayValue | undefined): RefListDisplayMode => {
+  const { showName, showIcon } = resolveRefListDisplay(value);
+  return showName && showIcon ? 'both' : showIcon ? 'icon' : 'name';
+};

--- a/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
+++ b/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
@@ -111,6 +111,15 @@ describe('RefListStatus', () => {
       expect(tag?.style.color).toBe('rgb(255, 255, 255)');
     });
 
+    it('drops a caller background, the badge colour being fixed here', () => {
+      const tag = tagOf(renderDesigner({
+        displayIsDynamic: true,
+        style: { background: 'lime', backgroundColor: 'lime' },
+      }));
+
+      expect(tag?.style.backgroundColor).toBe('rgb(140, 140, 140)');
+    });
+
     it('ignores the solid background switch and the list colour, which it does not govern', () => {
       currentList = [{ ...item, color: '#ff0000' }];
       const tag = tagOf(renderDesigner({ displayIsDynamic: true, solidBackground: false }));
@@ -159,6 +168,30 @@ describe('RefListStatus', () => {
       }));
 
       expect(tag?.style.color).toBe('rgb(255, 255, 255)');
+    });
+
+    // A solid badge paints its own background, so a caller's background declarations must not
+    // survive into the inline style - a `background` shorthand would reset the badge colour.
+    it('drops a caller background so the item colour wins', () => {
+      currentItem = { ...item, color: '#ff0000' };
+      const tag = tagOf(renderStatus({
+        solidBackground: true,
+        showReflistName: true,
+        style: { background: 'lime', backgroundColor: 'lime', backgroundImage: 'url(x.png)' },
+      }));
+
+      expect(tag?.style.backgroundColor).toBe('rgb(255, 0, 0)');
+      expect(tag?.style.backgroundImage).toBe('');
+    });
+
+    it('drops a caller background in the solid designer placeholder', () => {
+      const tag = tagOf(renderDesigner({
+        solidBackground: true,
+        showReflistName: true,
+        style: { background: 'lime', backgroundColor: 'lime' },
+      }));
+
+      expect(tag?.style.backgroundColor).toBe('rgb(140, 140, 140)');
     });
 
     it('reads as plain text when off, with no tag chrome', () => {

--- a/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
+++ b/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
@@ -1,0 +1,110 @@
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import * as React from 'react';
+import { IReferenceListItem } from '@/interfaces/referenceList';
+
+/**
+ * Covers the ways the appearance switches used to be inert: the tag vanished altogether once both
+ * Show Icon and Show Reference List Item Name were off, and Show Solid Background did nothing for
+ * an item with no colour configured.
+ */
+
+const item: IReferenceListItem = {
+  id: '1',
+  item: 'Male',
+  itemValue: 1,
+  description: null,
+  orderIndex: 0,
+  color: null,
+  icon: 'UserOutlined',
+  shortAlias: null,
+};
+
+let currentItem: IReferenceListItem = item;
+
+vi.mock('@/providers/referenceListDispatcher', () => ({
+  useReferenceListItem: () => ({ data: currentItem, loading: false, error: undefined }),
+}));
+
+vi.mock('@/providers', () => ({
+  useThemeState: () => ({ theme: { application: { primaryColor: '#1890ff' } } }),
+}));
+
+import { RefListStatus } from '../index';
+
+const renderStatus = (props: Partial<React.ComponentProps<typeof RefListStatus>>): HTMLElement => {
+  const { container } = render(
+    <RefListStatus referenceListId={{ module: 'Shesha', name: 'Gender' }} value={1} {...props} />,
+  );
+  return container;
+};
+
+const tagOf = (container: HTMLElement): HTMLElement | null => container.querySelector('.ant-tag');
+
+beforeEach(() => {
+  currentItem = item;
+});
+
+describe('RefListStatus', () => {
+  describe('showIcon', () => {
+    it('renders the item icon', () => {
+      expect(tagOf(renderStatus({ showIcon: true }))?.querySelector('.anticon-user')).not.toBeNull();
+    });
+
+    it('renders no icon when off', () => {
+      expect(tagOf(renderStatus({ showIcon: false, showReflistName: true }))?.querySelector('.anticon')).toBeNull();
+    });
+  });
+
+  describe('read only', () => {
+    // Read only is a status tag's natural state. Rendering it as plain text through
+    // ReadOnlyDisplayFormItem threw away everything the component displays.
+    it('still renders the tag, with its icon and colour', () => {
+      currentItem = { ...item, color: '#ff0000' };
+      const tag = tagOf(renderStatus({ readOnly: true, showIcon: true, showReflistName: true, solidBackground: true }));
+
+      expect(tag).not.toBeNull();
+      expect(tag?.querySelector('.anticon-user')).not.toBeNull();
+      expect(tag?.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    });
+  });
+
+  describe('solidBackground', () => {
+    it('paints the item colour when it has one', () => {
+      currentItem = { ...item, color: '#ff0000' };
+      const tag = tagOf(renderStatus({ solidBackground: true, showReflistName: true }));
+
+      expect(tag?.className).toContain('ant-tag-solid');
+      expect(tag?.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    });
+
+    it('falls back to grey for an item with no colour', () => {
+      currentItem = { ...item, color: null };
+      const tag = tagOf(renderStatus({ solidBackground: true, showReflistName: true }));
+
+      expect(tag?.className).toContain('ant-tag-solid');
+      expect(tag?.style.backgroundColor).toBe('rgb(140, 140, 140)');
+    });
+
+    it('forces the text white, over the configured font colour', () => {
+      currentItem = { ...item, color: '#ff0000' };
+      const tag = tagOf(renderStatus({
+        solidBackground: true,
+        showReflistName: true,
+        style: { color: '#000000' },
+      }));
+
+      expect(tag?.style.color).toBe('rgb(255, 255, 255)');
+    });
+
+    it('reads as plain text when off, with no tag chrome', () => {
+      currentItem = { ...item, color: '#ff0000' };
+      const tag = tagOf(renderStatus({ solidBackground: false, showReflistName: true }));
+
+      expect(tag?.textContent).toBe('Male');
+      expect(tag?.style.background).toBe('transparent');
+      expect(tag?.style.borderStyle).toBe('none');
+      expect(tag?.style.padding).toBe('0px');
+    });
+  });
+});

--- a/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
+++ b/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
@@ -21,7 +21,7 @@ const item: IReferenceListItem = {
   shortAlias: null,
 };
 
-let currentItem: IReferenceListItem = item;
+let currentItem: IReferenceListItem | undefined = item;
 let currentList: IReferenceListItem[] = [item];
 
 vi.mock('@/providers/referenceListDispatcher', () => ({
@@ -46,7 +46,7 @@ const tagOf = (container: HTMLElement): HTMLElement | null => container.querySel
 
 /** The designer branch is the one with no value to resolve, so `useReferenceListItem` returns nothing. */
 const renderDesigner = (props: Partial<React.ComponentProps<typeof RefListStatus>>): HTMLElement => {
-  currentItem = undefined as unknown as IReferenceListItem;
+  currentItem = undefined;
   return renderStatus({ ...props, isDesigner: true });
 };
 
@@ -96,6 +96,27 @@ describe('RefListStatus', () => {
 
     it('falls back to a stand-in when the component is unbound', () => {
       expect(tagOf(renderDesigner({ showReflistName: true }))?.textContent).toBe('N/A');
+    });
+  });
+
+  describe('a display driven by JS', () => {
+    // The canvas has no data to evaluate the expression against, and it could resolve differently
+    // per row, so one neutral shape stands for all of them.
+    it('previews one fixed shape on the canvas', () => {
+      const tag = tagOf(renderDesigner({ displayIsDynamic: true, propertyName: 'gender' }));
+
+      expect(tag?.textContent).toBe('Reference List Item');
+      expect(tag?.querySelector('.anticon-tag')).not.toBeNull();
+      expect(tag?.style.backgroundColor).toBe('rgb(140, 140, 140)');
+      expect(tag?.style.color).toBe('rgb(255, 255, 255)');
+    });
+
+    it('ignores the solid background switch and the list colour, which it does not govern', () => {
+      currentList = [{ ...item, color: '#ff0000' }];
+      const tag = tagOf(renderDesigner({ displayIsDynamic: true, solidBackground: false }));
+
+      expect(tag?.className).toContain('ant-tag-solid');
+      expect(tag?.style.backgroundColor).toBe('rgb(140, 140, 140)');
     });
   });
 

--- a/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
+++ b/shesha-reactjs/src/components/refListStatus/__tests__/refListStatus.test.tsx
@@ -4,9 +4,10 @@ import * as React from 'react';
 import { IReferenceListItem } from '@/interfaces/referenceList';
 
 /**
- * Covers the ways the appearance switches used to be inert: the tag vanished altogether once both
- * Show Icon and Show Reference List Item Name were off, and Show Solid Background did nothing for
- * an item with no colour configured.
+ * Covers the three ways the appearance switches used to be inert:
+ *  - Show Icon did nothing on the designer canvas, which always took the placeholder branch;
+ *  - the tag vanished altogether once both Show Icon and Show Reference List Item Name were off;
+ *  - Show Solid Background did nothing for an item with no colour configured.
  */
 
 const item: IReferenceListItem = {
@@ -21,9 +22,11 @@ const item: IReferenceListItem = {
 };
 
 let currentItem: IReferenceListItem = item;
+let currentList: IReferenceListItem[] = [item];
 
 vi.mock('@/providers/referenceListDispatcher', () => ({
   useReferenceListItem: () => ({ data: currentItem, loading: false, error: undefined }),
+  useReferenceList: () => ({ data: { name: 'Gender', items: currentList }, loading: false, error: undefined }),
 }));
 
 vi.mock('@/providers', () => ({
@@ -41,8 +44,15 @@ const renderStatus = (props: Partial<React.ComponentProps<typeof RefListStatus>>
 
 const tagOf = (container: HTMLElement): HTMLElement | null => container.querySelector('.ant-tag');
 
+/** The designer branch is the one with no value to resolve, so `useReferenceListItem` returns nothing. */
+const renderDesigner = (props: Partial<React.ComponentProps<typeof RefListStatus>>): HTMLElement => {
+  currentItem = undefined as unknown as IReferenceListItem;
+  return renderStatus({ ...props, isDesigner: true });
+};
+
 beforeEach(() => {
   currentItem = item;
+  currentList = [item];
 });
 
 describe('RefListStatus', () => {
@@ -53,6 +63,39 @@ describe('RefListStatus', () => {
 
     it('renders no icon when off', () => {
       expect(tagOf(renderStatus({ showIcon: false, showReflistName: true }))?.querySelector('.anticon')).toBeNull();
+    });
+
+    it('is honoured by the designer placeholder, which has no item to read an icon from', () => {
+      expect(tagOf(renderDesigner({ showIcon: true }))?.querySelector('.anticon')).not.toBeNull();
+      expect(tagOf(renderDesigner({ showIcon: false }))?.querySelector('.anticon')).toBeNull();
+    });
+
+    it('uses a generic tag icon on the canvas, never one lifted from another item', () => {
+      currentList = [{ ...item, icon: 'SmileOutlined' }];
+      const tag = tagOf(renderDesigner({ showIcon: true }));
+
+      expect(tag?.querySelector('.anticon-tag')).not.toBeNull();
+      expect(tag?.querySelector('.anticon-smile')).toBeNull();
+    });
+  });
+
+  describe('with neither the name nor an icon shown', () => {
+    it('still renders the tag', () => {
+      expect(tagOf(renderStatus({ showIcon: false, showReflistName: false }))).not.toBeNull();
+    });
+
+    it('names the tag for screen readers, since it carries no text', () => {
+      expect(tagOf(renderStatus({ showIcon: false, showReflistName: false }))?.getAttribute('aria-label')).toBe('Male');
+    });
+  });
+
+  describe('the designer placeholder text', () => {
+    it('names the component by its property name', () => {
+      expect(tagOf(renderDesigner({ showReflistName: true, propertyName: 'gender' }))?.textContent).toBe('gender');
+    });
+
+    it('falls back to a stand-in when the component is unbound', () => {
+      expect(tagOf(renderDesigner({ showReflistName: true }))?.textContent).toBe('N/A');
     });
   });
 
@@ -105,6 +148,13 @@ describe('RefListStatus', () => {
       expect(tag?.style.background).toBe('transparent');
       expect(tag?.style.borderStyle).toBe('none');
       expect(tag?.style.padding).toBe('0px');
+    });
+
+    it('strips the chrome from the designer placeholder too when off', () => {
+      const tag = tagOf(renderDesigner({ solidBackground: false, showReflistName: true }));
+
+      expect(tag?.style.background).toBe('transparent');
+      expect(tag?.style.borderStyle).toBe('none');
     });
   });
 });

--- a/shesha-reactjs/src/components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/components/refListStatus/index.tsx
@@ -9,7 +9,7 @@ import { RefListStatusPlaceholder } from './placeholder';
 import { useStyles } from './styles/styles';
 import RefTag from './tag';
 import { DescriptionTooltip } from './tooltip';
-import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, solidTagProps, SOLID_TEXT_COLOR } from './utils';
+import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, solidTagProps, SOLID_TEXT_COLOR, withoutBackground } from './utils';
 import { CSSObject } from 'antd-style';
 
 export interface IRefListStatusProps {
@@ -130,7 +130,7 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
              dropped from the inline style and the text is forced white - the icon follows through
              `currentColor`. With the badge off there is no chrome at all, just the text. */
           style={solidBackground === true
-            ? { ...rest, color: SOLID_TEXT_COLOR }
+            ? { ...withoutBackground(rest), color: SOLID_TEXT_COLOR }
             : { ...style, ...PLAIN_TEXT_STYLE }}
           className={cx(styles.shaStatusTag, disabled ? styles.shaStatusTagDisabled : undefined)}
         >

--- a/shesha-reactjs/src/components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/components/refListStatus/index.tsx
@@ -5,6 +5,7 @@ import { isNullOrWhiteSpace } from '@/utils/nullables';
 import { Alert, Skeleton } from 'antd';
 import { CSSProperties, FC, useEffect } from 'react';
 import { ShaIcon } from '../shaIcon';
+import { RefListStatusPlaceholder } from './placeholder';
 import { useStyles } from './styles/styles';
 import RefTag from './tag';
 import { DescriptionTooltip } from './tooltip';
@@ -30,6 +31,8 @@ export interface IRefListStatusProps {
   disabled?: boolean | undefined;
   /** Emotion class carrying the configured appearance; applied to the tag container. */
   className?: string | undefined;
+  /** Names the component on the designer canvas, where there is no value to show instead. */
+  propertyName?: string | undefined;
   /** Reports the resolved item text so a caller can expose it (e.g. through the component API). */
   onItemTextChange?: ((itemText: string | null | undefined) => void) | undefined;
 }
@@ -46,6 +49,7 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
     readOnly = false,
     disabled = false,
     className,
+    propertyName,
     onItemTextChange,
   } = props;
   const { width, height, minHeight, minWidth, maxHeight, maxWidth } = style;
@@ -87,16 +91,15 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
     if (isDesigner) {
       return (
         <div className={cx(styles.shaStatusTagContainer, className)}>
-          <RefTag
-            {...(solidBackground === true ? { color: solidColor, variant: 'solid' as const } : {})}
-            icon={null}
-            style={solidBackground === true
-              ? { ...rest, color: SOLID_TEXT_COLOR }
-              : { ...style, ...PLAIN_TEXT_STYLE }}
-            className={cx(styles.shaStatusTag, disabled ? styles.shaStatusTagDisabled : undefined)}
-          >
-            {showReflistName ? 'Reference List Item' : 'N/A'}
-          </RefTag>
+          <RefListStatusPlaceholder
+            referenceListId={referenceListId}
+            propertyName={propertyName}
+            showIcon={showIcon === true}
+            showReflistName={showReflistName}
+            solidBackground={solidBackground === true}
+            style={style}
+            tagClassName={cx(styles.shaStatusTag, disabled ? styles.shaStatusTagDisabled : undefined)}
+          />
         </div>
       );
     }

--- a/shesha-reactjs/src/components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/components/refListStatus/index.tsx
@@ -8,6 +8,7 @@ import { ShaIcon } from '../shaIcon';
 import { useStyles } from './styles/styles';
 import RefTag from './tag';
 import { DescriptionTooltip } from './tooltip';
+import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, SOLID_TEXT_COLOR } from './utils';
 import { CSSObject } from 'antd-style';
 
 export interface IRefListStatusProps {
@@ -74,15 +75,24 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
 
   const canShowIcon = showIcon && itemData?.icon;
 
+  /**
+   * A solid badge pulls its colour from the reference list item, the way the chevron does when its
+   * colour source is set to the reference list. Items with no colour fall back to grey rather than
+   * to nothing at all, which is what left Show Solid Background inert for colourless lists.
+   */
+  const solidColor = resolveColor(itemData?.color) ?? DEFAULT_SOLID_COLOR;
+
   // In designer mode, show a placeholder when there's no value or data
   if (typeof itemData?.itemValue === 'undefined' && !listItem.loading) {
     if (isDesigner) {
       return (
         <div className={cx(styles.shaStatusTagContainer, className)}>
           <RefTag
-            color="#d9d9d9"
+            {...(solidBackground === true ? { color: solidColor, variant: 'solid' as const } : {})}
             icon={null}
-            style={style}
+            style={solidBackground === true
+              ? { ...rest, color: SOLID_TEXT_COLOR }
+              : { ...style, ...PLAIN_TEXT_STYLE }}
             className={cx(styles.shaStatusTag, disabled ? styles.shaStatusTagDisabled : undefined)}
           >
             {showReflistName ? 'Reference List Item' : 'N/A'}
@@ -100,11 +110,17 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
     <div className={cx(styles.shaStatusTagContainer, className)}>
       <DescriptionTooltip showReflistName={showReflistName} currentStatus={itemData}>
         <RefTag
-          {...(solidBackground && !isNullOrWhiteSpace(itemData.color)
-            ? { color: itemData.color, variant: 'solid' as const }
-            : {})}
+          {...(solidBackground === true ? { color: solidColor, variant: 'solid' as const } : {})}
           icon={canShowIcon && !isNullOrWhiteSpace(itemData.icon) ? <ShaIcon iconName={itemData.icon} /> : null}
-          style={!solidBackground || !itemData.color ? style : { ...rest }}
+          /* With the name hidden the tag carries no text of its own, so name it explicitly - the
+             description tooltip only reaches pointer users. */
+          aria-label={showReflistName ? undefined : itemData.item ?? undefined}
+          /* A solid badge paints its own background, so the caller's background declarations are
+             dropped from the inline style and the text is forced white - the icon follows through
+             `currentColor`. With the badge off there is no chrome at all, just the text. */
+          style={solidBackground === true
+            ? { ...rest, color: SOLID_TEXT_COLOR }
+            : { ...style, ...PLAIN_TEXT_STYLE }}
           className={cx(styles.shaStatusTag, disabled ? styles.shaStatusTagDisabled : undefined)}
         >
           {showReflistName && itemData.item}

--- a/shesha-reactjs/src/components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/components/refListStatus/index.tsx
@@ -9,7 +9,7 @@ import { RefListStatusPlaceholder } from './placeholder';
 import { useStyles } from './styles/styles';
 import RefTag from './tag';
 import { DescriptionTooltip } from './tooltip';
-import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, SOLID_TEXT_COLOR } from './utils';
+import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, solidTagProps, SOLID_TEXT_COLOR } from './utils';
 import { CSSObject } from 'antd-style';
 
 export interface IRefListStatusProps {
@@ -33,6 +33,12 @@ export interface IRefListStatusProps {
   className?: string | undefined;
   /** Names the component on the designer canvas, where there is no value to show instead. */
   propertyName?: string | undefined;
+  /**
+   * Whether the display setting is a JS expression rather than a chosen mode. The designer canvas
+   * has no data to evaluate one against, so it previews a fixed representative tag instead of
+   * guessing which of the modes the expression will pick.
+   */
+  displayIsDynamic?: boolean | undefined;
   /** Reports the resolved item text so a caller can expose it (e.g. through the component API). */
   onItemTextChange?: ((itemText: string | null | undefined) => void) | undefined;
 }
@@ -50,6 +56,7 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
     disabled = false,
     className,
     propertyName,
+    displayIsDynamic = false,
     onItemTextChange,
   } = props;
   const { width, height, minHeight, minWidth, maxHeight, maxWidth } = style;
@@ -94,6 +101,7 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
           <RefListStatusPlaceholder
             referenceListId={referenceListId}
             propertyName={propertyName}
+            displayIsDynamic={displayIsDynamic}
             showIcon={showIcon === true}
             showReflistName={showReflistName}
             solidBackground={solidBackground === true}
@@ -113,7 +121,7 @@ export const RefListStatus: FC<IRefListStatusProps> = (props) => {
     <div className={cx(styles.shaStatusTagContainer, className)}>
       <DescriptionTooltip showReflistName={showReflistName} currentStatus={itemData}>
         <RefTag
-          {...(solidBackground === true ? { color: solidColor, variant: 'solid' as const } : {})}
+          {...(solidBackground === true ? solidTagProps(solidColor) : {})}
           icon={canShowIcon && !isNullOrWhiteSpace(itemData.icon) ? <ShaIcon iconName={itemData.icon} /> : null}
           /* With the name hidden the tag carries no text of its own, so name it explicitly - the
              description tooltip only reaches pointer users. */

--- a/shesha-reactjs/src/components/refListStatus/placeholder.tsx
+++ b/shesha-reactjs/src/components/refListStatus/placeholder.tsx
@@ -4,7 +4,7 @@ import { isNullOrWhiteSpace } from '@/utils/nullables';
 import { CSSProperties, FC } from 'react';
 import { ShaIcon } from '../shaIcon';
 import RefTag from './tag';
-import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, solidTagProps, SOLID_TEXT_COLOR } from './utils';
+import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, solidTagProps, SOLID_TEXT_COLOR, withoutBackground } from './utils';
 
 /** Stand-in text for a component with nothing to name it - an unbound status, in practice. */
 const PLACEHOLDER_TEXT = 'N/A';
@@ -66,7 +66,7 @@ export const RefListStatusPlaceholder: FC<IRefListStatusPlaceholderProps> = ({
       <RefTag
         {...solidTagProps(DEFAULT_SOLID_COLOR)}
         icon={<ShaIcon iconName={PLACEHOLDER_ICON} />}
-        style={{ ...style, color: SOLID_TEXT_COLOR }}
+        style={{ ...withoutBackground(style), color: SOLID_TEXT_COLOR }}
         className={tagClassName}
       >
         {DYNAMIC_TEXT}
@@ -78,7 +78,9 @@ export const RefListStatusPlaceholder: FC<IRefListStatusPlaceholderProps> = ({
     <RefTag
       {...(solidBackground ? solidTagProps(resolveColor(listColor) ?? DEFAULT_SOLID_COLOR) : {})}
       icon={showIcon ? <ShaIcon iconName={PLACEHOLDER_ICON} /> : null}
-      style={solidBackground ? { ...style, color: SOLID_TEXT_COLOR } : { ...style, ...PLAIN_TEXT_STYLE }}
+      style={solidBackground
+        ? { ...withoutBackground(style), color: SOLID_TEXT_COLOR }
+        : { ...style, ...PLAIN_TEXT_STYLE }}
       className={tagClassName}
     >
       {/* The text is dropped only when an icon is there to stand for the component. With neither,

--- a/shesha-reactjs/src/components/refListStatus/placeholder.tsx
+++ b/shesha-reactjs/src/components/refListStatus/placeholder.tsx
@@ -4,10 +4,15 @@ import { isNullOrWhiteSpace } from '@/utils/nullables';
 import { CSSProperties, FC } from 'react';
 import { ShaIcon } from '../shaIcon';
 import RefTag from './tag';
-import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, SOLID_TEXT_COLOR } from './utils';
+import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, solidTagProps, SOLID_TEXT_COLOR } from './utils';
 
 /** Stand-in text for a component with nothing to name it - an unbound status, in practice. */
 const PLACEHOLDER_TEXT = 'N/A';
+/**
+ * Stand-in text for a display driven by JS. Rendered uppercase by the tag's own `text-transform`,
+ * so it reads as REFERENCE LIST ITEM on the canvas.
+ */
+const DYNAMIC_TEXT = 'Reference List Item';
 /** Generic icon for the canvas, where there is no item to read a real one from. */
 const PLACEHOLDER_ICON = 'TagOutlined';
 
@@ -18,6 +23,8 @@ export interface IRefListStatusPlaceholderProps {
   showIcon: boolean;
   showReflistName: boolean;
   solidBackground: boolean;
+  /** Set when the display setting is a JS expression the canvas cannot evaluate. */
+  displayIsDynamic: boolean;
   style: CSSProperties;
   /** Emotion class for the tag itself, including the disabled treatment when it applies. */
   tagClassName: string;
@@ -38,6 +45,7 @@ export const RefListStatusPlaceholder: FC<IRefListStatusPlaceholderProps> = ({
   showIcon,
   showReflistName,
   solidBackground,
+  displayIsDynamic,
   style,
   tagClassName,
 }) => {
@@ -49,11 +57,26 @@ export const RefListStatusPlaceholder: FC<IRefListStatusPlaceholderProps> = ({
 
   const text = isNullOrWhiteSpace(propertyName) ? PLACEHOLDER_TEXT : propertyName;
 
+  /* A JS display could resolve to any of the modes, and to a different one per row. Rather than
+     pick one and misrepresent the rest, the canvas shows a single neutral shape: the icon, a grey
+     badge, and the component's own name. Show Solid Background and the list's colour are both
+     ignored here for the same reason - what the expression returns governs neither. */
+  if (displayIsDynamic) {
+    return (
+      <RefTag
+        {...solidTagProps(DEFAULT_SOLID_COLOR)}
+        icon={<ShaIcon iconName={PLACEHOLDER_ICON} />}
+        style={{ ...style, color: SOLID_TEXT_COLOR }}
+        className={tagClassName}
+      >
+        {DYNAMIC_TEXT}
+      </RefTag>
+    );
+  }
+
   return (
     <RefTag
-      {...(solidBackground
-        ? { color: resolveColor(listColor) ?? DEFAULT_SOLID_COLOR, variant: 'solid' as const }
-        : {})}
+      {...(solidBackground ? solidTagProps(resolveColor(listColor) ?? DEFAULT_SOLID_COLOR) : {})}
       icon={showIcon ? <ShaIcon iconName={PLACEHOLDER_ICON} /> : null}
       style={solidBackground ? { ...style, color: SOLID_TEXT_COLOR } : { ...style, ...PLAIN_TEXT_STYLE }}
       className={tagClassName}

--- a/shesha-reactjs/src/components/refListStatus/placeholder.tsx
+++ b/shesha-reactjs/src/components/refListStatus/placeholder.tsx
@@ -1,0 +1,67 @@
+import { IReferenceListIdentifier } from '@/interfaces/referenceList';
+import { useReferenceList } from '@/providers/referenceListDispatcher';
+import { isNullOrWhiteSpace } from '@/utils/nullables';
+import { CSSProperties, FC } from 'react';
+import { ShaIcon } from '../shaIcon';
+import RefTag from './tag';
+import { DEFAULT_SOLID_COLOR, PLAIN_TEXT_STYLE, resolveColor, SOLID_TEXT_COLOR } from './utils';
+
+/** Stand-in text for a component with nothing to name it - an unbound status, in practice. */
+const PLACEHOLDER_TEXT = 'N/A';
+/** Generic icon for the canvas, where there is no item to read a real one from. */
+const PLACEHOLDER_ICON = 'TagOutlined';
+
+export interface IRefListStatusPlaceholderProps {
+  referenceListId: IReferenceListIdentifier;
+  /** Named on the canvas so the configurator can tell one status apart from the next. */
+  propertyName: string | undefined;
+  showIcon: boolean;
+  showReflistName: boolean;
+  solidBackground: boolean;
+  style: CSSProperties;
+  /** Emotion class for the tag itself, including the disabled treatment when it applies. */
+  tagClassName: string;
+}
+
+/**
+ * Stand-in for the designer canvas, which has no value to resolve and so nothing for the appearance
+ * switches to act on.
+ *
+ * The icon is a generic tag rather than one lifted from the list: at design time there is no item
+ * to read an icon from, and picking some other item's would misrepresent whichever value the form
+ * ends up showing. The badge colour does come from the list, since that is a property of the list
+ * as a whole rather than of the absent value.
+ */
+export const RefListStatusPlaceholder: FC<IRefListStatusPlaceholderProps> = ({
+  referenceListId,
+  propertyName,
+  showIcon,
+  showReflistName,
+  solidBackground,
+  style,
+  tagClassName,
+}) => {
+  const items = useReferenceList(referenceListId).data?.items;
+
+  // The first item that actually carries one, so the badge previews the colour the runtime will
+  // paint for the items that have them, and grey for a list with none.
+  const listColor = items?.find((item) => !isNullOrWhiteSpace(item.color))?.color;
+
+  const text = isNullOrWhiteSpace(propertyName) ? PLACEHOLDER_TEXT : propertyName;
+
+  return (
+    <RefTag
+      {...(solidBackground
+        ? { color: resolveColor(listColor) ?? DEFAULT_SOLID_COLOR, variant: 'solid' as const }
+        : {})}
+      icon={showIcon ? <ShaIcon iconName={PLACEHOLDER_ICON} /> : null}
+      style={solidBackground ? { ...style, color: SOLID_TEXT_COLOR } : { ...style, ...PLAIN_TEXT_STYLE }}
+      className={tagClassName}
+    >
+      {/* The text is dropped only when an icon is there to stand for the component. With neither,
+          the runtime renders a bare colour swatch - or nothing at all with the badge off - which is
+          easy to mistake for a missing component while laying the form out. */}
+      {showReflistName ? text : showIcon ? null : PLACEHOLDER_TEXT}
+    </RefTag>
+  );
+};

--- a/shesha-reactjs/src/components/refListStatus/tag.tsx
+++ b/shesha-reactjs/src/components/refListStatus/tag.tsx
@@ -15,7 +15,7 @@ const EMPTY_TAG_MIN_WIDTH = 24;
  * accessible name for the case where the tag renders as a bare colour swatch, with no text for a
  * screen reader to announce.
  */
-interface ITagProps extends Pick<React.AriaAttributes, 'aria-label'> {
+export interface ITagProps extends Pick<React.AriaAttributes, 'aria-label'> {
   color?: string;
   /** antd tag variant. `solid` paints the background in `color` instead of a lightened tint. */
   variant?: 'filled' | 'solid' | 'outlined';

--- a/shesha-reactjs/src/components/refListStatus/tag.tsx
+++ b/shesha-reactjs/src/components/refListStatus/tag.tsx
@@ -1,7 +1,21 @@
 import { Tag } from 'antd';
 import { FC, PropsWithChildren } from 'react';
 import * as React from 'react';
-interface ITagProps {
+import { isDefined } from '@/utils/nullables';
+
+/**
+ * A tag carrying neither text nor an icon has nothing to give it width, so it collapses to its
+ * horizontal padding - and disappears entirely once that padding is zero. This keeps the colour
+ * swatch visible whatever the configured padding is; an explicit `minWidth` still wins.
+ */
+const EMPTY_TAG_MIN_WIDTH = 24;
+
+/**
+ * `aria-label` comes in through `AriaAttributes` rather than being declared inline: it is the tag's
+ * accessible name for the case where the tag renders as a bare colour swatch, with no text for a
+ * screen reader to announce.
+ */
+interface ITagProps extends Pick<React.AriaAttributes, 'aria-label'> {
   color?: string;
   /** antd tag variant. `solid` paints the background in `color` instead of a lightened tint. */
   variant?: 'filled' | 'solid' | 'outlined';
@@ -10,13 +24,15 @@ interface ITagProps {
   className?: string;
 }
 
-const RefTag: FC<PropsWithChildren<ITagProps>> = ({ children, ...props }) => {
-  if (!children && !props.icon) return null;
+const RefTag: FC<PropsWithChildren<ITagProps>> = ({ children, style, ...props }) => {
+  const isEmpty = !children && !props.icon;
+  const resolvedStyle = isEmpty ? { minWidth: EMPTY_TAG_MIN_WIDTH, ...style } : style;
 
   return (
     <Tag
       {...(props.className ? { className: props.className } : {})}
       {...props}
+      {...(isDefined(resolvedStyle) ? { style: resolvedStyle } : {})}
     >
       {children}
     </Tag>

--- a/shesha-reactjs/src/components/refListStatus/utils.ts
+++ b/shesha-reactjs/src/components/refListStatus/utils.ts
@@ -1,5 +1,6 @@
 import { isNullOrWhiteSpace } from '@/utils/nullables';
 import { CSSProperties } from 'react';
+import { ITagProps } from './tag';
 
 /**
  * Strips the tag chrome so the value reads as plain text, which is what the component looks like
@@ -37,3 +38,9 @@ export const SOLID_TEXT_COLOR = '#fff';
 export const resolveColor = (...candidates: (string | null | undefined)[]): string | undefined => {
   return candidates.find((candidate) => !isNullOrWhiteSpace(candidate)) ?? undefined;
 };
+
+/**
+ * The tag props that paint a solid badge. A declared return type gives `variant` its literal type,
+ * which a conditionally spread object literal would otherwise widen to `string`.
+ */
+export const solidTagProps = (color: string): Pick<ITagProps, 'color' | 'variant'> => ({ color, variant: 'solid' });

--- a/shesha-reactjs/src/components/refListStatus/utils.ts
+++ b/shesha-reactjs/src/components/refListStatus/utils.ts
@@ -1,0 +1,39 @@
+import { isNullOrWhiteSpace } from '@/utils/nullables';
+import { CSSProperties } from 'react';
+
+/**
+ * Strips the tag chrome so the value reads as plain text, which is what the component looks like
+ * with Show Solid Background off.
+ *
+ * Applied inline because the chrome arrives through an emotion class - the Appearance border,
+ * background, padding and shadow are written onto `.ant-tag`, which outranks any class this
+ * component could add of its own.
+ */
+export const PLAIN_TEXT_STYLE: CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+  padding: 0,
+};
+
+/**
+ * Colour a solid badge falls back to when the reference list item carries none of its own. Dark
+ * enough to read the white text a solid tag uses, and distinct from the pale grey of the ordinary
+ * filled tag, so Show Solid Background still visibly does something for a colourless list.
+ */
+export const DEFAULT_SOLID_COLOR = '#8c8c8c';
+
+/**
+ * Text and icon colour for a solid badge. Applied inline rather than left to antd's solid variant:
+ * the Appearance font colour reaches `.ant-tag` through an emotion class, which outranks antd's own
+ * rule and was painting black text onto the coloured background.
+ */
+export const SOLID_TEXT_COLOR = '#fff';
+
+/**
+ * First candidate that is an actual colour. The badge colour is resolved this way in both the
+ * runtime and the designer branch, so they stay in step as candidates are added or reordered.
+ */
+export const resolveColor = (...candidates: (string | null | undefined)[]): string | undefined => {
+  return candidates.find((candidate) => !isNullOrWhiteSpace(candidate)) ?? undefined;
+};

--- a/shesha-reactjs/src/components/refListStatus/utils.ts
+++ b/shesha-reactjs/src/components/refListStatus/utils.ts
@@ -40,6 +40,14 @@ export const resolveColor = (...candidates: (string | null | undefined)[]): stri
 };
 
 /**
+ * Drops a caller's background declarations, shorthand included - the shorthand would otherwise reset
+ * the background-color a solid badge paints itself with.
+ */
+export const withoutBackground = (
+  { background, backgroundColor, backgroundImage, ...rest }: CSSProperties,
+): CSSProperties => rest;
+
+/**
  * The tag props that paint a solid badge. A declared return type gives `variant` its literal type,
  * which a conditionally spread object literal would otherwise widen to `string`.
  */

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/index.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/index.tsx
@@ -30,6 +30,7 @@ import { DataSortingEditorWrapper } from "./dataSortingEditor";
 import { QueryBuilderWrapper } from "./queryBuilder";
 import { FiltersListWrapper } from "./filtersListWrapper";
 import { EditModeSelectorWrapper } from "./editModeSelector";
+import { RefListDisplaySelectorWrapper } from "./refListDisplaySelector";
 import { ConfigurableActionConfiguratorWrapper } from "./configurableActionConfigurator";
 import { RefListItemSelectorSettingsModalWrapper } from "./refListItemSelectorSettingsModal";
 import { PasswordWrapper } from "./password";
@@ -90,6 +91,7 @@ export const editorRegistry: EditorDictionary = {
   queryBuilder: QueryBuilderWrapper,
   filtersList: FiltersListWrapper,
   editModeSelector: EditModeSelectorWrapper,
+  refListDisplaySelector: RefListDisplaySelectorWrapper,
   threeStateSwitch: ThreeStateSwitchWrapper,
   configurableActionConfigurator: ConfigurableActionConfiguratorWrapper,
   RefListItemSelectorSettingsModal: RefListItemSelectorSettingsModalWrapper,

--- a/shesha-reactjs/src/designer-components/inputComponent/wrappers/refListDisplaySelector.tsx
+++ b/shesha-reactjs/src/designer-components/inputComponent/wrappers/refListDisplaySelector.tsx
@@ -1,0 +1,32 @@
+import RefListDisplaySelector from '@/components/refListDisplaySelector';
+import { useDefaultModelActionsOrUndefined } from '@/designer-components/_settings/defaultModelProvider/defaultModelProvider';
+import { IRefListDisplaySelectorSettingsInputProps } from '@/designer-components/settingsInput/interfaces';
+import { FCUnwrapped } from '@/providers/form/models';
+import { isNotNullOrWhiteSpace } from '@/utils/nullables';
+import { useMemo } from 'react';
+import { useStyles } from '../styles';
+
+export const RefListDisplaySelectorWrapper: FCUnwrapped<IRefListDisplaySelectorSettingsInputProps> = (props) => {
+  const { styles } = useStyles();
+  const { value, onChange, readOnly, size } = props;
+  const defaultModel = useDefaultModelActionsOrUndefined();
+  const onlyModel = isNotNullOrWhiteSpace(props.defaultModelPropertyName)
+    ? defaultModel?.getValueInfo(props.defaultModelPropertyName)?.state === 'onlyModel'
+    : true;
+
+  const currentValueAdditionalInfo = useMemo(
+    () => onlyModel ? undefined : (info: string) => defaultModel?.setCurrentValueAdditionalInfo(props.propertyName, info),
+    [onlyModel, defaultModel, props.propertyName],
+  );
+
+  return (
+    <RefListDisplaySelector
+      readOnly={readOnly}
+      value={value}
+      onChange={onChange}
+      onGetAdditionalInfo={currentValueAdditionalInfo}
+      size={size}
+      className={styles.radioBtns}
+    />
+  );
+};

--- a/shesha-reactjs/src/designer-components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/designer-components/refListStatus/index.tsx
@@ -1,5 +1,4 @@
 import { ConfigurableFormItem } from '@/components/formDesigner/components/formItem';
-import ReadOnlyDisplayFormItem from '@/components/readOnlyDisplayFormItem';
 import { RefListStatus } from '@/components/refListStatus/index';
 import { migrateCustomFunctions, migrateHiddenToVisible, migratePropertyName, migrateReadOnly, migrateStylingBoxToJson } from '@/designer-components/_common-migrations/migrateSettings';
 import { migrateVisibility } from '@/designer-components/_common-migrations/migrateVisibility';
@@ -8,12 +7,10 @@ import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { DataTypes } from '@/interfaces/dataTypes';
 import { IInputStyles, useForm } from '@/providers';
 import { useComponentApiProvider } from '@/providers/componentApi/provider';
-import { useReferenceListItem } from '@/providers/referenceListDispatcher';
-import { IReferenceListIdentifier } from '@/interfaces/referenceList';
 import { isDefined } from '@/utils/nullables';
 import { FileSearchOutlined } from '@ant-design/icons';
 import { Alert } from 'antd';
-import { FC, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { RefListStatusApi } from '../../componentsApi/componentApi';
 import { migrateFormApi } from '../_common-migrations/migrateFormApi1';
 import { migratePermissionsToVisiblePermissions } from '../_common-migrations/migratePermissionsToVisiblePermissions';
@@ -26,43 +23,6 @@ import { useStyles } from './styles';
 import { defaultStyles } from './utils';
 
 import apiCode from "../../componentsApi/componentApi.ts?raw";
-
-interface IRefListStatusReadOnlyProps {
-  model: IRefListStatusComponentProps;
-  referenceListId: IReferenceListIdentifier;
-  value: number | undefined;
-  onItemTextChange: (itemText: string | null | undefined) => void;
-}
-
-/**
- * Read-only rendering of the status.
- *
- * This resolves the item text itself rather than reusing the `itemText` the editable branch reports
- * through `onItemTextChange`: that callback only fires from `RefListStatus`, which read-only mode
- * never renders, so the text would otherwise stay undefined and the field would render empty.
- *
- * Resolving it through the hook also keeps it in step with `value` — the hook re-reads the list
- * whenever the value changes.
- */
-const RefListStatusReadOnly: FC<IRefListStatusReadOnlyProps> = ({ model, referenceListId, value, onItemTextChange }) => {
-  const item = useReferenceListItem(referenceListId.module, referenceListId.name, value);
-  const itemText = item.data?.item;
-
-  /* Reported so the component API exposes `itemText` in read-only mode too, matching the editable
-     branch. */
-  useEffect(() => {
-    onItemTextChange(itemText);
-  }, [itemText, onItemTextChange]);
-
-  return (
-    <ReadOnlyDisplayFormItem
-      value={itemText}
-      enableFullStyle={model.enableStyleOnReadonly}
-      style={model.styleCss}
-      styleValue={model}
-    />
-  );
-};
 
 const RefListStatusComponent: RefListStatusComponentDefinition = {
   allowInherit: true,
@@ -113,34 +73,28 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
     return (
       <ConfigurableFormItem<number> model={{ ...model }}>
         {(value, _onChange, _propertyName, ctx) => {
-          // Read only renders the value as plain text; disabled keeps the tag but greys it out and
-          // blocks pointer interaction. The two are independent settings of Interaction Mode.
-          return model.readOnly === true
-            ? (
-              <RefListStatusReadOnly
-                model={model}
-                referenceListId={referenceListId}
+          // The tag renders in every interaction mode. Read only is a status tag's natural state -
+          // rendering it as plain text instead threw away the icon, colour and badge, which is the
+          // whole of what the component displays. Disabled keeps the tag but greys it out and
+          // blocks pointer interaction; the two are independent settings of Interaction Mode.
+          return (
+            <div
+              className={styles.refListStatus}
+              {...getComponentEvents<number>(model, ALL_INPUT_EVENTS_WITHOUT_CHANGE, ctx, value, DataTypes.number)}
+            >
+              <RefListStatus
                 value={value ?? undefined}
+                referenceListId={referenceListId}
+                showIcon={model.showIcon}
+                showReflistName={showReflistName}
+                solidBackground={solidBackground}
+                isDesigner={formMode === 'designer'}
+                readOnly={model.readOnly === true}
+                disabled={model.disabled === true}
                 onItemTextChange={onItemTextChange}
               />
-            )
-            : (
-              <div
-                className={styles.refListStatus}
-                {...getComponentEvents<number>(model, ALL_INPUT_EVENTS_WITHOUT_CHANGE, ctx, value, DataTypes.number)}
-              >
-                <RefListStatus
-                  value={value ?? undefined}
-                  referenceListId={referenceListId}
-                  showIcon={model.showIcon}
-                  showReflistName={showReflistName}
-                  solidBackground={solidBackground}
-                  isDesigner={formMode === 'designer'}
-                  disabled={model.disabled === true}
-                  onItemTextChange={onItemTextChange}
-                />
-              </div>
-            );
+            </div>
+          );
         }}
       </ConfigurableFormItem>
     );

--- a/shesha-reactjs/src/designer-components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/designer-components/refListStatus/index.tsx
@@ -67,7 +67,7 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
     }, [apiContext, componentApi, itemText, model.componentName, model.id]);
     useEffectOnce(() => () => componentApi?.removeApi(model.id));
 
-    const { styles } = useStyles(model);
+    const { styles, cx } = useStyles(model);
 
     if (!isDefined(referenceListId)) {
       return formMode === 'designer'
@@ -91,7 +91,7 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
           // blocks pointer interaction; the two are independent settings of Interaction Mode.
           return (
             <div
-              className={styles.refListStatus}
+              className={cx(styles.refListStatus, formMode === 'designer' ? styles.designerFootprint : undefined)}
               {...getComponentEvents<number>(model, ALL_INPUT_EVENTS_WITHOUT_CHANGE, ctx, value, DataTypes.number)}
             >
               <RefListStatus

--- a/shesha-reactjs/src/designer-components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/designer-components/refListStatus/index.tsx
@@ -85,6 +85,7 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
               <RefListStatus
                 value={value ?? undefined}
                 referenceListId={referenceListId}
+                propertyName={model.propertyName}
                 showIcon={model.showIcon}
                 showReflistName={showReflistName}
                 solidBackground={solidBackground}

--- a/shesha-reactjs/src/designer-components/refListStatus/index.tsx
+++ b/shesha-reactjs/src/designer-components/refListStatus/index.tsx
@@ -1,4 +1,5 @@
 import { ConfigurableFormItem } from '@/components/formDesigner/components/formItem';
+import { resolveRefListDisplay } from '@/components/refListDisplaySelector/models';
 import { RefListStatus } from '@/components/refListStatus/index';
 import { migrateCustomFunctions, migrateHiddenToVisible, migratePropertyName, migrateReadOnly, migrateStylingBoxToJson } from '@/designer-components/_common-migrations/migrateSettings';
 import { migrateVisibility } from '@/designer-components/_common-migrations/migrateVisibility';
@@ -7,6 +8,8 @@ import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { DataTypes } from '@/interfaces/dataTypes';
 import { IInputStyles, useForm } from '@/providers';
 import { useComponentApiProvider } from '@/providers/componentApi/provider';
+import { useComponentModel } from '@/providers/form/providers/formMarkupProvider';
+import { isPropertySettings } from '../_settings/utils/utils';
 import { isDefined } from '@/utils/nullables';
 import { FileSearchOutlined } from '@ant-design/icons';
 import { Alert } from 'antd';
@@ -17,6 +20,7 @@ import { migratePermissionsToVisiblePermissions } from '../_common-migrations/mi
 import { migratePrevStyles } from '../_common-migrations/migrateStyles';
 import { ALL_INPUT_EVENTS_WITHOUT_CHANGE, getComponentEvents } from '../_common/events';
 import { IRefListStatusComponentProps, IRefListStatusComponentPropsV1, RefListStatusComponentDefinition } from './interfaces';
+import { migrateItemDisplay } from './migrations/migrateItemDisplay';
 import { IRefListStatusPropsV0 } from './migrations/models';
 import { getSettings } from './settings';
 import { useStyles } from './styles';
@@ -35,7 +39,15 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
   icon: <FileSearchOutlined />,
   Factory: ({ model, apiContext }) => {
     const { formMode } = useForm();
-    const { solidBackground = true, referenceListId, showReflistName = true } = model;
+    const { solidBackground = true, referenceListId } = model;
+
+    const { showName, showIcon } = resolveRefListDisplay(model.itemDisplay);
+
+    /* The raw markup still carries the unevaluated setting, which is the only way to tell a JS
+       display apart from a chosen mode: by the time the model reaches here the evaluators have all
+       been resolved. The canvas needs to know because it has no data to resolve them against. */
+    const rawModel: Partial<IRefListStatusComponentProps> = useComponentModel(model.id);
+    const displayIsDynamic = isPropertySettings(rawModel.itemDisplay) && rawModel.itemDisplay._mode === 'code';
 
     const [itemText, setItemText] = useState<string | undefined>(undefined);
     const onItemTextChange = useCallback((value: string | null | undefined) => setItemText(value ?? undefined), []);
@@ -86,10 +98,11 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
                 value={value ?? undefined}
                 referenceListId={referenceListId}
                 propertyName={model.propertyName}
-                showIcon={model.showIcon}
-                showReflistName={showReflistName}
+                showIcon={showIcon}
+                showReflistName={showName}
                 solidBackground={solidBackground}
                 isDesigner={formMode === 'designer'}
+                displayIsDynamic={displayIsDynamic}
                 readOnly={model.readOnly === true}
                 disabled={model.disabled === true}
                 onItemTextChange={onItemTextChange}
@@ -153,8 +166,18 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
     .add<IRefListStatusComponentPropsV1>(6, (prev, context) => context.isNew === true
       ? prev
       : { ...migratePrevStyles(prev, defaultStyles()) })
-    .add<IRefListStatusComponentProps>(7, (prev) => migrateReadOnly(prev))
-    .add<IRefListStatusComponentProps>(8, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(migrateStylingBoxToJson(prev)))),
+    .add<IRefListStatusComponentPropsV1>(7, (prev) => migrateReadOnly(prev))
+    .add<IRefListStatusComponentPropsV1>(8, (prev, context) => {
+      const migrated = migratePermissionsToVisiblePermissions(migrateHiddenToVisible(prev));
+      // stylingBox is a style migration, so it is for existing components only.
+      return context.isNew === true ? migrated : migrateStylingBoxToJson(migrated);
+    })
+    .add<IRefListStatusComponentProps>(9, (prev, context) => {
+      if (context.isNew === true) return prev;
+
+      const { showReflistName, showIcon, ...rest } = prev;
+      return { ...rest, ...migrateItemDisplay(showReflistName, showIcon) };
+    }),
   settingsFormMarkup: getSettings,
 
   linkToModelMetadata: (model, metadata): IRefListStatusComponentProps => {
@@ -176,7 +199,7 @@ const RefListStatusComponent: RefListStatusComponentDefinition = {
     propertyName: 'refListStatusAppearance',
     label: 'Reference List Status Label',
     version: 'latest',
-    showReflistName: true,
+    itemDisplay: 'name',
     solidBackground: true,
   },
 };

--- a/shesha-reactjs/src/designer-components/refListStatus/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/refListStatus/interfaces.ts
@@ -1,6 +1,7 @@
+import { RefListDisplayValue } from '@/components/refListDisplaySelector/models';
 import { ComponentDefinition } from '@/interfaces';
 import { IReferenceListIdentifier } from '@/interfaces/referenceList';
-import { IConfigurableFormComponent, IInputStyles } from '@/providers/form/models';
+import { IConfigurableFormComponent, IInputStyles, IPropertySetting } from '@/providers/form/models';
 
 /**
  * Model as it was before the refactor. Kept for the migrator steps that were released against it —
@@ -15,9 +16,13 @@ export interface IRefListStatusComponentPropsV1 extends IConfigurableFormCompone
 
 export interface IRefListStatusComponentProps extends IConfigurableFormComponent, IInputStyles {
   referenceListId?: IReferenceListIdentifier | undefined;
-  showIcon?: boolean | undefined;
+  /**
+   * Whether the item's name, its icon, or both are shown. A JS setting supplies the flags directly
+   * instead of a mode - see `RefListDisplayValue`. Replaces the `showReflistName` and `showIcon`
+   * switches, which V1 kept as a pair.
+   */
+  itemDisplay?: RefListDisplayValue | IPropertySetting<RefListDisplayValue> | undefined;
   solidBackground?: boolean | undefined;
-  showReflistName?: boolean | undefined;
 }
 
 export type RefListStatusComponentDefinition = ComponentDefinition<'refListStatus', IRefListStatusComponentProps>;

--- a/shesha-reactjs/src/designer-components/refListStatus/migrations/__tests__/migrateItemDisplay.test.ts
+++ b/shesha-reactjs/src/designer-components/refListStatus/migrations/__tests__/migrateItemDisplay.test.ts
@@ -1,0 +1,59 @@
+import { IRefListDisplay } from '@/components/refListDisplaySelector/models';
+import { SafeFunctionType } from '@/providers/form/models';
+import { migrateItemDisplay } from '../migrateItemDisplay';
+
+type DisplayEvaluator = (data: { showTheName: boolean }) => IRefListDisplay;
+
+/** `new Function` is typed only as callable, which says nothing about how it may be called. */
+const isDisplayEvaluator = (value: SafeFunctionType): value is DisplayEvaluator => typeof value === 'function';
+
+describe('migrateItemDisplay', () => {
+  it.each([
+    [true, false, 'name'],
+    [false, true, 'icon'],
+    [true, true, 'both'],
+    // The old pair had no mode for "neither", which rendered a bare colour badge.
+    [false, false, 'both'],
+  ] as const)('folds showReflistName=%p and showIcon=%p into %s', (showName, showIcon, expected) => {
+    expect(migrateItemDisplay(showName, showIcon).itemDisplay).toBe(expected);
+  });
+
+  it('keeps the pre-selector defaults for switches that were never set', () => {
+    expect(migrateItemDisplay(undefined, undefined).itemDisplay).toBe('name');
+  });
+
+  it('reads a value-mode setting through its stored value', () => {
+    expect(migrateItemDisplay({ _mode: 'value', _value: false }, { _mode: 'value', _value: true }).itemDisplay)
+      .toBe('icon');
+  });
+
+  describe('where either switch was driven by JS', () => {
+    const dynamic = migrateItemDisplay(
+      { _mode: 'code', _code: 'return data.showTheName;', _value: true },
+      false,
+    );
+
+    it('produces a JS setting rather than discarding the expression', () => {
+      expect(dynamic.itemDisplay).toMatchObject({ _mode: 'code' });
+    });
+
+    it('calls the original expression in place', () => {
+      const code = typeof dynamic.itemDisplay === 'object' ? dynamic.itemDisplay._code ?? '' : '';
+
+      expect(code).toContain('(() => { return data.showTheName; })()');
+    });
+
+    it('keeps the statically mapped mode as the fallback value', () => {
+      expect(dynamic.itemDisplay).toMatchObject({ _value: 'name' });
+    });
+
+    it('composes into an expression that evaluates to the display flags', () => {
+      const code = typeof dynamic.itemDisplay === 'object' ? dynamic.itemDisplay._code ?? '' : '';
+      const compiled = new Function('data', code);
+      if (!isDisplayEvaluator(compiled)) throw new Error('the migrated setting did not compile');
+
+      expect(compiled({ showTheName: true })).toEqual({ showName: true, showIcon: false });
+      expect(compiled({ showTheName: false })).toEqual({ showName: false, showIcon: false });
+    });
+  });
+});

--- a/shesha-reactjs/src/designer-components/refListStatus/migrations/migrateItemDisplay.ts
+++ b/shesha-reactjs/src/designer-components/refListStatus/migrations/migrateItemDisplay.ts
@@ -1,0 +1,72 @@
+import { RefListDisplayMode } from '@/components/refListDisplaySelector/models';
+import { IPropertySetting } from '@/providers/form/models';
+import { isDefined, isNotNullOrWhiteSpace } from '@/utils/nullables';
+
+/**
+ * Either of the two switches this replaces could be a plain boolean or a JS setting, both of them
+ * having been declared with `jsSetting: true`.
+ */
+type SwitchValue = boolean | IPropertySetting<boolean> | undefined;
+
+const isSetting = (value: SwitchValue): value is IPropertySetting<boolean> =>
+  isDefined(value) && typeof value === 'object' && '_mode' in value;
+
+/** The value a setting falls back to, which for a JS setting is the one stored alongside the code. */
+const staticValue = (value: SwitchValue, fallback: boolean): boolean => {
+  if (isSetting(value))
+    return value._value ?? fallback;
+  return isDefined(value) ? value : fallback;
+};
+
+/**
+ * The old pair had no mode for "neither", which rendered as a bare colour badge. Those land on
+ * `both`, so nothing comes out blank after the upgrade - at the cost of changing how a deliberately
+ * colour-only badge looks.
+ */
+const toMode = (showName: boolean, showIcon: boolean): RefListDisplayMode => {
+  if (showName && showIcon) return 'both';
+  if (showIcon) return 'icon';
+  if (showName) return 'name';
+  return 'both';
+};
+
+/**
+ * A JS switch is an expression body, so it composes into the new one by being called in place. That
+ * keeps a configurator's expressions working rather than silently discarding them for the static
+ * fallback the setting happens to carry.
+ */
+const expression = (value: SwitchValue, fallback: boolean): string =>
+  isSetting(value) && value._mode === 'code' && isNotNullOrWhiteSpace(value._code)
+    ? `(() => { ${value._code} })()`
+    : String(staticValue(value, fallback));
+
+/* `showName` defaulted to true and `showIcon` to false before the selector existed; the composed
+   expression has to keep both defaults for a migrated form to look the way it did. */
+const composedCode = (name: SwitchValue, icon: SwitchValue): string => [
+  '// Migrated from the separate Show Reference List Item Name and Show Icon settings.',
+  `const showName = ${expression(name, true)};`,
+  `const showIcon = ${expression(icon, false)};`,
+  'return { showName: showName === undefined ? true : Boolean(showName), showIcon: Boolean(showIcon) };',
+].join('\n');
+
+export interface IMigratedItemDisplay {
+  itemDisplay: RefListDisplayMode | IPropertySetting<RefListDisplayMode>;
+}
+
+/**
+ * Folds `showReflistName` and `showIcon` into the single `itemDisplay` setting the display selector
+ * reads. Where either switch was driven by JS the result is a JS setting too, since the selector's
+ * three modes cannot express a value computed per row.
+ */
+export const migrateItemDisplay = (showReflistName: SwitchValue, showIcon: SwitchValue): IMigratedItemDisplay => {
+  const mode = toMode(staticValue(showReflistName, true), staticValue(showIcon, false));
+
+  const isDynamic = (isSetting(showReflistName) && showReflistName._mode === 'code') ||
+    (isSetting(showIcon) && showIcon._mode === 'code');
+
+  return {
+    itemDisplay: isDynamic
+      ? { _mode: 'code', _code: composedCode(showReflistName, showIcon), _value: mode }
+      : mode,
+  };
+};

--- a/shesha-reactjs/src/designer-components/refListStatus/settings.ts
+++ b/shesha-reactjs/src/designer-components/refListStatus/settings.ts
@@ -24,13 +24,20 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                 .addSettingsInputRow({
                   inputs: [
                     { type: 'referenceListAutocomplete', propertyName: 'referenceListId', label: 'Reference List', validate: { required: true }, jsSetting: true },
-                    { type: 'switch', propertyName: 'showReflistName', label: 'Show Reference List Item Name', size: 'small', jsSetting: true, tooltip: 'When checked the DisplayName/RefList Name will be shown.' },
+                    {
+                      type: 'refListDisplaySelector', propertyName: 'itemDisplay', label: 'Display', size: 'small', jsSetting: true,
+                      tooltip: 'Whether to show the reference list item name, its icon, or both. At least one of the two is always shown.' +
+                        ' In JS mode, return an object of the form { showName: true, showIcon: false }.',
+                    },
                   ],
                 })
                 .addSettingsInputRow({
                   inputs: [
-                    { type: 'switch', propertyName: 'showIcon', label: 'Show Icon', size: 'small', jsSetting: true, tooltip: 'When checked the icon will display on the left side of the DisplayName' },
-                    { type: 'switch', propertyName: 'solidBackground', label: 'Show Solid Background', size: 'small', jsSetting: true, tooltip: 'When checked the component will show a coloured badge and display within it in white font the icon and/or the selected reference list item label.' },
+                    {
+                      type: 'switch', propertyName: 'solidBackground', label: 'Show Solid Background', size: 'small', jsSetting: true,
+                      tooltip: 'When checked the component shows a coloured badge, taking its colour from the reference list item, and' +
+                        ' displays the icon and/or name within it in white. When unchecked it reads as plain text.',
+                    },
                   ],
                 }))
               .stdCollapsiblePanel('Validations', (fb) => fb

--- a/shesha-reactjs/src/designer-components/refListStatus/styles.ts
+++ b/shesha-reactjs/src/designer-components/refListStatus/styles.ts
@@ -2,7 +2,7 @@ import { createStyles } from '@/styles';
 import { backgroundStyles, borderStyles, cssPropertiesToString, dimensionsStyles, fontStyles, paddingStyles, shadowStyles } from '../_common/styles/utils';
 import { IRefListStatusComponentProps } from './interfaces';
 
-export const useStyles = createStyles(({ css, cx }, model: IRefListStatusComponentProps) => {
+export const useStyles = createStyles(({ css, cx, token }, model: IRefListStatusComponentProps) => {
   const refListStatus = cx('sha-ref-list-status', css`
     display: flex;
     align-items: center;
@@ -34,7 +34,19 @@ export const useStyles = createStyles(({ css, cx }, model: IRefListStatusCompone
     }
   `);
 
+  /**
+   * Traces the tag on the canvas, which the plain-text state otherwise gives no clue about. An
+   * outline takes no space, and inset keeps it off the designer's own hover border on the ancestor.
+   */
+  const designerFootprint = cx('sha-ref-list-status-footprint', css`
+    .ant-tag {
+      outline: 1px dashed ${token.colorBorder};
+      outline-offset: -1px;
+    }
+  `);
+
   return {
     refListStatus,
+    designerFootprint,
   };
 });

--- a/shesha-reactjs/src/designer-components/settingsInput/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/settingsInput/interfaces.ts
@@ -24,6 +24,7 @@ import { IColumnProps } from '../columns/interfaces';
 import { DateFieldValueType } from '../dateField/interfaces';
 import { IDynamicActionsConfiguration } from '../dynamicActionsConfigurator/models';
 import { KeyInfomationBarItemProps } from '../keyInformationBar/interfaces';
+import { RefListDisplayValue } from '@/components/refListDisplaySelector/models';
 import { IRefListItemFormModel } from '@/components/refListSelectorDisplay/provider/models';
 import { ISizableColumnProps } from '../sizableColumns/interfaces';
 
@@ -432,6 +433,11 @@ export interface IEditModeSelectorSettingsInputProps extends ISettingsInputBase<
   interactionType?: InteractionType | undefined;
 }
 
+// Reference List Display Selector
+export interface IRefListDisplaySelectorSettingsInputProps extends ISettingsInputBase<RefListDisplayValue> {
+  type: 'refListDisplaySelector';
+}
+
 // Three State Switch
 export interface IThreeStateSwitchSettingsInputProps extends ISettingsInputBase<boolean> {
   type: 'threeStateSwitch';
@@ -523,6 +529,7 @@ export type BaseInputProps =
   IQueryBuilderSettingsInputProps |
   IFiltersListSettingsInputProps |
   IEditModeSelectorSettingsInputProps |
+  IRefListDisplaySelectorSettingsInputProps |
   IPermissionsSettingsInputProps |
   IConfigurableActionConfiguratorSettingsInputProps |
   IRefListItemSelectorSettingsModalProps |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a display selector for reference-list items, supporting name, icon, or both.
  - Added dynamic display settings with improved designer guidance.
  - Enhanced reference-list status badges with color handling, placeholders, accessibility labels, and plain-text rendering.

- **Bug Fixes**
  - Improved previews for missing, dynamic, and read-only reference-list values.
  - Preserved existing display settings during configuration migration.

- **Tests**
  - Added coverage for display selection, migrations, badge rendering, colors, and dynamic values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->