### PR TITLE
Entity Picker Fixes

### DIFF
--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/styles/styles.ts
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/styles/styles.ts
@@ -1,4 +1,4 @@
-import { dimensionsStyles, fontStyles } from '@/designer-components/_common/styles/utils';
+import { dimensionsStyles, fontStyles, paddingStyles } from '@/designer-components/_common/styles/utils';
 import { IStyleValue } from '@/providers';
 import { createStyles, sheshaStyles, getTextHoverEffects } from '@/styles';
 
@@ -67,13 +67,12 @@ export const useStyles = createStyles(({ css, cx, prefixCls, token }, styleValue
 
   const inputField = css`
     padding: 4px 11px;
+    ${paddingStyles(styleValue?.stylingBoxJson)}
     margin: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     ${dimensionsStyles(styleValue?.dimensions)}
     ${fontStyles(styleValue?.font, styleValue?.styleCss)}
-    }
-
   `;
 
   const wrapper = css`

--- a/shesha-reactjs/src/designer-components/entityPicker/index.tsx
+++ b/shesha-reactjs/src/designer-components/entityPicker/index.tsx
@@ -47,6 +47,18 @@ import apiCode from "../../componentsApi/componentApi.ts?raw";
 
 type EntityPickerValueType = string | string[] | IEntityReferenceDto | IEntityReferenceDto[];
 
+/**
+ * Resolves a configured dialog width. The settings form stores the width directly, but older
+ * configurations stored the literal `'custom'` alongside a separate numeric width and unit.
+ */
+const resolveDialogWidth = (
+  modalWidth: IEntityPickerComponentProps['modalWidth'],
+  customWidth: number | undefined,
+  widthUnits: string | undefined,
+): number | string | undefined => modalWidth === 'custom' && isDefined(customWidth)
+  ? `${customWidth}${widthUnits}`
+  : modalWidth;
+
 export type { IEntityPickerComponentProps };
 
 const EntityPickerComponent: EntityPickerComponentDefinition = {
@@ -92,7 +104,7 @@ const EntityPickerComponent: EntityPickerComponentDefinition = {
       return await getMetadata({ dataType: DataTypes.entityReference, modelType: model.entityType }) as IEntityMetadata;
     }, [model.entityType]);
 
-    const { filters, modalWidth, customWidth, widthUnits } = model;
+    const { filters } = model;
 
     const displayEntityKey = isNotNullOrWhiteSpace(model.displayEntityKey) ? model.displayEntityKey : '_displayName';
 
@@ -157,7 +169,10 @@ const EntityPickerComponent: EntityPickerComponentDefinition = {
       return <ValidationErrors error="The provided StoredFileId is invalid" />;
     }
 
-    const width = modalWidth === 'custom' && isDefined(customWidth) ? `${customWidth}${widthUnits}` : modalWidth;
+    // The picker dialog and the "add new record" dialog are sized independently. Both still honour
+    // the legacy `custom` width + units pair, which older configurations may carry.
+    const width = resolveDialogWidth(model.modalWidth, model.customWidth, model.widthUnits);
+    const addNewWidth = resolveDialogWidth(model.addNewModalWidth, model.addNewCustomWidth, model.addNewWidthUnits);
 
     return (
       <ConfigurableFormItem<EntityPickerValueType> model={model}>
@@ -184,7 +199,7 @@ const EntityPickerComponent: EntityPickerComponentDefinition = {
                   modalFormId: model.modalFormId,
                   modalTitle: model.modalTitle,
                   showModalFooter: model.showModalFooter,
-                  modalWidth: width,
+                  modalWidth: addNewWidth,
                   buttons: model.buttons,
                   footerButtons: model.footerButtons,
                 }
@@ -272,7 +287,21 @@ const EntityPickerComponent: EntityPickerComponentDefinition = {
 
       return { ...prev, desktop: { ...prev.desktop, ...styles }, tablet: { ...prev.tablet, ...styles }, mobile: { ...prev.mobile, ...styles } };
     })
-    .add<IEntityPickerComponentProps>(14, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(migrateStylingBoxToJson(prev)))),
+    .add<IEntityPickerComponentProps>(14, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(migrateStylingBoxToJson(prev))))
+    // `modalWidth` used to size both the picker dialog and the "add new record" dialog. Now that
+    // they are configured separately, seed the new record dialog from the old shared value so
+    // existing configurations keep rendering both dialogs at the width they do today.
+    .add<IEntityPickerComponentProps>(15, (prev, context) => {
+      if (context.isNew === true) return prev;
+      if (!isDefined(prev.modalWidth)) return prev;
+
+      return {
+        ...prev,
+        addNewModalWidth: prev.addNewModalWidth ?? prev.modalWidth,
+        addNewCustomWidth: prev.addNewCustomWidth ?? prev.customWidth,
+        addNewWidthUnits: prev.addNewWidthUnits ?? prev.widthUnits,
+      };
+    }),
   settingsFormMarkup: getSettings,
 
   getDefaultStyles: () => defaultStyles(),

--- a/shesha-reactjs/src/designer-components/entityPicker/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/entityPicker/interfaces.ts
@@ -25,6 +25,9 @@ export interface IEntityPickerComponentProps extends IConfigurableFormComponent,
   modalWidth?: number | string | 'custom' | undefined;
   customWidth?: number | undefined;
   widthUnits?: string | undefined;
+  addNewModalWidth?: number | string | 'custom' | undefined;
+  addNewCustomWidth?: number | undefined;
+  addNewWidthUnits?: string | undefined;
   buttons?: ButtonGroupItemProps[] | undefined;
   footerButtons?: ModalFooterButtons | undefined;
   dividerWidth?: string | undefined;

--- a/shesha-reactjs/src/designer-components/entityPicker/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityPicker/settingsForm.ts
@@ -95,6 +95,13 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                   modelType: modelTypeFromEntityType,
                   parentComponentType: 'entityPicker',
                 })
+                .addSettingsInput({
+                  inputType: 'customDropdown', propertyName: 'modalWidth', label: 'Dialog Width', allowClear: true, jsSetting: true,
+                  tooltip: 'Width of the dialog used to select an entity.',
+                  customTooltip: 'You can use any unit (%, px, em, etc). px by default if without unit',
+                  customDropdownMode: 'single',
+                  dropdownOptions: modalWidthOptions,
+                })
                 .addSettingsInput({ inputType: 'switch', propertyName: 'allowNewRecord', label: 'Allow New Record', size: 'small', layout: 'horizontal', jsSetting: true })
                 .stdCollapsiblePanel('Dialog Settings', (fb) => fb
                   .addSettingsInputRow({
@@ -113,7 +120,8 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                     ],
                   })
                   .addSettingsInput({
-                    inputType: 'customDropdown', propertyName: 'modalWidth', label: 'Dialog Width', allowClear: true, jsSetting: true,
+                    inputType: 'customDropdown', propertyName: 'addNewModalWidth', label: 'New Record Dialog Width', allowClear: true, jsSetting: true,
+                    tooltip: 'Width of the dialog used to create a new record. Independent of the picker `Dialog Width`.',
                     customTooltip: 'You can use any unit (%, px, em, etc). px by default if without unit',
                     customDropdownMode: 'single',
                     dropdownOptions: modalWidthOptions,

--- a/shesha-reactjs/src/designer-components/entityPicker/styles.ts
+++ b/shesha-reactjs/src/designer-components/entityPicker/styles.ts
@@ -63,9 +63,11 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IEn
       border: none;
       box-shadow: none;
       margin: 0;
+      
+      ${paddingStyles(model.stylingBoxJson)}
+      align-items: center;
 
       .${prefixCls}-select-selector {
-        ${paddingStyles(model.stylingBoxJson)}
         ${textStyles}
         height: 100%;
         background: transparent;


### PR DESCRIPTION
The Dialog Width setting sized both the picker dialog and the add new record dialog, and it only appeared once Allow New Record was switched on - so the picker dialog could not be sized at all unless the component also allowed creating records.

Dialog Width now sits above Allow New Record, is always visible, and applies only to the picker dialog. The new record dialog gets its own New Record Dialog Width inside the Dialog Settings panel. Migration 15 seeds it from the old shared value so existing forms keep both dialogs at the size they render today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent width settings for the entity picker and New Record dialogs.
  * Added support for custom dialog widths with configurable units.
  * Existing configurations are automatically migrated to preserve current sizing.

* **Improvements**
  * Updated settings labels and guidance to clarify separate dialog width configuration.
  * Improved entity picker spacing and vertical alignment.
  * Applied configured padding to read-only display fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->