### PR TITLE
fix: gate GraphQL Playground on non-production across all hosts (#4620)

### DIFF
--- a/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
+++ b/shesha-core/src/Shesha.Web.Host/Startup/Startup.cs
@@ -219,7 +219,7 @@ namespace Shesha.Web.Host.Startup
             });
 
             app.UseMiddleware<GraphQLMiddleware>();
-            if (_hostEnvironment.IsDevelopment())
+            if (!_hostEnvironment.IsProduction())
             {
                 app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
             }

--- a/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/Startup/Startup.cs
+++ b/shesha-functional-tests/backend/src/Boxfusion.SheshaFunctionalTests.Web.Host/Startup/Startup.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Shesha;
@@ -213,7 +214,10 @@ namespace Boxfusion.SheshaFunctionalTests.Web.Host.Startup
 					Authorization = new[] { new HangfireAuthorizationFilter() }
 				});
 			app.UseMiddleware<GraphQLMiddleware>();
-			app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+			if (!_hostEnvironment.IsProduction())
+			{
+				app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
+			}
 		}
 
 		private void AddApiVersioning(IServiceCollection services)

--- a/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/Startup.cs
+++ b/shesha-starter/backend/src/ShaCompanyName.ShaProjectName.Web.Host/Startup/Startup.cs
@@ -216,7 +216,7 @@ namespace ShaCompanyName.ShaProjectName.Web.Host.Startup
 					Authorization = new[] { new HangfireAuthorizationFilter() }
 				});
 			app.UseMiddleware<GraphQLMiddleware>();
-			if (_hostEnvironment.IsDevelopment())
+			if (!_hostEnvironment.IsProduction())
 			{
 				app.UseGraphQLPlayground(); //to explorer API navigate https://*DOMAIN*/ui/playground
 			}


### PR DESCRIPTION
Follow-up to #4620. Makes the GraphQL Playground gating consistent across all three hosts and closes a gap where it was served unconditionally.

## Before

| Host | Gating on `main` |
|---|---|
| `Shesha.Web.Host` | `IsDevelopment()` |
| `shesha-starter` | `IsDevelopment()` |
| `shesha-functional-tests` | **none — served in every environment, including Production** |

The functional-tests host was closed on `releases/0.43` in `2e089ef64`, but that follow-up was never cherry-picked, so on `main` the line is unchanged since the file was first added.

## After

All three hosts use `!_hostEnvironment.IsProduction()`, matching what `releases/0.43` already does for `Shesha.Web.Host`. The Playground stays available in Development and Staging for troubleshooting and is withheld in Production.

The functional-tests host also needed `using Microsoft.Extensions.Hosting;`, which supplies the `IsProduction()` extension.

## Note on scope

This widens exposure for `Shesha.Web.Host` and the starter: the Playground now also serves in Staging, where previously it was Development only. That is deliberate — it aligns the three hosts with each other and with 0.43. The security-relevant change is the functional-tests host, which previously served the Playground in production.

The Playground remains gated by environment rather than by permission. #4620 originally proposed a permission check (`app:Configurator` / `pages:maintenance`) so it would stay available to authorised users in every environment; that was not implemented then and is not implemented here. Worth tracking separately if still wanted.

## Testing

- [ ] Development — `/ui/playground` is reachable on all three hosts.
- [ ] Staging — `/ui/playground` is reachable on all three hosts.
- [ ] Production — `/ui/playground` returns **404** on all three hosts. It is not registered, so it is 404 rather than 401 or 403.
- [ ] `POST /graphql` continues to return 401 when unauthenticated and to execute normally when authenticated, in every environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GraphQL Playground is now available in all non-production environments, including staging and testing.

* **Bug Fixes**
  * Updated environment handling to ensure GraphQL Playground remains disabled in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->