### PR TITLE
fix datalist top border clipping, leaking selection highlight

### DIFF
--- a/shesha-reactjs/src/components/dataList/index.tsx
+++ b/shesha-reactjs/src/components/dataList/index.tsx
@@ -728,35 +728,33 @@ export const DataList: FC<IDataListProps> = ({
         border: '1px solid #d3d3d3',
         borderRadius: '8px',
       }),
-      ...(orientation !== 'wrap' && {
-        marginTop: gap !== undefined ? (typeof gap === 'number' ? `${gap}px` : gap) : '0px',
-      }),
     };
+
+    // the gap margin sits on the wrapper, outside the selection highlight - on the inner
+    // item it becomes a band of highlighted background above the card when selected
+    const gapMargin = orientation !== 'wrap'
+      ? { marginTop: gap !== undefined ? (typeof gap === 'number' ? `${gap}px` : gap) : '0px' }
+      : undefined;
 
     const wrapperStyle: CSSProperties =
       orientation === 'horizontal'
-        ? { flex: '0 0 auto', width: itemWidth, overflow: 'visible' }
+        ? { flex: '0 0 auto', width: itemWidth, overflow: 'visible', ...gapMargin }
         : orientation === 'wrap'
           ? { flex: `0 0 ${itemWidth}`, width: itemWidth, overflow: 'visible' }
-          : { flex: '0 0 100%', overflow: 'visible' };
+          : { flex: '0 0 100%', overflow: 'visible', ...gapMargin };
 
     return (
       <div key={`row-${index}`} style={wrapperStyle}>
         <ConditionalWrap
           condition={isSelectable}
-          // The selection control is a *sibling* of the row content, not its parent. Wrapping the
-          // content in antd's <label> made every click inside the row a label activation, which could
-          // only be suppressed with preventDefault - and that cancelled the default action of nested
-          // controls too, so checkboxes/radios/switches inside a row stopped toggling. Keeping them
-          // as siblings means there is nothing to suppress.
           wrap={(children) => (
-            <div className={classNames(styles.shaDatalistComponentItemCheckbox, { selected })}>
+            <div className={classNames(styles.shaDatalistComponentItemCheckbox, { selected, single: selectionMode === 'single' })}>
               {selectionMode === 'single'
                 ? (
+
+                  // TODO: Remove radio and revert to datalist item click selection. (JB)
                   <Radio
                     checked={selected}
-                    // Radio raises onChange only when it becomes checked, so clicking the already
-                    // selected row would never deselect it. onClick fires either way.
                     onClick={() => {
                       onSelectRowLocal(index, item);
                     }}

--- a/shesha-reactjs/src/components/dataList/styles/styles.ts
+++ b/shesha-reactjs/src/components/dataList/styles/styles.ts
@@ -40,6 +40,11 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
     
             &.selected {
                 background-color: ${token.colorPrimaryBgHover};
+            }
+
+            /* the padding forms the band between stacked selected items; in single mode there is
+               nothing to stack, so skip it and keep selection from shifting the layout */
+            &.selected:not(.single) {
                 padding-bottom: 8px;
             }
     
@@ -62,6 +67,10 @@ export const useStyles = createStyles(({ css, cx, token, prefixCls }) => {
             &.selected {
                 margin-top: 0;
             }
+        }
+
+        .${shaDatalistComponentBody} > div:first-child > .${shaDatalistComponentItemCheckbox}.selected:not(.single) {
+            padding-top: 8px;
         }
     
         .${shaDatalistComponentExtraSpace} {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing around data list items so selection highlights no longer include external margins.
  * Refined spacing for selected checkboxes, including the first and stacked selected items.
  * Adjusted wrapped layouts to prevent unintended gaps.
  * Improved styling for single-selection data lists by displaying radio controls instead of checkboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->