### PR TITLE
fix: fixed incorrect url in the side menu item when it's configured to execute script

### DIFF
--- a/shesha-reactjs/src/components/sidebarMenu/index.tsx
+++ b/shesha-reactjs/src/components/sidebarMenu/index.tsx
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/strict-boolean-expressions: "error" */
 import { FC, useRef, useState } from 'react';
 import { normalizeUrl } from '@/utils/url';
 import { isSidebarButton } from '@/interfaces/sidebar';
@@ -63,9 +64,9 @@ const SidebarMenu: FC<ISidebarMenuProps> = ({ theme = 'dark' }) => {
           if (initialSelection.current === undefined && isSidebarButton(nestedItem) && isNavigationActionConfiguration(nestedItem.actionConfiguration)) {
             const url = getUrlFromNavigationRequest(nestedItem.actionConfiguration.actionArguments);
 
-            if (url && normalizeUrl(url) === currentUrl) {
+            if (!isNullOrWhiteSpace(url) && normalizeUrl(url) === currentUrl) {
               initialSelection.current = nestedItem.id;
-              if (!selectedKey)
+              if (isNullOrWhiteSpace(selectedKey))
                 setSelectedKey(nestedItem.id);
             }
           }
@@ -86,7 +87,7 @@ const SidebarMenu: FC<ISidebarMenuProps> = ({ theme = 'dark' }) => {
       theme={theme}
       items={menuItems}
       {...(keys ? { defaultOpenKeys: keys } : {})}
-      {...(selectedKey ? { selectedKeys: [selectedKey] } : {})}
+      {...(!isNullOrWhiteSpace(selectedKey) ? { selectedKeys: [selectedKey] } : {})}
     />
   );
 };

--- a/shesha-reactjs/src/components/sidebarMenu/utils.tsx
+++ b/shesha-reactjs/src/components/sidebarMenu/utils.tsx
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/strict-boolean-expressions: "error" */
 import { MenuProps, Tooltip } from 'antd';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
@@ -7,6 +8,7 @@ import { ISidebarMenuItem, isSidebarButton, isSidebarGroup, SidebarItemType } fr
 import { IConfigurableActionConfiguration, isNavigationActionConfiguration } from '@/providers/index';
 import Link from 'next/link';
 import { QuestionCircleOutlined } from '@ant-design/icons';
+import { isDefined, isNullOrWhiteSpace } from '@/utils';
 
 type MenuItem = Required<MenuProps>['items'][number];
 
@@ -47,20 +49,20 @@ function getItem({ label, key, icon, children, isParent, itemType, onClick, navi
               {label}
             </Link>
           )
-          : <Link href="" className={className} onClick={clickHandler}>{label}</Link>)
+          : <span className={className} onClick={clickHandler}>{label}</span>)
         : <span className={className}>{label}</span>;
 
       // Extract text content for the overflow tooltip
       const textContent = typeof label === 'string' ? label : undefined;
 
       // Wrap content in tooltip for text overflow (CSS handles the ellipsis)
-      const contentWithOverflowTooltip = textContent ? (
+      const contentWithOverflowTooltip = !isNullOrWhiteSpace(textContent) ? (
         <Tooltip title={textContent} placement="top" mouseEnterDelay={0.5}>
           {baseContent}
         </Tooltip>
       ) : baseContent;
 
-      if (!tooltip) return contentWithOverflowTooltip;
+      if (!isDefined(tooltip)) return contentWithOverflowTooltip;
 
       const tooltipText = typeof tooltip === 'string' ? tooltip : undefined;
       return (
@@ -95,7 +97,7 @@ export interface IProps {
 export const sidebarMenuItemToMenuItem = ({ item, onButtonClick, onItemEvaluation, getFormUrl, getUrl }: IProps): MenuItem => {
   const { id, title, icon, itemType } = item;
 
-  if (item.hidden) return null;
+  if (item.hidden === true) return null;
 
   const children = isSidebarGroup(item)
     ? item.childItems?.map((item) => sidebarMenuItemToMenuItem({ item, onButtonClick, onItemEvaluation, getFormUrl, getUrl }))


### PR DESCRIPTION
#5398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar navigation selection when URLs or selected keys are empty or whitespace-only.
  * Sidebar items with click actions or form navigation now behave as non-link controls instead of navigating to empty URLs.
  * Improved tooltip display by preventing empty or whitespace-only overflow tooltips.
  * Hidden sidebar items are now consistently excluded only when explicitly marked as hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->