### PR TITLE
Stop component tooltip flickering in the form designer

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/configurableFormComponent/dragWrapper.tsx
+++ b/shesha-reactjs/src/components/formDesigner/configurableFormComponent/dragWrapper.tsx
@@ -51,19 +51,21 @@ export const DragWrapper: FC<PropsWithChildren<IDragWrapperProps>> = (props) => 
       );
   };
 
-  const onMouseOver = (event: React.MouseEvent<HTMLElement>): void => {
+  const onMouseEnter = (event: React.MouseEvent<HTMLElement>): void => {
     event.stopPropagation();
     setIsOpen(true);
   };
 
-  const onMouseOut = (event: React.MouseEvent<HTMLElement>): void => {
+  const onMouseLeave = (event: React.MouseEvent<HTMLElement>): void => {
     event.stopPropagation();
     setIsOpen(false);
   };
 
   return (
-    <Tooltip title={tooltip} placement="right" open={isOpen}>
-      <div className={props.className} onClick={onClick} onMouseOver={onMouseOver} onMouseOut={onMouseOut}>
+    // `pointerEvents: none` keeps the overlay out of hit-testing, otherwise moving the cursor onto the
+    // tooltip triggers mouse leave on the wrapper and the tooltip flickers open/closed under the cursor
+    <Tooltip title={tooltip} placement="right" open={isOpen} styles={{ root: { pointerEvents: 'none' } }}>
+      <div className={props.className} onClick={onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {props.children}
       </div>
     </Tooltip>


### PR DESCRIPTION
The designer's component tooltip is opened manually from mouse events on the drag wrapper. Because the overlay received pointer events, moving the cursor onto the tooltip fired mouse leave on the wrapper, which closed the tooltip, put the cursor back over the component, and reopened it - an open/close oscillation for as long as the cursor stayed there.

Set pointerEvents: none on the tooltip root so the informational overlay stays out of hit-testing, and switch the wrapper to onMouseEnter/ onMouseLeave, which do not re-fire on transitions between the wrapper and its own descendants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior in the form designer.
  * Prevented tooltip flickering when moving the cursor over the overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->