### PR TITLE
security: force password change for seeded default users (#4614)

### DIFF
--- a/ISSUE-4614-TESTING.md
+++ b/ISSUE-4614-TESTING.md
@@ -1,0 +1,54 @@
+# Issue 4614 — seeded users must require a password change
+
+Two paths are covered and both need testing: a **new** database (the seeder) and an **existing**
+database (the migration).
+
+## Test 1 — fresh deployment, empty database
+
+- [ ] Deploy against an empty database and let the host initialisation seed the default users.
+- [ ] Inspect `AbpUsers` for `admin`, `dev` and `config`.
+- [ ] **Pass:** `RequireChangePassword` is `1` / `true` for all three. **Fail:** any of them is `0` / `false`.
+
+## Test 2 — existing deployment still on the default password
+
+- [ ] Start from a database seeded by an earlier build, where the three accounts still have the
+      default password and `RequireChangePassword = 0`.
+- [ ] Deploy this build and let migrations run.
+- [ ] **Pass:** all three accounts now have `RequireChangePassword = 1`. **Fail:** only `admin`
+      changed, or none did.
+
+## Test 3 — accounts with a changed password are left alone
+
+- [ ] Before deploying, change `dev`'s password to something else and set
+      `RequireChangePassword = 0`.
+- [ ] Deploy and let migrations run.
+- [ ] **Pass:** `dev` still has `RequireChangePassword = 0` — the migration only flags accounts that
+      still hold the default password. **Fail:** `dev` was flagged anyway.
+
+## Test 4 — the flag clears when the password is changed
+
+- [ ] As one of the seeded users, change the password.
+- [ ] **Pass:** `RequireChangePassword` becomes `0` for that user.
+
+## Test 5 — login response carries the flag
+
+- [ ] Log in as a seeded user and inspect the authentication response.
+- [ ] **Pass:** `requiredChangePassword` is `true`.
+
+## Test 6 — regression
+
+- [ ] Existing non-default users are untouched — no `RequireChangePassword` changes for them.
+- [ ] Login, and the normal password change flow, both still work.
+- [ ] Run against **both** SQL Server and PostgreSQL: the migration has a separate code path per
+      database and only one of them runs on any given deployment.
+
+## Known limitation — not covered by this change
+
+Setting the flag does **not** by itself block anything. `RequiredChangePassword` is returned in the
+login response and `requireChangePassword` is declared in the front-end API types, but no component
+reads it, and no backend check refuses requests while the flag is set. A seeded user can therefore
+still log in and use the application with the default password.
+
+This change delivers what the card asks for — the flag is set on seeding and backfilled for existing
+databases — but enforcing it needs a separate card covering the front end and/or an API-level gate.
+Please do not test for a forced password-change prompt; there is not one yet.

--- a/shesha-core/src/Shesha.Core/Roles/HostRoleAndUserBuilder.cs
+++ b/shesha-core/src/Shesha.Core/Roles/HostRoleAndUserBuilder.cs
@@ -89,6 +89,9 @@ namespace Shesha.Roles
                 user.Password = new PasswordHasher<User>(new OptionsWrapper<PasswordHasherOptions>(new PasswordHasherOptions())).HashPassword(user, "123qwe");
                 user.IsEmailConfirmed = true;
                 user.IsActive = true;
+                // seeded with a well known default password, so the account must not stay usable
+                // with it - force a change on first login (#4614)
+                user.RequireChangePassword = true;
 
                 _userRepository.Insert(user);
 

--- a/shesha-core/src/Shesha.Framework/Migrations/M20260828112399.cs
+++ b/shesha-core/src/Shesha.Framework/Migrations/M20260828112399.cs
@@ -1,0 +1,116 @@
+﻿using FluentMigrator;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Shesha.FluentMigrator;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Shesha.Migrations
+{
+    /// <summary>
+    /// #4614: the seeded `admin`, `dev` and `config` accounts were created with a well known default
+    /// password and no forced reset. `HostRoleAndUserBuilder` now sets `RequireChangePassword` when it
+    /// creates them, but databases seeded before that change still hold the default, so flag any of the
+    /// three that do.
+    ///
+    /// M20250127103000 already did this, but only for `Id = 1`, which left `dev` and `config` untouched.
+    ///
+    /// The stored password is salted by ASP.NET Identity, so the same plain text produces a different
+    /// hash for every user and it cannot be matched with a literal comparison. Each candidate row is
+    /// verified with the same `PasswordHasher` configuration the seeder uses; anything else is left alone.
+    /// </summary>
+    [Migration(20260828112399)]
+    public class M20260828112399 : OneWayMigration
+    {
+        public override void Up()
+        {
+            IfDatabase("SqlServer").Execute.WithConnection((connection, transaction) =>
+            {
+                FlagDefaultUsers(connection, transaction, useSqlServerSyntax: true);
+            });
+
+            IfDatabase("PostgreSql").Execute.WithConnection((connection, transaction) =>
+            {
+                FlagDefaultUsers(connection, transaction, useSqlServerSyntax: false);
+            });
+        }
+
+        private void FlagDefaultUsers(IDbConnection connection, IDbTransaction transaction, bool useSqlServerSyntax)
+        {
+            // same configuration as HostRoleAndUserBuilder uses when it seeds the accounts
+            var passwordHasher = new PasswordHasher<DefaultUser>(
+                new OptionsWrapper<PasswordHasherOptions>(new PasswordHasherOptions())
+            );
+
+            var tableName = useSqlServerSyntax ? "AbpUsers" : "\"AbpUsers\"";
+            var idColumn = useSqlServerSyntax ? "Id" : "\"Id\"";
+            var userNameColumn = useSqlServerSyntax ? "UserName" : "\"UserName\"";
+            var passwordColumn = useSqlServerSyntax ? "Password" : "\"Password\"";
+            var requireChangeColumn = useSqlServerSyntax ? "RequireChangePassword" : "\"RequireChangePassword\"";
+            var isDeletedCheck = useSqlServerSyntax ? "IsDeleted = 0" : "\"IsDeleted\" = false";
+            var trueValue = useSqlServerSyntax ? "1" : "true";
+
+            var idsToFlag = new List<long>();
+
+            using (var selectCommand = connection.CreateCommand())
+            {
+                selectCommand.Transaction = transaction;
+                selectCommand.CommandText = $@"
+                    SELECT {idColumn}, {userNameColumn}, {passwordColumn}
+                    FROM {tableName}
+                    WHERE {userNameColumn} IN ('admin', 'dev', 'config')
+                    AND {isDeletedCheck}
+                    AND {passwordColumn} IS NOT NULL";
+
+                using var reader = selectCommand.ExecuteReader();
+                while (reader.Read())
+                {
+                    var userId = reader.GetInt64(0);
+                    var userName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
+                    var hashedPassword = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);
+
+                    if (string.IsNullOrEmpty(hashedPassword))
+                        continue;
+
+                    try
+                    {
+                        var result = passwordHasher.VerifyHashedPassword(
+                            new DefaultUser { UserName = userName },
+                            hashedPassword,
+                            "123qwe"
+                        );
+
+                        if (result == PasswordVerificationResult.Success ||
+                            result == PasswordVerificationResult.SuccessRehashNeeded)
+                        {
+                            idsToFlag.Add(userId);
+                        }
+                    }
+                    catch
+                    {
+                        // unrecognised hash format, leave the account untouched
+                    }
+                }
+            }
+
+            foreach (var userId in idsToFlag)
+            {
+                using var updateCommand = connection.CreateCommand();
+                updateCommand.Transaction = transaction;
+                updateCommand.CommandText = $@"
+                    UPDATE {tableName}
+                    SET {requireChangeColumn} = {trueValue}
+                    WHERE {idColumn} = {userId}";
+                updateCommand.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// Placeholder for the password hasher, which only needs a reference type to verify against.
+        /// </summary>
+        private class DefaultUser
+        {
+            public string UserName { get; set; } = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the seeding half of #4614.

## The problem

`HostRoleAndUserBuilder.EnsureUserExist` seeds `admin`, `dev` and `config` with a well known default password, sets `IsEmailConfirmed` and `IsActive`, and leaves `RequireChangePassword` at its default. A fresh deployment therefore has three admin-level accounts usable on a published password with nothing prompting a change.

## The change

**1. Set the flag when seeding** — one line in `EnsureUserExist`, which covers all three accounts since they share that method.

**2. Backfill existing databases** — a new migration flags any of the three that still hold the default password.

`M20250127103000` already did this, but only for `Id = 1`, so `dev` and `config` were never covered.

## A correction to the approach on the card

The card proposes matching a literal hash:

```sql
UPDATE dbo.AbpUsers SET [RequireChangePassword] = 1
WHERE [Password] = 'AQAAAAIAAYagAAAAEFKROtKVvkKZcM2mW3hG8W3GBMbyljRRKm8cNTm43o+bEefY9dZdh0MdN+tK0oOgjQ=='
```

That does not work. ASP.NET Identity salts each hash, so the same plain text produces a different value for every user — the literal would match at most one row by coincidence, and normally none.

The migration instead reads each candidate row and verifies it with the same `PasswordHasher` configuration the seeder uses, which is the approach `M20250127103000` already established. Accounts whose password has been changed fail verification and are left untouched. Unreadable hash formats are skipped rather than flagged.

Both SQL Server and PostgreSQL paths are provided, matching the existing migration's structure. Rows are collected before any update so no write happens while a reader is open on the connection.

## Important: this sets the flag, it does not enforce it

The card states "the infrastructure to force password change on login is already in place". That is only partly true, and worth being explicit about:

- `TokenAuthController` returns `RequiredChangePassword` in the login response — **yes**
- `UserAppService.ChangePasswordAsync` clears the flag when the password changes — **yes**
- Anything that *acts* on the flag — **no**

`requireChangePassword` appears in the front end only as a type declaration in `apis/tokenAuth.ts`, `apis/session.ts` and `interfaces/tokenData.ts`. No component reads it, and no backend check refuses requests while it is set. A seeded user can still log in and use the application with the default password.

So this closes the gap the card describes and satisfies the stated test — the flag is correctly set on new and existing databases — but the credential risk is not fully mitigated until something enforces it. That needs a separate card covering the front-end prompt and/or an API-level gate. I have not widened the scope here.

## Testing

`ISSUE-4614-TESTING.md` covers the fresh-deployment and existing-database paths, that already-changed passwords are left alone, and the regression checks. Note the migration has a separate code path per database engine, so it needs testing on both SQL Server and PostgreSQL.

## Not included

`releases/0.43` has the same gap — its `EnsureUserExist` is byte-identical in the relevant block. This PR targets `main` only; 0.43 needs the same change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Host accounts created with a default password must now change it upon first login.
  * Existing seeded admin, developer, and configuration accounts using the default password are also required to update it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->