### PR TITLE
Keep designer tooltips from stacking up and show them at the cursor

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/configurableFormComponent/__tests__/dragWrapper.test.tsx
+++ b/shesha-reactjs/src/components/formDesigner/configurableFormComponent/__tests__/dragWrapper.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Wrappers nest - a container's wrapper holds its children's wrappers - so hover handling has to answer
+ * two questions correctly at once:
+ *  - only the innermost wrapper under the cursor shows a tooltip (ancestors must not pile up);
+ *  - every wrapper closes when the cursor leaves, including ancestors of the element that was left.
+ * Stopping propagation satisfied the first and broke the second, leaving container tooltips stuck open.
+ *
+ * The tooltip is also anchored to the cursor rather than to the component, whose right edge can be a whole
+ * canvas away for a container, and the anchor lives in the body so the canvas' CSS `zoom` cannot scale the
+ * viewport coordinates it is positioned with.
+ */
+
+const models: Record<string, { id: string; type: string; propertyName: string }> = {
+  container: { id: 'container', type: 'container', propertyName: 'outer' },
+  child: { id: 'child', type: 'textField', propertyName: 'inner' },
+};
+
+vi.mock('@/providers/form', () => ({
+  ShaForm: { useComponentModel: (id: string) => models[id] },
+}));
+
+vi.mock('@/providers/formDesigner', () => ({
+  useFormDesigner: () => ({ setSelectedComponent: vi.fn() }),
+  useFormDesignerSelectedComponentId: () => undefined,
+  useFormDesignerIsDebug: () => false,
+}));
+
+// The real tooltip renders through a portal with motion, which jsdom cannot settle. The stub exposes the
+// only things this test cares about: whether a wrapper asked to be open, and the overlay's pointer-events.
+interface ITooltipStubProps {
+  title?: ReactNode;
+  open?: boolean | undefined;
+  styles?: { root?: CSSProperties | undefined } | undefined;
+  children?: ReactNode;
+}
+
+vi.mock('antd', () => ({
+  Tooltip: ({ title, open, styles, children }: ITooltipStubProps) => (
+    <>
+      {Boolean(open) && (
+        <div data-testid="tooltip" data-pointer-events={styles?.root?.pointerEvents}>{title}</div>
+      )}
+      {children}
+    </>
+  ),
+}));
+
+import DragWrapper from '../dragWrapper';
+
+const renderNested = (): { container: HTMLElement; outside: HTMLElement } => {
+  const { container } = render(
+    <div>
+      <DragWrapper componentId="container" className="outer-wrapper">
+        <span data-testid="container-chrome">container label</span>
+        <DragWrapper componentId="child" className="inner-wrapper">
+          <span data-testid="child-content">child input</span>
+        </DragWrapper>
+      </DragWrapper>
+      <div data-testid="canvas">canvas</div>
+    </div>,
+  );
+  return { container, outside: screen.getByTestId('canvas') };
+};
+
+const openTooltips = (): string[] => screen.queryAllByTestId('tooltip').map((el) => el.textContent);
+
+const anchorOf = (): HTMLElement | null => screen.queryByTestId('drag-wrapper-tooltip-anchor');
+
+describe('DragWrapper hover tooltip', () => {
+  it('shows only the innermost wrapper tooltip when hovering a nested component', () => {
+    renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('child-content'));
+
+    const tooltips = openTooltips();
+    expect(tooltips).toHaveLength(1);
+    expect(tooltips[0]).toContain('inner');
+    expect(tooltips[0]).not.toContain('outer');
+  });
+
+  it('shows the container tooltip when hovering the container itself', () => {
+    renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('container-chrome'));
+
+    const tooltips = openTooltips();
+    expect(tooltips).toHaveLength(1);
+    expect(tooltips[0]).toContain('outer');
+  });
+
+  it('closes the container tooltip when the cursor moves into a child component', () => {
+    renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('container-chrome'));
+    expect(openTooltips()[0]).toContain('outer');
+
+    fireEvent.mouseOut(screen.getByTestId('container-chrome'), {
+      relatedTarget: screen.getByTestId('child-content'),
+    });
+    fireEvent.mouseOver(screen.getByTestId('child-content'));
+
+    const tooltips = openTooltips();
+    expect(tooltips).toHaveLength(1);
+    expect(tooltips[0]).toContain('inner');
+  });
+
+  it('closes every tooltip when the cursor leaves a nested component for the canvas', () => {
+    const { outside } = renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('child-content'));
+    expect(openTooltips()).toHaveLength(1);
+
+    fireEvent.mouseOut(screen.getByTestId('child-content'), { relatedTarget: outside });
+
+    expect(openTooltips()).toHaveLength(0);
+  });
+
+  it('keeps the tooltip open while the cursor moves between elements inside the same wrapper', () => {
+    renderNested();
+    const content = screen.getByTestId('child-content');
+
+    fireEvent.mouseOver(content);
+    expect(openTooltips()).toHaveLength(1);
+
+    // leaving for a descendant of the same wrapper is not a leave, and must not close/reopen the tooltip
+    fireEvent.mouseOut(content, { relatedTarget: content.firstChild ?? content });
+
+    expect(openTooltips()).toHaveLength(1);
+  });
+
+  it('renders the overlay without pointer events so hovering it cannot close the tooltip', () => {
+    renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('child-content'));
+
+    expect(screen.getByTestId('tooltip').getAttribute('data-pointer-events')).toBe('none');
+  });
+  it('anchors the tooltip to the point where the cursor entered the component', () => {
+    renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('child-content'), { clientX: 120, clientY: 64 });
+
+    const anchor = anchorOf();
+    expect(anchor).not.toBeNull();
+    expect(anchor?.style.position).toBe('fixed');
+    expect(anchor?.style.left).toBe('120px');
+    expect(anchor?.style.top).toBe('64px');
+  });
+
+  it('keeps the anchor pinned while the cursor moves around inside the component', () => {
+    renderNested();
+    const content = screen.getByTestId('child-content');
+
+    fireEvent.mouseOver(content, { clientX: 120, clientY: 64 });
+    fireEvent.mouseOver(content, { clientX: 300, clientY: 210 });
+
+    expect(anchorOf()?.style.left).toBe('120px');
+    expect(anchorOf()?.style.top).toBe('64px');
+  });
+
+  it('renders the anchor outside the canvas so its coordinates are not scaled by canvas zoom', () => {
+    const { container } = renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('child-content'));
+
+    const anchor = anchorOf();
+    expect(anchor).not.toBeNull();
+    expect(container.contains(anchor)).toBe(false);
+  });
+
+  it('removes the anchor when the tooltip closes', () => {
+    const { outside } = renderNested();
+
+    fireEvent.mouseOver(screen.getByTestId('child-content'));
+    expect(anchorOf()).not.toBeNull();
+
+    fireEvent.mouseOut(screen.getByTestId('child-content'), { relatedTarget: outside });
+
+    expect(anchorOf()).toBeNull();
+  });
+});

--- a/shesha-reactjs/src/components/formDesigner/configurableFormComponent/dragWrapper.tsx
+++ b/shesha-reactjs/src/components/formDesigner/configurableFormComponent/dragWrapper.tsx
@@ -1,5 +1,6 @@
 import { FC, PropsWithChildren, useMemo, useState } from 'react';
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 import { ShaForm } from '@/providers/form';
 import { Tooltip } from 'antd';
 import { useFormDesigner, useFormDesignerSelectedComponentId, useFormDesignerIsDebug } from '@/providers/formDesigner';
@@ -11,11 +12,20 @@ interface IDragWrapperProps {
   className?: string | undefined;
 }
 
+/** Marks the wrapper element so nested wrappers can work out which one of them is the innermost under the cursor. */
+const DRAG_WRAPPER_MARKER = 'data-sha-drag-wrapper';
+/** Width of the anchor, which is what keeps the tooltip clear of the cursor it sits next to. */
+const CURSOR_GAP = 14;
+
 export const DragWrapper: FC<PropsWithChildren<IDragWrapperProps>> = (props) => {
   const selectedComponentId = useFormDesignerSelectedComponentId();
   const isDebug = useFormDesignerIsDebug();
   const { setSelectedComponent } = useFormDesigner();
-  const [isOpen, setIsOpen] = useState(false);
+  /**
+   * Viewport position the tooltip is pinned to, or `null` while the component is not hovered. Pinned to the
+   * cursor rather than to the component, whose right edge can be a whole canvas away for a container.
+   */
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
 
   const componentModel = ShaForm.useComponentModel(props.componentId);
 
@@ -51,24 +61,59 @@ export const DragWrapper: FC<PropsWithChildren<IDragWrapperProps>> = (props) => 
       );
   };
 
-  const onMouseEnter = (event: React.MouseEvent<HTMLElement>): void => {
-    event.stopPropagation();
-    setIsOpen(true);
+  // Wrappers nest (a container's wrapper contains its children's wrappers), so only the innermost one under the
+  // cursor shows its tooltip. That decision is made explicitly instead of by stopping propagation: ancestors must
+  // still receive these events, otherwise their tooltips never get the chance to close.
+  const onMouseOver = (event: React.MouseEvent<HTMLElement>): void => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (target?.closest(`[${DRAG_WRAPPER_MARKER}]`) !== event.currentTarget) {
+      setAnchor(null);
+      return;
+    }
+
+    const { clientX, clientY } = event;
+    // pinned to where the cursor entered, so it doesn't hop as the cursor crosses inner elements
+    setAnchor((prev) => prev ?? { x: clientX, y: clientY });
   };
 
-  const onMouseLeave = (event: React.MouseEvent<HTMLElement>): void => {
-    event.stopPropagation();
-    setIsOpen(false);
+  const onMouseOut = (event: React.MouseEvent<HTMLElement>): void => {
+    // moves between elements inside this wrapper are not a leave - closing on those flickers the tooltip
+    const nextTarget = event.relatedTarget instanceof Node ? event.relatedTarget : null;
+    if (nextTarget !== null && event.currentTarget.contains(nextTarget)) return;
+
+    setAnchor(null);
   };
 
   return (
-    // `pointerEvents: none` keeps the overlay out of hit-testing, otherwise moving the cursor onto the
-    // tooltip triggers mouse leave on the wrapper and the tooltip flickers open/closed under the cursor
-    <Tooltip title={tooltip} placement="right" open={isOpen} styles={{ root: { pointerEvents: 'none' } }}>
-      <div className={props.className} onClick={onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-        {props.children}
-      </div>
-    </Tooltip>
+    <div
+      {...{ [DRAG_WRAPPER_MARKER]: true }}
+      className={props.className}
+      onClick={onClick}
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+    >
+      {props.children}
+
+      {anchor !== null && createPortal(
+        // Portalled into the body so the canvas' CSS `zoom` scales neither these viewport coordinates nor
+        // the overlay (see the theme provider's getPopupContainer). `pointerEvents: none` keeps the overlay
+        // out of hit-testing - otherwise reaching it counts as leaving the component and the tooltip flickers.
+        <Tooltip open title={tooltip} placement="right" styles={{ root: { pointerEvents: 'none' } }}>
+          <span
+            data-testid="drag-wrapper-tooltip-anchor"
+            style={{
+              position: 'fixed',
+              left: anchor.x,
+              top: anchor.y,
+              width: CURSOR_GAP,
+              height: 1,
+              pointerEvents: 'none',
+            }}
+          />
+        </Tooltip>,
+        document.body,
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
Wrappers nest, so a container's wrapper contains its children's wrappers. The previous commit stopped propagation on mouse leave, and because React dispatches enter/leave along the whole ancestor chain in a single pass, ancestor wrappers never received the event - their tooltips stayed open, several at a time, and outlived the cursor. Decide "innermost wins" explicitly instead, by comparing the closest wrapper of the event target against the handling wrapper, so ancestors keep receiving events and can close themselves. Mouse out ignores moves whose related target is still inside the wrapper, which is what stops the tooltip flickering as the cursor crosses a component's inner elements.

Also anchor the tooltip to the point where the cursor entered, rather than to the component: a container spans the canvas, so placement="right" put its tooltip an entire canvas away from the cursor. The anchor is portalled into the body because the canvas scales itself with CSS zoom, which would scale the viewport coordinates the anchor is positioned with, and diverts popups into a zoomed container - out there both anchor and tooltip stay unzoomed.

Tests cover innermost-only display, container-to-child handover, close on leave, moves inside a wrapper, the anchor position and the overlay's pointer-events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form designer hover tooltips so only the innermost component displays a tooltip.
  * Tooltips now close reliably when leaving a component or the canvas, while remaining stable when moving within the same component.
  * Tooltip positioning stays anchored to the cursor and remains correctly sized and positioned during canvas zoom.
  * Tooltip overlays no longer interfere with pointer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->