### PR TITLE
use carmel cases

### DIFF
--- a/shesha-reactjs/src/components/expressionEditor/index.tsx
+++ b/shesha-reactjs/src/components/expressionEditor/index.tsx
@@ -10,6 +10,7 @@ import './styles.css';
 import type { ExpressionContext, ExpressionContextValue } from './contextMetadata';
 import { arrayHasAtLeastNDefined } from '@/utils/array';
 import { isNullOrWhiteSpace } from '@/utils/nullables';
+import { toCamelCase } from '@/utils/string';
 
 export type { ExpressionContext, ExpressionContextValue };
 
@@ -104,9 +105,12 @@ export const buildExpressionContextFromPaths = (
   paths.forEach((pathValue) => {
     if (!pathValue) return;
 
+    // Metadata paths reflect backend (PascalCase) property names, but the runtime data
+    // object is JSON-camelCased (see Startup's UseCamelCasing) - convert each segment
+    // independently so suggestions match what's actually accessible at evaluation time.
     const segments = pathValue
       .split('.')
-      .map((segment) => segment.trim())
+      .map((segment) => toCamelCase(segment.trim()))
       .filter(Boolean);
 
     if (segments.length === 0) return;


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/4997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated expression editor paths to match the camelCase format used by runtime data.
  * Improved expression evaluation when backend metadata uses differently cased property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->