### PR TITLE
fix: refresh the data table context when the dataset changes (#5352)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ npm run build
 npm test
 
 # Run single test file
-npm test -- --testPathPattern="path/to/test"
+npx vitest run path/to/test
 
 # Watch mode for development
 npm run start
@@ -120,8 +120,9 @@ Replaces GlobalState to prevent unnecessary re-renders:
 - Tests run against SQL Server/PostgreSQL in containers
 
 ### Frontend Tests
-- Framework: Jest with React Testing Library
-- Config: `jest.config.js`
+- Framework: Vitest with React Testing Library (jest-dom matchers via `@testing-library/jest-dom/vitest`)
+- Config: `vitest.config.mjs`, setup in `vitest-setup.ts`
+- `globals: true`, so `describe`/`it`/`expect`/`vi` are used without importing them (typed via the `vitest/globals` entry in `tsconfig.json`)
 - Test files: `*.test.ts` or `*.spec.tsx` in `src/`
 
 ## Key Patterns

--- a/shesha-reactjs/src/providers/dataTable/__tests__/contextRegistration.test.tsx
+++ b/shesha-reactjs/src/providers/dataTable/__tests__/contextRegistration.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { PropsWithChildren, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { IDataTableStateContext } from '../interfaces.state';
+import { IDatasetInstance } from '../models';
+import { IRepository } from '../repository/interfaces';
+import { throwError } from '@/utils/errors';
+
+type Binding = { data: IDataTableStateContext; api: IDatasetInstance };
+
+/** Data and api published to the data context on each render of the binder */
+const bindings: Binding[] = [];
+
+const lastBinding = (): Binding => bindings[bindings.length - 1] ?? throwError('the data context was not registered');
+
+vi.mock('@/providers/dataContextProvider/dataContextBinder', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  default: (props: PropsWithChildren<{ data: IDataTableStateContext; api: IDatasetInstance }>): ReactNode => {
+    bindings.push({ data: props.data, api: props.api });
+    return props.children;
+  },
+}));
+
+vi.mock('@/providers/configurableActionsDispatcher', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useConfigurableAction: (): undefined => undefined,
+}));
+
+const { DataTableProviderWithRepository } = await import('../provider');
+
+const makeRepository = (): IRepository => ({
+  repositoryType: 'test',
+  fetchingSettingsHash: '',
+  prepareColumns: vi.fn().mockResolvedValue([]),
+  fetch: vi.fn().mockResolvedValue({ rows: [], totalPages: 0, totalRows: 0, totalRowsBeforeFilter: 0 }),
+  exportToExcel: vi.fn().mockResolvedValue(undefined),
+  reorder: vi.fn().mockResolvedValue(undefined),
+  performCreate: vi.fn(),
+  performUpdate: vi.fn(),
+  performDelete: vi.fn(),
+} as unknown as IRepository);
+
+describe('data table context registration', () => {
+  it('publishes the current dataset state to the context after the selection changes', async () => {
+    bindings.length = 0;
+
+    render(
+      <DataTableProviderWithRepository
+        repository={makeRepository()}
+        dataFetchingMode="paging"
+        actionOwnerId="owner-1"
+        actionOwnerName="TestTable"
+      >
+        <div>child</div>
+      </DataTableProviderWithRepository>,
+    );
+
+    await waitFor(() => expect(bindings.length).toBeGreaterThan(0));
+    expect(lastBinding().data.selectedRow).toBeUndefined();
+
+    const api = lastBinding().api;
+    act(() => api.setSelectedRow(0, { id: 'row-1' }));
+
+    // the context must expose the new state, not the snapshot taken when the binder mounted -
+    // scripts read the selection through it (`contexts.<name>.selectedRow`)
+    await waitFor(() => expect(lastBinding().data.selectedRow?.id).toBe('row-1'));
+  });
+});

--- a/shesha-reactjs/src/providers/dataTable/__tests__/contextRegistration.test.tsx
+++ b/shesha-reactjs/src/providers/dataTable/__tests__/contextRegistration.test.tsx
@@ -1,6 +1,5 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { PropsWithChildren, ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
 import { IDataTableStateContext } from '../interfaces.state';
 import { IDatasetInstance } from '../models';
 import { IRepository } from '../repository/interfaces';

--- a/shesha-reactjs/src/providers/dataTable/hooks.ts
+++ b/shesha-reactjs/src/providers/dataTable/hooks.ts
@@ -25,15 +25,23 @@ const useDataset = (): IDatasetInstance => {
   return useDataTableActions() as IDatasetInstance; // TODO: remove cast when refactoring is done
 };
 
-export const useDatasetSubscription = (eventType: DatasetEvents): object => {
-  const instance = useDataset();
-
+/**
+ * Subscribe to the events of the specified dataset instance. Is used when the instance is not available
+ * through the context yet (e.g. by the component that registers the data table context)
+ */
+export const useDatasetInstanceSubscription = (instance: IDatasetInstance, eventType: DatasetEvents): object => {
   const [dummy, forceUpdate] = useState({});
   useEffect(() => {
     return instance.subscribe(eventType, () => forceUpdate({}));
   }, [instance, eventType]);
 
   return dummy;
+};
+
+export const useDatasetSubscription = (eventType: DatasetEvents): object => {
+  const instance = useDataset();
+
+  return useDatasetInstanceSubscription(instance, eventType);
 };
 
 const useDataTableStateOrUndefined = (): IDataTableStateContext | undefined => useContext(DataTableStateContext);

--- a/shesha-reactjs/src/providers/dataTable/provider.tsx
+++ b/shesha-reactjs/src/providers/dataTable/provider.tsx
@@ -1,6 +1,6 @@
 import { FC, PropsWithChildren, useEffect, useMemo } from "react";
 import { useDeepCompareEffect } from "@/hooks/useDeepCompareEffect";
-import { useDatasetInstance, useDatasetState, useDatasetSubscription } from "./hooks";
+import { useDatasetInstance, useDatasetInstanceSubscription, useDatasetState, useDatasetSubscription } from "./hooks";
 import { DataTableActionsContext, DataTableStateContext, IDataTableStateContext } from "./contexts";
 import { useConfigurableAction } from "../configurableActionsDispatcher";
 import { IDataTableProviderBaseProps } from "./provider.props";
@@ -48,6 +48,12 @@ const DataTableProviderWithRepositoryWithContext: FC<PropsWithChildren<DataTable
     actionOwnerName = "",
     instance,
   } = props;
+
+  // The data context below publishes `instance.state` to scripts (`contexts.<name>.selectedRow` etc.).
+  // `updateState` replaces the state object instead of mutating it, so without this subscription the
+  // component never re-renders on dataset changes and the context keeps exposing the state captured
+  // on mount - row selection, fetched data and paging never reach the scripts.
+  useDatasetInstanceSubscription(instance, 'data');
 
   useConfigurableAction(
     {


### PR DESCRIPTION
#5352 

Creating a form from a template produced a blank form. The create dialog's `onPrepareSubmitData` reads the chosen template from the table's data context:

    const selectedId = contexts.FormTemplates?.selectedRow?.id;
    const preparedMarkup = await application.forms.prepareTemplateAsync(selectedId, ...);

`selectedId` was always undefined, so an empty markup was posted and the form was created blank - with no script error and a successful API call.

`DataContextBinder` exposes the value of its `data` prop through a ref that is refreshed on render, and the component that registers the table context passes `instance.state`. `DatasetInstance.updateState` replaces the state object and notifies its subscribers, but that component subscribed to nothing, so it never re-rendered and the context kept exposing the state captured on mount. Row selection, fetched data and paging never reached the scripts, while the `selectedRow` constant (fed by the subscribing `DataTableStateContext`) stayed correct - which is why the wizard's Next button worked and the submit did not.

Subscribe the registering component to the dataset's `data` events.

Verified against the functional-test backend: the created form now contains the generated Details View markup instead of an empty one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Data table context now reflects the latest dataset state after selection changes.
  * Scripts and integrations receive updated selected-row information instead of stale values.

* **Tests**
  * Added coverage confirming that selected-row context updates correctly when a new row is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->