### PR TITLE
Render reference list tags the way the values list does

### DIFF
--- a/shesha-reactjs/src/components/dropdown/styles.ts
+++ b/shesha-reactjs/src/components/dropdown/styles.ts
@@ -151,6 +151,19 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }, model: IDr
         }
       }
 
+      /* Plain text means plain text. antd paints every multi-select selection into a chip of its
+         own — background, radius and inline padding — which reads as a tag even though Display
+         Style asked for none, so the chip chrome is stripped back to bare text. Scoped by antd's
+         own multi-select class: single-select never paints one. The trailing margin is kept, or
+         adjacent values would run together with nothing separating them. */
+      ${model.displayStyle === 'tags' ? '' : `
+      &&&&.${prefixCls}-select-multiple .${prefixCls}-select-selection-item {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        padding-inline: 0;
+      }`}
+
       &&&& input {
         ${fontStyles(model.font, model.styleCss)}
       }

--- a/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
+++ b/shesha-reactjs/src/components/refListDropDown/genericRefListDropDown.tsx
@@ -203,6 +203,10 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
       {...(mode ? { mode } : {})}
       placeholder={placeholder}
       {...(displayStyle === 'tags' ? {
+        /* Single-select renders the selection through `labelRender`; multi-select renders each
+           selected item through `tagRender` instead. Supplying only `labelRender` left multi-select
+           on antd's default tag, which shows the remove icon but none of the item's label, icon or
+           colour — the same pair the `values` data source renders, so the two look identical. */
         labelRender: (props) => {
           const option = options.find((o) => o.value === props.value);
           return (
@@ -215,7 +219,27 @@ export const GenericRefListDropDown = <TValue = unknown>(props: IGenericRefListD
               tagStyle={tagStyle}
               variant={tagVariant}
               showItemName={showItemName}
-              label={option?.label}
+              label={option?.label ?? props.label}
+            />
+          );
+        },
+        tagRender: (props) => {
+          const option = options.find((o) => o.value === props.value);
+          return (
+            <ReflistTag
+              value={option?.value}
+              description={option?.description}
+              /* Border and background colour come from the reference list item itself; a colourless
+                 item falls through to the configured tag Appearance. */
+              color={option?.color}
+              icon={option?.icon}
+              showIcon={showIcon}
+              tagStyle={tagStyle}
+              variant={tagVariant}
+              showItemName={showItemName}
+              label={option?.label ?? props.label}
+              closable={props.closable}
+              onClose={props.onClose}
             />
           );
         },


### PR DESCRIPTION
antd renders a single selection through labelRender but each item of a multi-select through tagRender, and the reference list dropdown supplied only the first. So with Style: Tags and Enable Multi-Select on, every selected item fell back to antd's own tag - a remove icon and nothing else, no label, no icon and none of the item's colour. The values data source already passed both and rendered correctly, which is why only the reference list looked wrong.

The reference list path now passes the same pair, so both data sources draw the same ReflistTag. Its border and background colour come from the colour on the reference list item, and an item without one falls through to the configured tag Appearance. Removal still works because tagRender hands its closable and onClose along.

Plain text was not plain either. antd paints every multi-select selection into a chip of its own - background, radius and inline padding
- whatever the Display Style, and the existing rule only zeroed the line width, so the chip still read as a tag. That chrome is now stripped unless Display Style is Tags. It sits in the shared style hook, so it covers both data sources, and the trailing margin stays or adjacent values would run together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multi-select dropdown tag display with item labels, icons, and colors.
  * Added fallback text when a selected option is unavailable.

* **Style**
  * Updated non-tag multi-select selections to appear as clean, unstyled text instead of chips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->