### PR TITLE
security: let database permissions override code-level AllowAnonymous

### DIFF
--- a/shesha-core/src/Shesha.Application/Authorization/ApiAuthorizationHelper.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/ApiAuthorizationHelper.cs
@@ -7,6 +7,7 @@ using Abp.Localization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Shesha.Configuration.Security;
+using Shesha.Domain.Enums;
 using Shesha.Extensions;
 using Shesha.Permissions;
 using Shesha.Reflection;
@@ -42,13 +43,14 @@ namespace Shesha.Authorization
             if (!_authConfiguration.IsEnabled)
                 return;
 
-            if (type == null ||
-                type.HasAttribute<AllowAnonymousAttribute>() || methodInfo.HasAttribute<AllowAnonymousAttribute>() || 
-                type.HasAttribute<AbpAllowAnonymousAttribute>() || methodInfo.HasAttribute<AbpAllowAnonymousAttribute>())
+            if (type == null)
                 return;
 
+            var hasCodeAllowAnonymous = type.HasAttribute<AllowAnonymousAttribute>() || methodInfo.HasAttribute<AllowAnonymousAttribute>()
+                || type.HasAttribute<AbpAllowAnonymousAttribute>() || methodInfo.HasAttribute<AbpAllowAnonymousAttribute>();
+
             var controllerType = typeof(ControllerBase);
-            if (type == null || !controllerType.IsAssignableFrom(type) && !type.HasInterface(typeof(IApplicationService)))
+            if (!controllerType.IsAssignableFrom(type) && !type.HasInterface(typeof(IApplicationService)))
                 return;
 
             var typeName = type.GetRequiredFullName();
@@ -60,6 +62,12 @@ namespace Shesha.Authorization
 
             var securitySettings = await _securitySettings.SecuritySettings.GetValueOrNullAsync();
 
+            // If code-level [AllowAnonymous] is present, use it as the fallback for Inherited.
+            // Database configuration with an explicit access level will still take precedence.
+            var defaultAccess = hasCodeAllowAnonymous
+                ? RefListPermissionedAccess.AllowAnonymous
+                : securitySettings?.DefaultEndpointAccess ?? RefListPermissionedAccess.AnyAuthenticated;
+
             // Note: requireAll is intentionally false — multiple permissions are OR'd (any single permission grants access)
             await _objectPermissionChecker.AuthorizeAsync(
                 false,
@@ -67,7 +75,7 @@ namespace Shesha.Authorization
                 methodName,
                 ShaPermissionedObjectsTypes.WebApiAction,
                 AbpSession.UserId.HasValue,
-                securitySettings?.DefaultEndpointAccess ?? Domain.Enums.RefListPermissionedAccess.AnyAuthenticated,
+                defaultAccess,
                 securitySettings?.DefaultEndpointPermissions
             );
         }

--- a/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
+++ b/shesha-core/src/Shesha.Application/Authorization/SheshaAuthorizationFilter.cs
@@ -6,8 +6,6 @@ using Abp.Events.Bus;
 using Abp.Events.Bus.Exceptions;
 using Abp.Web.Models;
 using Castle.Core.Logging;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
@@ -37,13 +35,6 @@ namespace Shesha.Authorization
 
         public virtual async Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            var endpoint = context.HttpContext?.GetEndpoint();
-            // Allow Anonymous skips all authorization
-            if (endpoint?.Metadata.GetMetadata<IAllowAnonymous>() != null)
-            {
-                return;
-            }
-
             if (!context.ActionDescriptor.IsControllerAction())
             {
                 return;


### PR DESCRIPTION
## Summary

Port of #4646 (merged to `releases/0.43`) to `main`. Closes #4621.

Code-level `[AllowAnonymous]` / `[AbpAllowAnonymous]` attributes completely bypassed database-configured permissions: both `SheshaAuthorizationFilter` and `ApiAuthorizationHelper` returned early when the attribute was present, so administrators had no way to lock down such endpoints via the permission management UI.

This change makes database configuration take precedence:

- `SheshaAuthorizationFilter` no longer skips authorization when `IAllowAnonymous` endpoint metadata is present.
- `ApiAuthorizationHelper` detects the code-level attribute and passes `RefListPermissionedAccess.AllowAnonymous` as the *default* (Inherited-replacement) access to `ObjectPermissionChecker.AuthorizeAsync`. A DB record with an explicit (non-Inherited) access level therefore overrides the attribute; with no DB record or `Inherited` access, the attribute is still honoured and anonymous access keeps working.

## Notes on the port

`main` diverged from `releases/0.43` via #5018, which refactored `ApiAuthorizationHelper.AuthorizeAsync` (added the `defaultPermissions` parameter and `GetValueOrNullAsync` settings lookup). The fix was re-applied on top of that refactor:

- Kept `GetValueOrNullAsync` + the `?? AnyAuthenticated` fallback from #5018 instead of the 0.43 branch's `NullReferenceException` on missing settings.
- `securitySettings?.DefaultEndpointPermissions` is still passed through; it is only consulted by the checker when the default access is `RequiresPermissions`, so it has no effect when the anonymous fallback applies.

## How to test

1. Anonymous call to an `[AllowAnonymous]` endpoint (e.g. `GET /api/services/app/Settings/GetValue`) with no DB override → 200.
2. In the permissioned-objects admin UI, set that endpoint's access to `Any authenticated` (or `Requires permissions`) → anonymous call now returns 401; authenticated call succeeds.
3. Set access back to `Inherited` → anonymous call works again.
4. Regression: login (`/api/TokenAuth/Authenticate`) and other anonymous endpoints without DB overrides still work anonymously.