### PR TITLE
remove redundant onRowSave

### DIFF
--- a/shesha-reactjs/src/designer-components/dataList/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/dataList/settingsForm.ts
@@ -386,17 +386,6 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf }) => {
                   hideLabel: false,
                   description: 'Custom Action configuration executed when saving list items (validation, calculations, etc.)',
                 })
-                .addSettingsInput({
-                  id: nanoid(),
-                  propertyName: 'onRowSave',
-                  label: 'On Row Save',
-                  inputType: 'codeEditor',
-                  parentId: eventsTabId,
-                  tooltip: 'Custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations). This handler should return an object or a Promise<object>.',
-                  hidden: { _code: 'return getSettingValue(data?.canAddInline) === "no" && getSettingValue(data?.canEditInline) === "no";', _mode: 'code', _value: false },
-                  description: 'Allows custom business logic to be executed on saving of new/updated row (e.g. custom validation / calculations).',
-                  hideLabel: false,
-                })
                 .addConfigurableActionConfigurator({
                   id: nanoid(),
                   propertyName: 'onRowDeleteSuccessAction',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the **onRowSave** custom code editor from the DataList Events settings.
  * Existing row-save success, list-item save, and row-delete event settings remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->