### PR TITLE
fix: fixed default collapsed state of CS tree

### DIFF
--- a/shesha-core/src/Shesha.Core/Domain/ShaRoleIdentifier.cs
+++ b/shesha-core/src/Shesha.Core/Domain/ShaRoleIdentifier.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Shesha.Domain
+{
+    /// <summary>
+    /// Role identifier
+    /// </summary>
+    [Serializable]
+    public class ShaRoleIdentifier : ConfigurationItemIdentifier<ShaRole>, IIdentifierFactory<ShaRoleIdentifier>
+    {
+        public ShaRoleIdentifier(string? module, string name) : base(module, name)
+        {
+        }
+
+        public static ShaRoleIdentifier New(string? module, string name)
+        {
+            return new ShaRoleIdentifier(module, name);
+        }
+    }
+}

--- a/shesha-reactjs/src/configuration-studio/index.tsx
+++ b/shesha-reactjs/src/configuration-studio/index.tsx
@@ -20,7 +20,7 @@ import { useLocalStorage } from '@/hooks';
 const ConfigurationStudio: FC = () => {
   const { styles } = useStyles();
   const [treeCollapsed, setTreeCollapsed] = useLocalStorage('shesha:cs-tree-collapsed', false);
-  const [treeTreePinned, setTreeTreePinned] = useLocalStorage('shesha:cs-tree-pinned', true);
+  const [treePinned, setTreePinned] = useLocalStorage('shesha:cs-tree-pinned', true);
   const defaultTreePanelSize = typeof window !== 'undefined' ? (20 / 100) * window.innerWidth : 350;
 
   return (
@@ -59,10 +59,10 @@ const ConfigurationStudio: FC = () => {
             panelMax="50%"
 
             defaultPanelSize={defaultTreePanelSize}
-            defaultExpanded={!treeCollapsed}
+            defaultExpanded={!treeCollapsed && treePinned}
             onExpandedToggle={(expanded) => setTreeCollapsed(!expanded)}
-            defaultPinned={treeTreePinned}
-            onPinnedToggle={(pinned) => setTreeTreePinned(pinned)}
+            defaultPinned={treePinned}
+            onPinnedToggle={(pinned) => setTreePinned(pinned)}
           >
             <WorkArea />
           </SplitLayout>


### PR DESCRIPTION
- added ShaRoleIdentifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identifying configured roles by module and name.

- **Improvements**
  - Improved Configuration Studio’s tree panel behavior by consistently preserving its pinned state and restoring the appropriate expanded or collapsed view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->