### PR TITLE
fix(actions): register actionResponse/actionError for On Success/Fail…

### DIFF
--- a/shesha-reactjs/src/designer-components/configurableActionsConfigurator/configurator.tsx
+++ b/shesha-reactjs/src/designer-components/configurableActionsConfigurator/configurator.tsx
@@ -5,6 +5,7 @@ import { IConfigurableActionGroupDictionary } from '@/providers/configurableActi
 import { SourceFilesFolderProvider } from '@/providers/sourceFileManager/sourcesFolderProvider';
 import { arrayHasAtLeastNDefined } from '@/utils/array';
 import { useAvailableStandardConstantsMetadata } from '@/utils/metadata/hooks';
+import { registerActionErrorAction, registerActionResponseAction } from '@/utils/metadata/standardProperties';
 import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 import { nanoid } from '@/utils/uuid';
 import { Collapse, Form } from 'antd';
@@ -46,7 +47,17 @@ export const ConfigurableActionConfigurator: FC<IConfigurableActionConfiguratorP
   const { getActions, getConfigurableActionOrNull } = useConfigurableActionDispatcher();
   const actions = getActions();
 
-  const availableConstants = useAvailableStandardConstantsMetadata();
+  // actionResponse/actionError are only injected into the execution context of nested
+  // On Success / On Fail handlers (see configurableActionsDispatcher), so only expose them there.
+  const availableConstants = useAvailableStandardConstantsMetadata(
+    undefined,
+    props.level > 0
+      ? (metaBuilder) => {
+        registerActionResponseAction(metaBuilder, 'actionResponse');
+        registerActionErrorAction(metaBuilder, 'actionError');
+      }
+      : undefined,
+  );
 
   const formValues = useMemo<IActionFormModel | null>(() => {
     if (!value)

--- a/shesha-reactjs/src/utils/metadata/hooks/useAvailableStandardConstantsMetadata.ts
+++ b/shesha-reactjs/src/utils/metadata/hooks/useAvailableStandardConstantsMetadata.ts
@@ -1,10 +1,15 @@
 import { IObjectMetadata } from "@/interfaces";
+import { IObjectMetadataBuilder } from "../metadataBuilder";
 import { useAvailableConstantsMetadata } from "./useAvailableConstantsMetadata";
 
-export const useAvailableStandardConstantsMetadata = (makeComponentsNullable?: boolean): IObjectMetadata => {
+export const useAvailableStandardConstantsMetadata = (
+  makeComponentsNullable?: boolean,
+  onBuild?: (metaBuilder: IObjectMetadataBuilder) => void,
+): IObjectMetadata => {
   const availableConstants = useAvailableConstantsMetadata({
     addGlobalConstants: true,
     makeComponentsNullable,
+    ...(onBuild ? { onBuild } : {}),
   });
   return availableConstants;
 };

--- a/shesha-reactjs/src/utils/metadata/standardProperties.tsx
+++ b/shesha-reactjs/src/utils/metadata/standardProperties.tsx
@@ -124,6 +124,26 @@ export const registerSelectedRowAction: MetadataBuilderAction = (builder, name =
   });
 };
 
+export const registerActionResponseAction: MetadataBuilderAction = (builder, name = "actionResponse") => {
+  builder.addCustom(name, "Response returned by the previous action (available in On Success Handler scripts)", () => {
+    const definition: TypeDefinition = {
+      typeName: 'unknown',
+      files: [],
+    };
+    return Promise.resolve(definition);
+  });
+};
+
+export const registerActionErrorAction: MetadataBuilderAction = (builder, name = "actionError") => {
+  builder.addCustom(name, "Error thrown by the previous action (available in On Fail Handler scripts)", () => {
+    const definition: TypeDefinition = {
+      typeName: 'unknown',
+      files: [],
+    };
+    return Promise.resolve(definition);
+  });
+};
+
 export const registerPageContextAction: MetadataBuilderAction = (builder, name = "pageContext") => {
   builder.addCustom(name, "Contexts data of current page @deprecated use page.context instead. This item is outdated and will be removed in further versions.", () => {
     const definition: TypeDefinition = {


### PR DESCRIPTION
… script editors

These variables are injected into the execution context of nested On Success/On Fail handlers at runtime but were never registered with the Monaco IntelliSense metadata builder, causing the editor to underline them as unresolved even though they work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response and error context values for nested success and failure actions.
  * These values can now be used to reference the result or error from a preceding action when configuring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->