### PR TITLE
fix: unauthenticated ChangePassword returns 500 instead of 401 (#4625)

### DIFF
--- a/ISSUE-4625-TESTING.md
+++ b/ISSUE-4625-TESTING.md
@@ -1,0 +1,49 @@
+# Issue 4625 — unauthenticated `ChangePassword` must return 401, not 500
+
+Run against a database that existed **before** `[AbpAllowAnonymous]` was removed from
+`ChangePasswordAsync`. A freshly created database never had the stale row and will pass
+these tests even without the fix.
+
+## Test 1 — Reproduce on the unpatched build (optional, confirms your database is affected)
+
+- [ ] On a build without this migration, call `POST /api/services/app/User/ChangePassword` with **no**
+      `Authorization` header.
+- [ ] **Affected:** HTTP **500**. **Not affected:** HTTP 401 — your database has no stale row, so
+      switch to a database that reproduces it before continuing.
+
+## Test 2 — The migration corrects the stored access
+
+- [ ] Deploy this build and let migrations run.
+- [ ] Open **Permissioned objects**, find `UserAppService` → `ChangePassword`.
+- [ ] **Pass:** Access reads **Inherited**. **Fail:** still **Allow anonymous**.
+
+## Test 3 — Unauthenticated request now returns 401
+
+- [ ] Call `POST /api/services/app/User/ChangePassword` with no `Authorization` header.
+- [ ] **Pass:** HTTP **401**. **Fail:** HTTP 500, or the request is processed.
+
+## Test 4 — Authenticated password change still works
+
+- [ ] Log in as an ordinary user and change your password through the UI.
+- [ ] **Pass:** succeeds as before. **Fail:** access denied, or a 401/403.
+- [ ] Log in again with the new password.
+
+## Test 5 — Administrator overrides are still respected
+
+- [ ] Set `ChangePassword` Access to **Disable**, save.
+- [ ] As the ordinary user, try to change your password. **Pass:** refused.
+- [ ] Restore Access to **Inherited**.
+
+## Test 6 — Deliberate customisations are not overwritten
+
+- [ ] Before deploying, set some *other* endpoint to **Allow anonymous** and note it.
+- [ ] Deploy and let migrations run.
+- [ ] **Pass:** that endpoint is still **Allow anonymous** — the migration only touches
+      `Shesha.Users.UserAppService@ChangePassword`.
+
+## Test 7 — Regression check
+
+- [ ] Log in with username and password.
+- [ ] Forgot-password flow, including receiving and entering the OTP.
+- [ ] Forced password change on first login (if your environment uses it).
+- [ ] Load the app signed out — login page appears, no errors.

--- a/shesha-core/src/Shesha.Framework/Migrations/M20260828074399.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/M20260828074399.cs
@@ -1,0 +1,37 @@
+﻿using FluentMigrator;
+using Shesha.Domain.Enums;
+using Shesha.FluentMigrator;
+
+namespace Shesha.Migrations
+{
+    /// <summary>
+    /// #4625: `ChangePasswordAsync` no longer carries `[AbpAllowAnonymous]`, but databases that were
+    /// seeded while it did still hold an `AllowAnonymous` row for the endpoint.
+    /// `PermissionedObjectsBootstrapper` only overwrites the stored access when the code level
+    /// definition is hardcoded or the stored access is `Inherited`; after the attribute was removed
+    /// neither holds, so the stale row survives every restart. `ObjectPermissionChecker` then treats
+    /// the endpoint as anonymous and returns without throwing, the request reaches the method body
+    /// and `AbpSession.GetUserId()` throws `AbpException`, which surfaces as HTTP 500 instead of 401.
+    /// Resetting the row to `Inherited` restores the value a fresh installation seeds, so the access
+    /// falls back to the `DefaultEndpointAccess` security setting as it does for every other endpoint.
+    /// Rows customised to any other access level are left untouched.
+    /// </summary>
+    [Migration(20260828074399)]
+    public class M20260828074399 : OneWayMigration
+    {
+        public override void Up()
+        {
+            Update.Table("permissioned_objects").InSchema("frwk")
+                .Set(new
+                {
+                    access_lkp = (long)RefListPermissionedAccess.Inherited,
+                    hardcoded = false,
+                })
+                .Where(new
+                {
+                    @object = "Shesha.Users.UserAppService@ChangePassword",
+                    access_lkp = (long)RefListPermissionedAccess.AllowAnonymous,
+                });
+        }
+    }
+}


### PR DESCRIPTION
Fixes the regression reported on #4625: an unauthenticated call to `ChangePassword` returns **HTTP 500** on `main`, where `releases/0.43` correctly returns **401**.

## Why it happens

The code level fix for #4625 was correct — it just never reached existing databases.

1. `4db5d50d` removed `[AbpAllowAnonymous]` from `ChangePasswordAsync`.
2. Databases seeded while that attribute existed still hold `access_lkp = AllowAnonymous` for `Shesha.Users.UserAppService@ChangePassword`. `ApiPermissionedObjectProvider` maps `[AbpAllowAnonymous]` to `AllowAnonymous` and marks the row `Hardcoded`.
3. `PermissionedObjectsBootstrapper` never corrects it:

   ```csharp
   if (item.Hardcoded == true || dbItem.Access == RefListPermissionedAccess.Inherited)
   ```

   With the attribute gone the provider reports `Hardcoded = false`, and the stored access is `AllowAnonymous` rather than `Inherited`. Neither branch is taken, so the stale row survives every restart.
4. `ObjectPermissionChecker` sees `AllowAnonymous` and returns early without throwing.
5. `SheshaAuthorizationFilter` only produces 401 when a helper throws `AbpAuthorizationException` — so no 401 is produced.
6. The request reaches the method body, `AbpSession.GetUserId()` throws `AbpException`, and the ABP exception filter maps that to **500**.

`releases/0.43` behaves correctly because it never carried the attribute, so its row is `Inherited` and step 4 throws. The difference between the branches is database state, not logic — the `ObjectPermissionChecker` implementations are identical on this path.

## The change

A migration resets that one row to `Inherited`, which is what a fresh installation seeds, so access falls back to the `DefaultEndpointAccess` security setting like every other endpoint.

The update is scoped to `object = 'Shesha.Users.UserAppService@ChangePassword'` **and** `access_lkp = AllowAnonymous`, so rows customised to any other access level are left untouched.

## Testing

`ISSUE-4625-TESTING.md` has the manual test plan. Note these tests need a database created **before** the attribute was removed — a fresh database never had the stale row and passes even without this fix.

## Not covered

Any endpoint configured as `AllowAnonymous` whose body calls `GetUserId()` will still return 500 rather than 401, including if an administrator sets `ChangePassword` that way from the UI. Closing that means either restoring a guard clause — which #4625 deliberately removed — or having the checker reject anonymous callers more generally. Both felt out of scope for this regression fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed password-change requests returning an internal server error in some upgraded environments.
  * Requests now correctly require authentication and return **401 Unauthorized** when access is not permitted.
  * Existing custom access settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->