### PR TITLE
fix: fixed incorrect migrations sorting in FireFox

### DIFF
--- a/shesha-reactjs/src/utils/fluentMigrator/migrator.ts
+++ b/shesha-reactjs/src/utils/fluentMigrator/migrator.ts
@@ -76,7 +76,7 @@ implements IMigrationRegistrationsOwner<TDst, TContext> {
   upgrade = (currentModel: IHasVersion, context: TContext): TDst => {
     if (currentModel.version !== 'latest') {
       const versionNumber = currentModel.version as number;
-      const unappliedMigrations = this.migrations.filter((m) => m.version > versionNumber).sort((m) => m.version);
+      const unappliedMigrations = this.migrations.filter((m) => m.version > versionNumber).sort((a, b) => (a.version - b.version));
 
       let current = { ...currentModel };
       unappliedMigrations.forEach((migration) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed migration ordering so unapplied migrations now run sequentially in ascending version order.
  * Prevented incorrect upgrade behavior caused by migrations being processed out of order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->