### PR TITLE
Katleho/bugfix/api call config

### DIFF
--- a/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
+++ b/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
@@ -73,7 +73,7 @@ export const VerbSelector: FC<VerbSelectorProps> = ({ verbs, value, onChange, si
 
 // Mirrors the scheme check the "API Call" action uses (isGlobalUrl in configurable-actions/api-call.ts)
 // to decide whether a URL is routed to this app's own backend or sent as-is to an external host.
-const hasScheme = (url: string): boolean => Boolean(url.match(/^(http|https|ftp):\/\//i));
+const hasScheme = (url: string): boolean => Boolean(url.match(/^(http|https):\/\//i));
 
 // Heuristic warning only: a bare host (e.g. "some-api.example.com/path", no "http(s)://") reads as
 // "external" to a person but has no scheme, so it will be treated as a relative path and sent to this

--- a/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
+++ b/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
@@ -85,7 +85,7 @@ const looksLikeSchemelessExternalUrl = (url: string | null): boolean => {
     return false;
   if (url.startsWith('/') || url.startsWith('{'))
     return false;
-  const hostPart = url.split(/[/?#]/, 1)[0];
+  const hostPart = url.split(/[/?#]/, 1)[0] ?? '';
   return /\./.test(hostPart) && !/\s/.test(hostPart);
 };
 

--- a/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
+++ b/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
@@ -77,13 +77,13 @@ const hasScheme = (url: string): boolean => Boolean(url.match(/^(http|https|ftp)
 
 // Heuristic warning only: a bare host (e.g. "some-api.example.com/path", no "http(s)://") reads as
 // "external" to a person but has no scheme, so it will be treated as a relative path and sent to this
-// app's own backend instead. Deliberately conservative — skips relative-path convention ("/..."),
-// mustache expressions ("{{...}}"), and anything without a dot in the host-like segment — so it never
-// fires on a legitimate relative API path.
+// app's own backend instead. Deliberately conservative — skips relative-path conventions ("/...",
+// "./...", "../..."), mustache expressions ("{{...}}"), and anything without a dot in the host-like
+// segment — so it never fires on a legitimate relative API path.
 const looksLikeSchemelessExternalUrl = (url: string | null): boolean => {
   if (isNullOrWhiteSpace(url) || hasScheme(url))
     return false;
-  if (url.startsWith('/') || url.startsWith('{'))
+  if (url.startsWith('/') || url.startsWith('{') || url.startsWith('./') || url.startsWith('../'))
     return false;
   const hostPart = url.split(/[/?#]/, 1)[0] ?? '';
   return /\./.test(hostPart) && !/\s/.test(hostPart);

--- a/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
+++ b/shesha-reactjs/src/components/endpointsAutocomplete/endpointsAutocomplete.tsx
@@ -71,6 +71,24 @@ export const VerbSelector: FC<VerbSelectorProps> = ({ verbs, value, onChange, si
   );
 };
 
+// Mirrors the scheme check the "API Call" action uses (isGlobalUrl in configurable-actions/api-call.ts)
+// to decide whether a URL is routed to this app's own backend or sent as-is to an external host.
+const hasScheme = (url: string): boolean => Boolean(url.match(/^(http|https|ftp):\/\//i));
+
+// Heuristic warning only: a bare host (e.g. "some-api.example.com/path", no "http(s)://") reads as
+// "external" to a person but has no scheme, so it will be treated as a relative path and sent to this
+// app's own backend instead. Deliberately conservative — skips relative-path convention ("/..."),
+// mustache expressions ("{{...}}"), and anything without a dot in the host-like segment — so it never
+// fires on a legitimate relative API path.
+const looksLikeSchemelessExternalUrl = (url: string | null): boolean => {
+  if (isNullOrWhiteSpace(url) || hasScheme(url))
+    return false;
+  if (url.startsWith('/') || url.startsWith('{'))
+    return false;
+  const hostPart = url.split(/[/?#]/, 1)[0];
+  return /\./.test(hostPart) && !/\s/.test(hostPart);
+};
+
 const getUrlFromValue = (value?: EndpointsAutocompleteValue): string | null => {
   if (!value)
     return null;
@@ -150,6 +168,7 @@ export const EndpointsAutocomplete: FC<IEndpointsAutocompleteProps> = ({ readOnl
   };
 
   const url = getUrlFromValue(props.value);
+  const showSchemeWarning = looksLikeSchemelessExternalUrl(url);
 
   const autocomplete = (
     <AutoComplete
@@ -171,19 +190,32 @@ export const EndpointsAutocomplete: FC<IEndpointsAutocompleteProps> = ({ readOnl
     </AutoComplete>
   );
 
+  const schemeWarning = showSchemeWarning ? (
+    <div className={styles.schemeWarning}>
+      This looks like an external host without http:// or https:// — it will be sent as a relative path
+      to this app&apos;s own backend instead. Add the scheme (e.g. https://{url}) to call an external API.
+    </div>
+  ) : null;
+
   return mode === 'endpoint'
     ? (
-      <Space.Compact className={styles.compactContainer}>
-        <VerbSelector
-          verbs={props.availableHttpVerbs ?? []}
-          onChange={onVerbChange}
-          value={props.value && isApiEndpoint(props.value) ? props.value.httpVerb : ""}
-          size={props.size}
-        />
-        {autocomplete}
-      </Space.Compact>
+      <>
+        <Space.Compact className={styles.compactContainer}>
+          <VerbSelector
+            verbs={props.availableHttpVerbs ?? []}
+            onChange={onVerbChange}
+            value={props.value && isApiEndpoint(props.value) ? props.value.httpVerb : ""}
+            size={props.size}
+          />
+          {autocomplete}
+        </Space.Compact>
+        {schemeWarning}
+      </>
     )
     : (
-      <>{autocomplete}</>
+      <>
+        {autocomplete}
+        {schemeWarning}
+      </>
     );
 };

--- a/shesha-reactjs/src/components/endpointsAutocomplete/styles.ts
+++ b/shesha-reactjs/src/components/endpointsAutocomplete/styles.ts
@@ -14,9 +14,16 @@ export const useStyles = createStyles(({ css, cx, token }) => {
     color: ${token.colorTextTertiary};
   `);
 
+  const schemeWarning = cx(css`
+    color: ${token.colorWarningText};
+    font-size: ${token.fontSizeSM}px;
+    margin-top: 4px;
+  `);
+
   return {
     verbSelector,
     compactContainer,
     affix,
+    schemeWarning,
   };
 });

--- a/shesha-reactjs/src/components/requestConfigModal/models.ts
+++ b/shesha-reactjs/src/components/requestConfigModal/models.ts
@@ -37,7 +37,7 @@ export type IRequestBody =
  */
 export interface IResponseTransformationConfiguration {
   enabled: boolean;
-  /** JavaScript body that receives `input` (the response) and returns the transformed value. */
+  /** JavaScript body that receives `response` (the raw API response) and returns the transformed value. */
   script: string;
 }
 

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -150,7 +150,7 @@ const applyResponseTransformation = async (
 };
 
 const isGlobalUrl = (url: string): boolean => {
-  return !isNullOrWhiteSpace(url) && Boolean(url.match(/^(http|ftp|https):\/\//gi));
+  return !isNullOrWhiteSpace(url) && Boolean(url.match(/^(http|https):\/\//gi));
 };
 
 const hasHeader = (headers: Record<string, string>, name: string): boolean =>

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -103,7 +103,8 @@ const getApiCallArgumentsForm: FormMarkupFactory = ({ fbf }) => {
         type: 'endpointsAutocomplete',
         propertyName: 'url',
         label: 'URL',
-        description: 'Relative or absolute URL of the API endpoint. Relative ones will be send to the current back-end. Absolute URLs (must start with http:// or https://) can be used for external applications — a bare domain without the scheme is treated as relative and will still be sent to this app’s own back-end.',
+        description: 'Relative or absolute URL of the API endpoint. Relative ones will be send to the current back-end. Absolute URLs (must start with http:// or https://) can be used for '
+          + 'external applications — a bare domain without the scheme is treated as relative and will still be sent to this app’s own back-end.',
         httpVerb: "{data.verb}",
       },
     ],

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { nanoid } from '@/utils/uuid';
 import { useSheshaApplication } from "@/providers";
 import { useAvailableConstantsData, evaluateString, executeScript, genericActionArgumentsEvaluator } from '@/providers/form/utils';
@@ -180,12 +179,15 @@ export const useApiCallAction = (): void => {
   const { backendUrl, httpHeaders } = useSheshaApplication();
 
   // The response transformation runs as a standard Shesha script, so it needs the same constants
-  // (globalState, pageContext, http, form, data, …) as every other code editor. `responseHolder`
-  // is a stable object whose `response` key is registered as an available constant; we write the
-  // actual response into it just before executing the transformation. The accessor reads it lazily,
-  // so the live value is picked up without rebuilding the constants on every API response.
-  const responseHolder = useRef<{ response: unknown }>({ response: undefined });
-  const allData = useAvailableConstantsData({}, responseHolder.current);
+  // (globalState, pageContext, http, form, data, …) as every other code editor. `useApiCallAction` is
+  // registered once, permanently, from `ApplicationActionsProcessor` near the app root — outside every
+  // form's `FormProvider` — so form-scoped constants (`form`, `data`, `selectedRow`, …) can never be
+  // populated on `allData` itself. The `context` the executer receives from the dispatcher, however,
+  // *is* scoped to whichever component actually triggered the action, so it carries a working `form`.
+  // We merge `context` on top of `allData` (context wins on overlaps) when building the transformation
+  // script's execution context, below, so it gets both the working form-scoped constants and the
+  // standard global ones.
+  const allData = useAvailableConstantsData({});
 
   useConfigurableAction<IApiCallArguments>({
     isPermament: true,
@@ -370,9 +372,12 @@ export const useApiCallAction = (): void => {
         ...(baseUrl && { baseURL: baseUrl }),
       }).then((response) => {
         const original: unknown = unwrapAbpResponse(response.data) as unknown;
-        // Expose the freshly-received response to the transformation script as `response`.
-        responseHolder.current.response = original;
-        return applyResponseTransformation(original, allData, requestConfig?.responseTransformation);
+        // Build the transformation script's context from the CALLER's context (has a working `form`,
+        // `data`, `selectedRow`, …, since it was built where the triggering button/component actually
+        // lives) merged over this hook's own `allData` (has the standard global constants but no
+        // working form-scoped ones — see the comment on `allData` above), plus `response` itself.
+        const transformationContext = { ...allData, ...(context as object), response: original };
+        return applyResponseTransformation(original, transformationContext, requestConfig?.responseTransformation);
       });
     },
   }, [backendUrl, httpHeaders, allData]);

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -103,8 +103,8 @@ const getApiCallArgumentsForm: FormMarkupFactory = ({ fbf }) => {
         type: 'endpointsAutocomplete',
         propertyName: 'url',
         label: 'URL',
-        description: 'Relative or absolute URL of the API endpoint. Relative ones will be sent to the current back-end. Absolute URLs (must start with http:// or https://) can be used for '
-          + 'external applications — a bare domain without the scheme is treated as relative and will still be sent to this app’s own back-end.',
+        description: 'Relative or absolute URL of the API endpoint. Relative ones will be sent to the current back-end. Absolute URLs (must start with http:// or https://) can be used for ' +
+          'external applications — a bare domain without the scheme is treated as relative and will still be sent to this app’s own back-end.',
         httpVerb: "{data.verb}",
       },
     ],

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -104,7 +104,7 @@ const getApiCallArgumentsForm: FormMarkupFactory = ({ fbf }) => {
         type: 'endpointsAutocomplete',
         propertyName: 'url',
         label: 'URL',
-        description: 'Relative or absolute URL of the API endpoint. Relative ones will be send to the current back-end. Absolute URLs can be used for external applications.',
+        description: 'Relative or absolute URL of the API endpoint. Relative ones will be send to the current back-end. Absolute URLs (must start with http:// or https://) can be used for external applications — a bare domain without the scheme is treated as relative and will still be sent to this app’s own back-end.',
         httpVerb: "{data.verb}",
       },
     ],

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -103,7 +103,7 @@ const getApiCallArgumentsForm: FormMarkupFactory = ({ fbf }) => {
         type: 'endpointsAutocomplete',
         propertyName: 'url',
         label: 'URL',
-        description: 'Relative or absolute URL of the API endpoint. Relative ones will be send to the current back-end. Absolute URLs (must start with http:// or https://) can be used for '
+        description: 'Relative or absolute URL of the API endpoint. Relative ones will be sent to the current back-end. Absolute URLs (must start with http:// or https://) can be used for '
           + 'external applications — a bare domain without the scheme is treated as relative and will still be sent to this app’s own back-end.',
         httpVerb: "{data.verb}",
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a warning when an external-looking URL is entered without an `http://`, `https://`, or `ftp://` scheme.
  - Clarified that bare domains are treated as relative paths, while FTP URLs use the backend URL.

- **Documentation**
  - Updated response transformation guidance to identify `response` as the raw API response.

- **Bug Fixes**
  - Improved response transformation behavior by providing the current form context and raw response consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->