### PR TITLE
Chevron fixes

### DIFF
--- a/shesha-reactjs/src/components/chevron/__tests__/chevron.test.tsx
+++ b/shesha-reactjs/src/components/chevron/__tests__/chevron.test.tsx
@@ -3,11 +3,11 @@ import { ChevronControl } from '..';
 import { RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
 import { IChevronProps } from '../models';
 
-const items: RefListGroupItemProps[] = [
-  { id: 'male-id', item: 'Male', itemValue: 1 } as RefListGroupItemProps,
-  { id: 'female-id', item: 'Female', itemValue: 2, hidden: true } as RefListGroupItemProps,
-  { id: 'other-id', item: 'Other', itemValue: 3 } as RefListGroupItemProps,
-];
+const items = [
+  { id: 'male-id', item: 'Male', itemValue: 1 },
+  { id: 'female-id', item: 'Female', itemValue: 2, hidden: true },
+  { id: 'other-id', item: 'Other', itemValue: 3 },
+] satisfies RefListGroupItemProps[];
 
 vi.mock('@/components/refListSelectorDisplay/provider', () => ({
   useRefListItemGroupConfigurator: () => ({ items }),
@@ -19,7 +19,7 @@ vi.mock('@/designer-components/button/configurableButton', () => ({
   ),
 }));
 
-const model = { id: 'c1', type: 'chevron', propertyName: 'gender' } as IChevronProps;
+const model = { id: 'c1', type: 'chevron', propertyName: 'gender' } satisfies IChevronProps;
 
 const steps = (): (string | null)[] => Array.from(document.querySelectorAll('button')).map((b) => b.textContent);
 

--- a/shesha-reactjs/src/components/chevron/__tests__/chevron.test.tsx
+++ b/shesha-reactjs/src/components/chevron/__tests__/chevron.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { ChevronControl } from '..';
 import { RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
 import { IChevronProps } from '../models';
@@ -14,7 +14,9 @@ vi.mock('@/components/refListSelectorDisplay/provider', () => ({
 }));
 vi.mock('@/providers/theme', () => ({ useTheme: () => ({ theme: { application: { primaryColor: '#1890ff' } } }) }));
 vi.mock('@/designer-components/button/configurableButton', () => ({
-  default: (props: { label?: string }) => <button type="button">{props.label}</button>,
+  default: (props: { label?: string; onBeforeClick?: () => void }) => (
+    <button type="button" onClick={() => props.onBeforeClick?.()}>{props.label}</button>
+  ),
 }));
 
 const model = { id: 'c1', type: 'chevron', propertyName: 'gender' } as IChevronProps;
@@ -25,5 +27,27 @@ describe('ChevronControl', () => {
   it('does not render a hidden step', () => {
     render(<ChevronControl {...model} value={1} />);
     expect(steps()).toEqual(['Male', 'Other']);
+  });
+
+  it('writes the clicked step back to the bound property', () => {
+    const onChange = vi.fn();
+    render(<ChevronControl {...model} value={1} onChange={onChange} />);
+
+    act(() => {
+      Array.from(document.querySelectorAll('button')).find((b) => b.textContent === 'Other')!.click();
+    });
+
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('does not write back when read only', () => {
+    const onChange = vi.fn();
+    render(<ChevronControl {...model} readOnly value={1} onChange={onChange} />);
+
+    act(() => {
+      Array.from(document.querySelectorAll('button')).find((b) => b.textContent === 'Other')!.click();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/shesha-reactjs/src/components/chevron/__tests__/chevron.test.tsx
+++ b/shesha-reactjs/src/components/chevron/__tests__/chevron.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { ChevronControl } from '..';
+import { RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
+import { IChevronProps } from '../models';
+
+const items: RefListGroupItemProps[] = [
+  { id: 'male-id', item: 'Male', itemValue: 1 } as RefListGroupItemProps,
+  { id: 'female-id', item: 'Female', itemValue: 2, hidden: true } as RefListGroupItemProps,
+  { id: 'other-id', item: 'Other', itemValue: 3 } as RefListGroupItemProps,
+];
+
+vi.mock('@/components/refListSelectorDisplay/provider', () => ({
+  useRefListItemGroupConfigurator: () => ({ items }),
+}));
+vi.mock('@/providers/theme', () => ({ useTheme: () => ({ theme: { application: { primaryColor: '#1890ff' } } }) }));
+vi.mock('@/designer-components/button/configurableButton', () => ({
+  default: (props: { label?: string }) => <button type="button">{props.label}</button>,
+}));
+
+const model = { id: 'c1', type: 'chevron', propertyName: 'gender' } as IChevronProps;
+
+const steps = (): (string | null)[] => Array.from(document.querySelectorAll('button')).map((b) => b.textContent);
+
+describe('ChevronControl', () => {
+  it('does not render a hidden step', () => {
+    render(<ChevronControl {...model} value={1} />);
+    expect(steps()).toEqual(['Male', 'Other']);
+  });
+});

--- a/shesha-reactjs/src/components/chevron/index.tsx
+++ b/shesha-reactjs/src/components/chevron/index.tsx
@@ -10,7 +10,7 @@ import { useStyles } from "./styles";
 import { fadeColor } from "../refListSelectorDisplay/provider/utils";
 
 export const ChevronControl: FC<IChevronControlProps> = (props) => {
-  const { value, activeColor, showIcons, colorSource } = props;
+  const { value, activeColor, showIcons, colorSource, onChange, readOnly } = props;
   const { items: refListItems } = useRefListItemGroupConfigurator();
   // Render from the reference list held by the provider rather than the saved snapshot,
   // so the designer, preview and runtime cannot drift apart.
@@ -35,28 +35,36 @@ export const ChevronControl: FC<IChevronControlProps> = (props) => {
     }
   }, [activeColor, theme.application?.primaryColor]);
 
+  // The item configurator stores the per-step visibility as `hidden`, so that is what a step is
+  // filtered on. Reading `visible` never worked: the configurator's editor seeds it to `true`,
+  // so every step rendered regardless of the Hide switch.
+  const visibleItems = useMemo(() => items.filter((item) => item.hidden !== true), [items]);
+
+  const selectItem = React.useCallback((itemValue: number): void => {
+    if (readOnly === true) return;
+    onChange?.(itemValue);
+  }, [onChange, readOnly]);
+
   const renderButton = React.useCallback((itemProps: IChevronButton, uuid: string): ReactNode => {
     const color = getColor(colorSource ?? 'primary', itemProps.color);
-    // The item configurator stores the per-step visibility as `hidden`, so that is what a step is
-    // filtered on. Reading `visible` never worked: the configurator's editor seeds it to `true`,
-    // so every step rendered regardless of the Hide switch.
-    return itemProps.hidden !== true
-      ? (
-        <ConfigurableButton
-          key={uuid}
-          {...itemProps}
-          icon={showIcons === true ? itemProps.icon : undefined}
-          buttonType="default"
-          label={itemProps.item}
-          className={classNames(styles.chevronButton, { [styles.chevronButtonActive]: itemProps.itemValue === value })}
-          font={props.font}
-          background={{ type: 'color', color: itemProps.itemValue === value ? color : fadeColor(color, 70) }}
-        />
-      )
-      : undefined;
-  }, [colorSource, getColor, props.font, showIcons, styles.chevronButton, styles.chevronButtonActive, value]);
+    return (
+      <ConfigurableButton
+        key={uuid}
+        {...itemProps}
+        icon={showIcons === true ? itemProps.icon : undefined}
+        buttonType="default"
+        label={itemProps.item}
+        className={classNames(styles.chevronButton, { [styles.chevronButtonActive]: itemProps.itemValue === value })}
+        font={props.font}
+        background={{ type: 'color', color: itemProps.itemValue === value ? color : fadeColor(color, 70) }}
+        // Clicking a step must set the bound property. `onBeforeClick` runs in addition to the
+        // step's own action, so the Events configuration keeps working.
+        onBeforeClick={() => selectItem(itemProps.itemValue)}
+      />
+    );
+  }, [colorSource, getColor, props.font, selectItem, showIcons, styles.chevronButton, styles.chevronButtonActive, value]);
 
-  const buttons = useMemo(() => items.map((item) => renderButton(item, item.id)), [items, renderButton]);
+  const buttons = useMemo(() => visibleItems.map((item) => renderButton(item, item.id)), [visibleItems, renderButton]);
 
   const updateArrows = React.useCallback((stages: HTMLDivElement): void => {
     setShowLeftArrow(stages.scrollLeft > 0);

--- a/shesha-reactjs/src/components/chevron/index.tsx
+++ b/shesha-reactjs/src/components/chevron/index.tsx
@@ -37,7 +37,10 @@ export const ChevronControl: FC<IChevronControlProps> = (props) => {
 
   const renderButton = React.useCallback((itemProps: IChevronButton, uuid: string): ReactNode => {
     const color = getColor(colorSource ?? 'primary', itemProps.color);
-    return itemProps.visible !== false
+    // The item configurator stores the per-step visibility as `hidden`, so that is what a step is
+    // filtered on. Reading `visible` never worked: the configurator's editor seeds it to `true`,
+    // so every step rendered regardless of the Hide switch.
+    return itemProps.hidden !== true
       ? (
         <ConfigurableButton
           key={uuid}

--- a/shesha-reactjs/src/components/chevron/models.ts
+++ b/shesha-reactjs/src/components/chevron/models.ts
@@ -37,6 +37,7 @@ export interface IChevronProps extends IConfigurableFormComponent<IChevronStyleP
 
 export interface IChevronControlProps extends IChevronProps {
   value?: number | null | undefined;
+  onChange?: ((value: number | null | undefined) => void) | undefined;
 }
 
 export interface IChevronButton extends IButtonGroupItem {

--- a/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/itemConfiguration.test.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/itemConfiguration.test.tsx
@@ -1,0 +1,92 @@
+import { act, render } from '@testing-library/react';
+import { FC, useEffect, useState } from 'react';
+import { IReferenceListItem } from '@/interfaces/referenceList';
+import { RefListItemGroupConfiguratorProvider, useRefListItemGroupConfigurator } from '../provider';
+import { RefListGroupItemProps } from '../provider/models';
+
+const refListItems: IReferenceListItem[] = [
+  { id: 'male-id', item: 'Male', itemValue: 1, description: null, orderIndex: 0, color: null, icon: null, shortAlias: null },
+  { id: 'female-id', item: 'Female', itemValue: 2, description: null, orderIndex: 1, color: null, icon: null, shortAlias: null },
+];
+
+const getReferenceList = vi.fn(() => ({ promise: Promise.resolve({ items: refListItems }) }));
+
+vi.mock('@/providers/referenceListDispatcher', () => ({
+  useReferenceListDispatcher: () => ({ getReferenceList }),
+}));
+
+interface IProbeHandle {
+  items: RefListGroupItemProps[];
+  configureFirstItem: () => void;
+}
+
+const Probe: FC<{ onReady: (handle: IProbeHandle) => void }> = ({ onReady }) => {
+  const { items, updateItem } = useRefListItemGroupConfigurator();
+
+  useEffect(() => {
+    onReady({
+      items,
+      configureFirstItem: () => updateItem({
+        id: 'male-id',
+        settings: {
+          hidden: true,
+          tooltip: 'first step',
+          actionConfiguration: { actionName: 'Show Dialog', actionOwner: 'x' },
+        } as RefListGroupItemProps,
+      }),
+    });
+  });
+
+  return <div>{items.length}</div>;
+};
+
+/** Stands in for the settings-panel host, which re-renders whenever the configured value is written back. */
+const Host: FC<{ onReady: (handle: IProbeHandle) => void; onRerender: (rerender: () => void) => void }> = ({ onReady, onRerender }) => {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    onRerender(() => setTick((tick) => tick + 1));
+  });
+
+  return (
+    <RefListItemGroupConfiguratorProvider items={[]} referenceList={{ name: 'Gender', module: 'Core' }}>
+      <Probe onReady={onReady} />
+    </RefListItemGroupConfiguratorProvider>
+  );
+};
+
+describe('RefList item configurator', () => {
+  it('keeps a step configuration when the host re-renders', async () => {
+    let handle: IProbeHandle | undefined;
+    let rerender = (): void => undefined;
+    const captureHandle = (h: IProbeHandle): void => {
+      handle = h;
+    };
+    const captureRerender = (fn: () => void): void => {
+      rerender = fn;
+    };
+
+    await act(async () => {
+      render(<Host onReady={captureHandle} onRerender={captureRerender} />);
+      await Promise.resolve();
+    });
+
+    expect(handle?.items).toHaveLength(2);
+
+    // configure the FIRST step: Hide, a tooltip and an action
+    await act(() => {
+      handle?.configureFirstItem();
+    });
+
+    expect(handle?.items[0]).toMatchObject({ hidden: true, tooltip: 'first step', actionConfiguration: { actionName: 'Show Dialog' } });
+
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+
+    expect(handle?.items[0]).toMatchObject({ hidden: true, tooltip: 'first step', actionConfiguration: { actionName: 'Show Dialog' } });
+    // the reference list is read once per identity, so a re-render must not read it again
+    expect(getReferenceList).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/itemConfiguration.test.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/itemConfiguration.test.tsx
@@ -55,6 +55,13 @@ const Host: FC<{ onReady: (handle: IProbeHandle) => void; onRerender: (rerender:
   );
 };
 
+/** Stands in for the rendered component, whose items come from the saved component model. */
+const Canvas: FC<{ items: RefListGroupItemProps[]; onReady: (handle: IProbeHandle) => void }> = ({ items, onReady }) => (
+  <RefListItemGroupConfiguratorProvider items={items} referenceList={{ name: 'Gender', module: 'Core' }}>
+    <Probe onReady={onReady} />
+  </RefListItemGroupConfiguratorProvider>
+);
+
 describe('RefList item configurator', () => {
   it('keeps a step configuration when the host re-renders', async () => {
     let handle: IProbeHandle | undefined;
@@ -88,5 +95,30 @@ describe('RefList item configurator', () => {
     expect(handle?.items[0]).toMatchObject({ hidden: true, tooltip: 'first step', actionConfiguration: { actionName: 'Show Dialog' } });
     // the reference list is read once per identity, so a re-render must not read it again
     expect(getReferenceList).toHaveBeenCalledTimes(1);
+  });
+
+  it('adopts a configuration saved by the host without being re-created', async () => {
+    let handle: IProbeHandle | undefined;
+    const captureHandle = (h: IProbeHandle): void => {
+      handle = h;
+    };
+
+    let rendered: ReturnType<typeof render> | undefined;
+    await act(async () => {
+      rendered = render(<Canvas items={[]} onReady={captureHandle} />);
+      await Promise.resolve();
+    });
+
+    expect(handle?.items.map((i) => i.hidden)).toEqual([undefined, undefined]);
+
+    // the designer saves "Hide" on the second step
+    await act(async () => {
+      rendered?.rerender(<Canvas items={[{ id: 'female-id', itemValue: 2, hidden: true } as RefListGroupItemProps]} onReady={captureHandle} />);
+      await Promise.resolve();
+    });
+
+    expect(handle?.items.map((i) => i.hidden)).toEqual([undefined, true]);
+    // the display data still comes from the reference list
+    expect(handle?.items[1]).toMatchObject({ item: 'Female', itemValue: 2 });
   });
 });

--- a/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/itemConfiguration.test.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/itemConfiguration.test.tsx
@@ -29,10 +29,11 @@ const Probe: FC<{ onReady: (handle: IProbeHandle) => void }> = ({ onReady }) => 
       configureFirstItem: () => updateItem({
         id: 'male-id',
         settings: {
+          id: 'male-id',
           hidden: true,
           tooltip: 'first step',
-          actionConfiguration: { actionName: 'Show Dialog', actionOwner: 'x' },
-        } as RefListGroupItemProps,
+          actionConfiguration: { actionOwner: 'x', actionName: 'Show Dialog', handleSuccess: false, handleFail: false, _type: undefined },
+        },
       }),
     });
   });
@@ -113,7 +114,7 @@ describe('RefList item configurator', () => {
 
     // the designer saves "Hide" on the second step
     await act(async () => {
-      rendered?.rerender(<Canvas items={[{ id: 'female-id', itemValue: 2, hidden: true } as RefListGroupItemProps]} onReady={captureHandle} />);
+      rendered?.rerender(<Canvas items={[{ id: 'female-id', itemValue: 2, hidden: true }]} onReady={captureHandle} />);
       await Promise.resolve();
     });
 

--- a/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/writeBack.test.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/writeBack.test.tsx
@@ -1,0 +1,86 @@
+import { act, render } from '@testing-library/react';
+import { FC } from 'react';
+import { IReferenceListItem } from '@/interfaces/referenceList';
+import { RefListGroupItemProps } from '../provider/models';
+
+const refListItems: IReferenceListItem[] = [
+  { id: 'male-id', item: 'Male', itemValue: 1, description: null, orderIndex: 0, color: null, icon: null, shortAlias: null },
+  { id: 'female-id', item: 'Female', itemValue: 2, description: null, orderIndex: 1, color: null, icon: null, shortAlias: null },
+];
+
+const getReferenceList = vi.fn(() => ({ promise: Promise.resolve({ items: refListItems }) }));
+
+vi.mock('@/providers/referenceListDispatcher', () => ({
+  useReferenceListDispatcher: () => ({ getReferenceList }),
+}));
+
+// Stand-in for the real item settings form: writes an action onto the selected item, the way
+// RefListItemProperties does through its debounced updateItem.
+vi.mock('../options/configurator', async () => {
+  const { useRefListItemGroupConfigurator: useCfg } = await import('../provider');
+  const Stub: FC = () => {
+    const { selectedItemId, updateItem } = useCfg();
+    return (
+      <button
+        type="button"
+        onClick={() => updateItem({ id: selectedItemId!, settings: { actionConfiguration: { actionName: 'Show Dialog' } } as RefListGroupItemProps })}
+      >
+        set action
+      </button>
+    );
+  };
+  return { default: Stub };
+});
+
+import RefListItemSelectorSettingsModal from '../options/modal';
+
+describe('RefList items write-back', () => {
+  it('propagates a first-step configuration to the host form value', async () => {
+    const onChange = vi.fn();
+    await act(async () => {
+      render(
+        <RefListItemSelectorSettingsModal
+          value={[]}
+          onChange={onChange}
+          readOnly={false}
+          referenceList={{ name: 'Gender', module: 'Core' }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const calls = (): RefListGroupItemProps[][] => onChange.mock.calls.map((c) => c[0] as RefListGroupItemProps[]);
+
+    // the empty list the host already holds must not be written back; only the items read from
+    // the reference list are reported
+    expect(calls()).toHaveLength(1);
+    expect(calls()[0]).toHaveLength(2);
+
+    // open the FIRST step's configuration modal
+    const gears = Array.from(document.querySelectorAll<HTMLButtonElement>('.sha-toolbar-item button'));
+    expect(gears).toHaveLength(2);
+    await act(() => {
+      gears[0]!.click();
+    });
+
+    const setAction = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find((b) => b.textContent === 'set action');
+    await act(() => {
+      setAction!.click();
+    });
+
+    const last = calls()[calls().length - 1];
+    expect(last?.find((i) => i.itemValue === 1)).toMatchObject({ actionConfiguration: { actionName: 'Show Dialog' } });
+
+    // ... and it survives saving the step modal, which closes it and re-renders the host
+    const save = Array.from(document.querySelectorAll<HTMLButtonElement>('.ant-modal button')).find((b) => b.textContent === 'Save');
+    expect(save).toBeDefined();
+    await act(async () => {
+      save!.click();
+      await Promise.resolve();
+    });
+
+    const afterSave = calls()[calls().length - 1];
+    expect(afterSave?.find((i) => i.itemValue === 1)).toMatchObject({ actionConfiguration: { actionName: 'Show Dialog' } });
+    expect(getReferenceList).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/writeBack.test.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/writeBack.test.tsx
@@ -1,7 +1,7 @@
 import { act, render } from '@testing-library/react';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { IReferenceListItem } from '@/interfaces/referenceList';
-import { RefListGroupItemProps } from '../provider/models';
+import { IRefListItemFormModel } from '../provider/models';
 
 const refListItems: IReferenceListItem[] = [
   { id: 'male-id', item: 'Male', itemValue: 1, description: null, orderIndex: 0, color: null, icon: null, shortAlias: null },
@@ -20,10 +20,17 @@ vi.mock('../options/configurator', async () => {
   const { useRefListItemGroupConfigurator: useCfg } = await import('../provider');
   const Stub: FC = () => {
     const { selectedItemId, updateItem } = useCfg();
+    if (selectedItemId === undefined) return null;
     return (
       <button
         type="button"
-        onClick={() => updateItem({ id: selectedItemId!, settings: { actionConfiguration: { actionName: 'Show Dialog' } } as RefListGroupItemProps })}
+        onClick={() => updateItem({
+          id: selectedItemId,
+          settings: {
+            id: selectedItemId,
+            actionConfiguration: { actionOwner: 'x', actionName: 'Show Dialog', handleSuccess: false, handleFail: false, _type: undefined },
+          },
+        })}
       >
         set action
       </button>
@@ -35,14 +42,45 @@ vi.mock('../options/configurator', async () => {
 import RefListItemSelectorSettingsModal from '../options/modal';
 
 /**
+ * The stored shape of an item: the reference list's own fields travel with it, but only `item` and
+ * `itemValue` are part of the declared item type.
+ */
+type SerializedItem = IRefListItemFormModel & { orderIndex?: number | undefined };
+
+/**
  * A previously saved list, as it comes back from the form configuration: the reference list's
  * blank display data (colour, icon, alias) was dropped when it was serialised.
- * `orderIndex` is carried on the stored items but is not part of the declared item type.
  */
-const savedItems = [
+const savedItems: SerializedItem[] = [
   { id: 'male-id', item: 'Male', itemValue: 1, orderIndex: 0 },
   { id: 'female-id', item: 'Female', itemValue: 2, orderIndex: 1 },
-] as unknown as RefListGroupItemProps[];
+];
+
+/** Stands in for the settings form: the value it holds is what the configurator reports back to it. */
+const ControlledHost: FC<{ initialValue: SerializedItem[]; onValue: (value: IRefListItemFormModel[]) => void }> = ({ initialValue, onValue }) => {
+  const [value, setValue] = useState<IRefListItemFormModel[]>(initialValue);
+
+  return (
+    <RefListItemSelectorSettingsModal
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue ?? []);
+        onValue(newValue ?? []);
+      }}
+      readOnly={false}
+      referenceList={{ name: 'Gender', module: 'Core' }}
+    />
+  );
+};
+
+const clickButton = async (matches: (button: HTMLButtonElement) => boolean): Promise<void> => {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(matches);
+  expect(button).toBeDefined();
+  await act(async () => {
+    button!.click();
+    await Promise.resolve();
+  });
+};
 
 describe('RefList items write-back', () => {
   beforeEach(() => {
@@ -50,68 +88,49 @@ describe('RefList items write-back', () => {
   });
 
   it('reports nothing when the reference list only fills in blank display data', async () => {
-    const onChange = vi.fn();
+    const onValue = vi.fn();
     await act(async () => {
-      render(
-        <RefListItemSelectorSettingsModal
-          value={savedItems}
-          onChange={onChange}
-          readOnly={false}
-          referenceList={{ name: 'Gender', module: 'Core' }}
-        />,
-      );
+      render(<ControlledHost initialValue={savedItems} onValue={onValue} />);
       await Promise.resolve();
     });
 
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onValue).not.toHaveBeenCalled();
   });
 
   it('propagates a first-step configuration to the host form value', async () => {
-    const onChange = vi.fn();
+    const onValue = vi.fn<(value: IRefListItemFormModel[]) => void>();
     await act(async () => {
-      render(
-        <RefListItemSelectorSettingsModal
-          value={[]}
-          onChange={onChange}
-          readOnly={false}
-          referenceList={{ name: 'Gender', module: 'Core' }}
-        />,
-      );
+      render(<ControlledHost initialValue={[]} onValue={onValue} />);
       await Promise.resolve();
     });
 
-    const calls = (): RefListGroupItemProps[][] => onChange.mock.calls.map((c) => c[0] as RefListGroupItemProps[]);
+    const lastValue = (): IRefListItemFormModel[] | undefined => onValue.mock.lastCall?.[0];
 
     // the empty list the host already holds must not be written back; only the items read from
     // the reference list are reported
-    expect(calls()).toHaveLength(1);
-    expect(calls()[0]).toHaveLength(2);
+    expect(onValue).toHaveBeenCalledTimes(1);
+    expect(lastValue()).toHaveLength(2);
 
     // open the FIRST step's configuration modal
     const gears = Array.from(document.querySelectorAll<HTMLButtonElement>('.sha-toolbar-item button'));
     expect(gears).toHaveLength(2);
-    await act(() => {
-      gears[0]!.click();
-    });
-
-    const setAction = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find((b) => b.textContent === 'set action');
-    await act(() => {
-      setAction!.click();
-    });
-
-    const last = calls()[calls().length - 1];
-    expect(last?.find((i) => i.itemValue === 1)).toMatchObject({ actionConfiguration: { actionName: 'Show Dialog' } });
-
-    // ... and it survives saving the step modal, which closes it and re-renders the host
-    const save = Array.from(document.querySelectorAll<HTMLButtonElement>('.ant-modal button')).find((b) => b.textContent === 'Save');
-    expect(save).toBeDefined();
     await act(async () => {
-      save!.click();
+      gears[0]!.click();
       await Promise.resolve();
     });
 
-    const afterSave = calls()[calls().length - 1];
-    expect(afterSave?.find((i) => i.itemValue === 1)).toMatchObject({ actionConfiguration: { actionName: 'Show Dialog' } });
+    await clickButton((b) => b.textContent === 'set action');
+
+    expect(lastValue()?.find((i) => i.itemValue === 1)).toMatchObject({ actionConfiguration: { actionName: 'Show Dialog' } });
+
+    // saving the step modal closes it and re-renders the host from the value it now holds, which
+    // must still carry the configuration
+    const reportsBeforeSave = onValue.mock.calls.length;
+    await clickButton((b) => b.textContent === 'Save' && b.closest('.ant-modal') !== null);
+
+    expect(lastValue()?.find((i) => i.itemValue === 1)).toMatchObject({ actionConfiguration: { actionName: 'Show Dialog' } });
+    // the round trip through the host is settled: saving reports nothing new
+    expect(onValue.mock.calls).toHaveLength(reportsBeforeSave);
     expect(getReferenceList).toHaveBeenCalledTimes(1);
   });
 });

--- a/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/writeBack.test.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/__tests__/writeBack.test.tsx
@@ -34,7 +34,38 @@ vi.mock('../options/configurator', async () => {
 
 import RefListItemSelectorSettingsModal from '../options/modal';
 
+/**
+ * A previously saved list, as it comes back from the form configuration: the reference list's
+ * blank display data (colour, icon, alias) was dropped when it was serialised.
+ * `orderIndex` is carried on the stored items but is not part of the declared item type.
+ */
+const savedItems = [
+  { id: 'male-id', item: 'Male', itemValue: 1, orderIndex: 0 },
+  { id: 'female-id', item: 'Female', itemValue: 2, orderIndex: 1 },
+] as unknown as RefListGroupItemProps[];
+
 describe('RefList items write-back', () => {
+  beforeEach(() => {
+    getReferenceList.mockClear();
+  });
+
+  it('reports nothing when the reference list only fills in blank display data', async () => {
+    const onChange = vi.fn();
+    await act(async () => {
+      render(
+        <RefListItemSelectorSettingsModal
+          value={savedItems}
+          onChange={onChange}
+          readOnly={false}
+          referenceList={{ name: 'Gender', module: 'Core' }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('propagates a first-step configuration to the host form value', async () => {
     const onChange = vi.fn();
     await act(async () => {

--- a/shesha-reactjs/src/components/refListSelectorDisplay/options/modal.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/options/modal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from 'antd';
-import { FC, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 import { useDeepCompareEffect } from 'react-use';
 import RefListItemGroupConfigurator from './configurator';
 import RefListItemsContainer from './refListItemsContainer';
@@ -47,7 +47,16 @@ export const TableViewSelectorSettingsModalInner: FC<ITableViewSelectorSettingsM
   hideModal,
 }) => {
   const { items, readOnly } = useRefListItemGroupConfigurator();
+
+  // Only actual changes are written back. Reporting the items the host already holds queued a
+  // no-op save on every open of the settings panel and, while the reference list was still being
+  // read, briefly wrote an empty list over the configured one.
+  const hasReportedInitialItems = useRef(false);
   useDeepCompareEffect(() => {
+    if (!hasReportedInitialItems.current) {
+      hasReportedInitialItems.current = true;
+      return;
+    }
     onChange?.(items);
   }, [items]);
 

--- a/shesha-reactjs/src/components/refListSelectorDisplay/options/modal.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/options/modal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from 'antd';
-import { FC, useRef, useState } from 'react';
+import { FC, useState } from 'react';
 import { useDeepCompareEffect } from 'react-use';
 import RefListItemGroupConfigurator from './configurator';
 import RefListItemsContainer from './refListItemsContainer';
@@ -7,6 +7,10 @@ import { useStyles } from './styles/styles';
 import { IRefListItemFormModel } from '../provider/models';
 import { RefListItemGroupConfiguratorProvider, useRefListItemGroupConfigurator } from '../provider';
 import { IReferenceListIdentifier } from '@/interfaces';
+import { removeUndefinedProps } from '@/utils/object';
+import { isEqual } from 'lodash';
+
+const EMPTY_ITEMS: IRefListItemFormModel[] = [];
 
 interface IFiltersListProps {
   items?: IRefListItemFormModel[];
@@ -41,27 +45,32 @@ export interface ITableViewSelectorSettingsModal {
   referenceList?: IReferenceListIdentifier | undefined;
 }
 
+/**
+ * Compares two item lists the way the host stores them: a property that is absent, undefined,
+ * null or blank means the same thing once saved, so reading the reference list must not read as a
+ * change simply because it filled those in.
+ */
+const isSameConfiguration = (left: IRefListItemFormModel[], right: IRefListItemFormModel[] | null | undefined): boolean =>
+  isEqual(removeUndefinedProps(left), removeUndefinedProps(right ?? EMPTY_ITEMS));
+
 export const TableViewSelectorSettingsModalInner: FC<ITableViewSelectorSettingsModal> = ({
   visible,
+  value,
   onChange,
   hideModal,
 }) => {
   const { items, readOnly } = useRefListItemGroupConfigurator();
 
-  // Only actual changes are written back. Reporting the items the host already holds queued a
-  // no-op save on every open of the settings panel and, while the reference list was still being
-  // read, briefly wrote an empty list over the configured one.
-  const hasReportedInitialItems = useRef(false);
+  // Report the items only when they differ from what the host already holds. Reading the reference
+  // list normalises them, and reporting that normalisation marked the form as modified as soon as
+  // the component was selected - before the user had changed anything.
   useDeepCompareEffect(() => {
-    if (!hasReportedInitialItems.current) {
-      hasReportedInitialItems.current = true;
-      return;
-    }
+    if (isSameConfiguration(items, value)) return;
     onChange?.(items);
-  }, [items]);
+  }, [items, value]);
 
   const updateFilters = (): void => {
-    if (typeof onChange === 'function') onChange(items);
+    if (typeof onChange === 'function' && !isSameConfiguration(items, value)) onChange(items);
     hideModal();
   };
 
@@ -81,7 +90,6 @@ export const TableViewSelectorSettingsModalInner: FC<ITableViewSelectorSettingsM
   );
 };
 
-const EMPTY_ITEMS: IRefListItemFormModel[] = [];
 export const RefListItemSelectorSettingsModal: FC<Omit<ITableViewSelectorSettingsModal, 'visible' | 'hideModal'>> = (
   props,
 ) => {

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/actions.ts
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/actions.ts
@@ -1,16 +1,20 @@
 import { createAction } from '@reduxjs/toolkit';
 import { ISettingsUpdatePayload, IUpdateChildItemsPayload, IUpdateItemSettingsPayload } from './contexts';
 import { IReferenceListItem } from '@/interfaces/referenceList';
+import { RefListGroupItemProps } from './models';
 
 export enum RefListItemGroupActionEnums {
   UpdateItem = 'UPDATE_ITEM',
   SelectItem = 'SELECT_ITEM',
   UpdateChildItems = 'UPDATE_CHILD_ITEMS',
   SetItems = 'SET_ITEMS',
+  SyncConfiguredItems = 'SYNC_CONFIGURED_ITEMS',
   StoreSettings = 'STORE_SETTINGS',
 }
 
 export const setItems = createAction<IReferenceListItem[]>(RefListItemGroupActionEnums.SetItems);
+
+export const syncConfiguredItemsAction = createAction<RefListGroupItemProps[]>(RefListItemGroupActionEnums.SyncConfiguredItems);
 
 export const selectItemAction = createAction<string>(RefListItemGroupActionEnums.SelectItem);
 

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/index.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/index.tsx
@@ -21,6 +21,7 @@ import {
   selectItemAction,
   setItems,
   storeSettingsAction,
+  syncConfiguredItemsAction,
   updateChildItemsAction,
   updateItemAction,
 } from '@/components/refListSelectorDisplay/provider/actions';
@@ -78,6 +79,20 @@ const RefListSelectorDisplayProvider: FC<PropsWithChildren<IRefListItemGroupConf
       console.error('Failed to fetch reference list', error);
     });
   }, [getReferenceList, referenceList]);
+
+  // The items are seeded into the reducer only once, so a configuration saved by the host (the
+  // component model in the designer) has to be adopted explicitly - otherwise hiding a step or
+  // changing its action showed no effect until the component was re-created.
+  // The signature, rather than the array, drives the effect: the host rebuilds the array on every
+  // render, and the settings panel derives it from this state in the first place, so keying on the
+  // content is what stops the sync from feeding back into itself.
+  const configuredItemsSignature = JSON.stringify(props.items);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const configuredItems = useMemo(() => props.items, [configuredItemsSignature]);
+
+  useEffect(() => {
+    dispatch(syncConfiguredItemsAction(configuredItems));
+  }, [configuredItems]);
 
   const selectItem = useCallback((uid: string): void => {
     dispatch(selectItemAction(uid));

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/index.tsx
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/index.tsx
@@ -29,7 +29,7 @@ import RefListItemGroupReducer from '@/components/refListSelectorDisplay/provide
 import { getItemById } from '@/components/refListSelectorDisplay/provider/utils';
 import { useReferenceListDispatcher } from '@/providers/referenceListDispatcher';
 import { IReferenceListIdentifier } from '@/interfaces/referenceList';
-import { isDefined } from '@/utils/nullables';
+import { isDefined, isNotNullOrWhiteSpace } from '@/utils/nullables';
 import { throwError } from '@/utils/errors';
 
 export interface IRefListItemGroupConfiguratorProviderPropsBase {
@@ -52,20 +52,32 @@ const RefListSelectorDisplayProvider: FC<PropsWithChildren<IRefListItemGroupConf
     readOnly: readOnly ?? false,
   });
 
-  useEffect(() => {
-    if (props.items.length && props.items.some((x) => x.referenceList === props.referenceList)) return;
-    if (!isDefined(props.referenceList))
-      return;
+  // The hosting settings input rebuilds the identifier object on every render, so it is narrowed
+  // to its parts here. Keeping the object itself in the dependencies re-read the reference list on
+  // every re-render, and each read replaced the items - racing the per-item configuration the user
+  // was editing (#5125).
+  const referenceListName = props.referenceList?.name;
+  const referenceListModule = props.referenceList?.module;
+  const referenceList = useMemo<IReferenceListIdentifier | undefined>(
+    () => isNotNullOrWhiteSpace(referenceListName)
+      ? { name: referenceListName, module: referenceListModule ?? null }
+      : undefined,
+    [referenceListName, referenceListModule],
+  );
 
+  useEffect(() => {
+    if (!isDefined(referenceList))
+      return;
+    // The items are read once per reference list, and freshly on every mount, so a reference list
+    // edited elsewhere is still picked up without discarding local configuration.
     getReferenceList({
-      refListId: props.referenceList,
+      refListId: referenceList,
     }).promise.then((t) => {
       dispatch(setItems(t.items));
     }).catch((error) => {
       console.error('Failed to fetch reference list', error);
-      throw error;
     });
-  }, [getReferenceList, props.items, props.referenceList]);
+  }, [getReferenceList, referenceList]);
 
   const selectItem = useCallback((uid: string): void => {
     dispatch(selectItemAction(uid));

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
@@ -1,11 +1,21 @@
 import {
   REF_LIST_ITEM_GROUP_CONTEXT_INITIAL_STATE,
 } from './contexts';
-import { IRefListItemGroup, isIRefListItemGroup, RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
+import { IRefListGroupItemBase, isIRefListItemGroup, RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
 import { getItemPositionById } from '@/components/refListSelectorDisplay/provider/utils';
 import { createReducer } from '@reduxjs/toolkit';
 import { setItems, selectItemAction, updateItemAction, updateChildItemsAction, storeSettingsAction, syncConfiguredItemsAction } from './actions';
 import { isDefined } from '@/utils/nullables';
+
+/**
+ * The reference list defines a flat set of items, so a group's children are never carried over
+ * when its settings are reapplied.
+ */
+const withoutChildItems = (item: RefListGroupItemProps): IRefListGroupItemBase => {
+  if (!isIRefListItemGroup(item)) return item;
+  const { childItems: _childItems, ...rest } = item;
+  return rest;
+};
 
 export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT_INITIAL_STATE, (builder) => {
   builder
@@ -30,11 +40,9 @@ export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT
           const prior = priorByValue.get(item.itemValue);
           // Keep every setting the user configured for the item and refresh only the data the
           // reference list owns. Listing the preserved properties one by one silently dropped the
-          // rest of the item configuration on each re-read. `childItems` is not carried over: the
-          // reference list defines a flat set of items.
-          const { childItems: _childItems, ...priorSettings } = (prior ?? {}) as IRefListItemGroup;
+          // rest of the item configuration on each re-read.
           return {
-            ...priorSettings,
+            ...(isDefined(prior) ? withoutChildItems(prior) : {}),
             ...item,
             item: item.item ?? undefined,
             color: item.color ?? undefined,
@@ -64,7 +72,7 @@ export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT
           if (!isDefined(configured)) return item;
 
           // The reference list owns the display data, the host owns the configuration.
-          const { childItems: _childItems, id: _id, item: _item, itemValue: _itemValue, color: _color, icon: _icon, ...settings } = configured as IRefListItemGroup;
+          const { id: _id, item: _item, itemValue: _itemValue, color: _color, icon: _icon, ...settings } = withoutChildItems(configured);
           return { ...item, ...settings };
         }),
       };

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
@@ -4,7 +4,7 @@ import {
 import { IRefListItemGroup, isIRefListItemGroup, RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
 import { getItemPositionById } from '@/components/refListSelectorDisplay/provider/utils';
 import { createReducer } from '@reduxjs/toolkit';
-import { setItems, selectItemAction, updateItemAction, updateChildItemsAction, storeSettingsAction } from './actions';
+import { setItems, selectItemAction, updateItemAction, updateChildItemsAction, storeSettingsAction, syncConfiguredItemsAction } from './actions';
 import { isDefined } from '@/utils/nullables';
 
 export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT_INITIAL_STATE, (builder) => {
@@ -40,6 +40,32 @@ export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT
             color: item.color ?? undefined,
             icon: item.icon ?? undefined,
           };
+        }),
+      };
+    })
+    .addCase(syncConfiguredItemsAction, (state, { payload }) => {
+      // Adopt the configuration held by the host (the component model). The items are seeded into
+      // the reducer only once, so without this a setting saved in the designer - a step hidden, an
+      // action changed - was not reflected until the whole component was re-created.
+      // The provider dispatches this only when the incoming configuration actually differs, so
+      // rebuilding the items here cannot feed back into itself.
+      if (payload.length === 0) return state;
+
+      const configuredByValue = new Map<number, RefListGroupItemProps>();
+      payload.forEach((configured) => {
+        if (isDefined(configured.itemValue))
+          configuredByValue.set(configured.itemValue, configured);
+      });
+
+      return {
+        ...state,
+        items: state.items.map<RefListGroupItemProps>((item) => {
+          const configured = isDefined(item.itemValue) ? configuredByValue.get(item.itemValue) : undefined;
+          if (!isDefined(configured)) return item;
+
+          // The reference list owns the display data, the host owns the configuration.
+          const { childItems: _childItems, id: _id, item: _item, itemValue: _itemValue, color: _color, icon: _icon, ...settings } = configured as IRefListItemGroup;
+          return { ...item, ...settings };
         }),
       };
     })

--- a/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
+++ b/shesha-reactjs/src/components/refListSelectorDisplay/provider/reducers.ts
@@ -1,7 +1,7 @@
 import {
   REF_LIST_ITEM_GROUP_CONTEXT_INITIAL_STATE,
 } from './contexts';
-import { isIRefListItemGroup, RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
+import { IRefListItemGroup, isIRefListItemGroup, RefListGroupItemProps } from '@/components/refListSelectorDisplay/provider/models';
 import { getItemPositionById } from '@/components/refListSelectorDisplay/provider/utils';
 import { createReducer } from '@reduxjs/toolkit';
 import { setItems, selectItemAction, updateItemAction, updateChildItemsAction, storeSettingsAction } from './actions';
@@ -10,8 +10,8 @@ import { isDefined } from '@/utils/nullables';
 export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT_INITIAL_STATE, (builder) => {
   builder
     .addCase(setItems, (state, { payload }) => {
-      // Preserve any per-item configuration (Hide/Events) the user already set, matched by itemValue,
-      // so re-fetching the reference list does not wipe saved settings (the cause of #5125).
+      // Preserve the per-item configuration the user already set, matched by itemValue, so
+      // re-reading the reference list does not wipe saved settings (the cause of #5125).
       const priorByValue = new Map<number, RefListGroupItemProps>();
       const indexPriorItems = (items: RefListGroupItemProps[]): void => {
         items.forEach((prior) => {
@@ -28,13 +28,17 @@ export const RefListItemGroupReducer = createReducer(REF_LIST_ITEM_GROUP_CONTEXT
         ...state,
         items: payload.map<RefListGroupItemProps>((item) => {
           const prior = priorByValue.get(item.itemValue);
+          // Keep every setting the user configured for the item and refresh only the data the
+          // reference list owns. Listing the preserved properties one by one silently dropped the
+          // rest of the item configuration on each re-read. `childItems` is not carried over: the
+          // reference list defines a flat set of items.
+          const { childItems: _childItems, ...priorSettings } = (prior ?? {}) as IRefListItemGroup;
           return {
+            ...priorSettings,
             ...item,
             item: item.item ?? undefined,
             color: item.color ?? undefined,
             icon: item.icon ?? undefined,
-            ...(isDefined(prior?.hidden) ? { hidden: prior.hidden } : {}),
-            ...(isDefined(prior?.actionConfiguration) ? { actionConfiguration: prior.actionConfiguration } : {}),
           };
         }),
       };

--- a/shesha-reactjs/src/designer-components/button/configurableButton/index.tsx
+++ b/shesha-reactjs/src/designer-components/button/configurableButton/index.tsx
@@ -20,6 +20,13 @@ export interface IConfigurableButtonProps extends Omit<IButtonItem, 'itemSubType
   className?: string | undefined;
   additionalDomProperties?: Record<string, unknown> | undefined;
   onClick?: React.MouseEventHandler<HTMLElement> | undefined;
+  /**
+   * Runs before the button's own behaviour instead of replacing it: unlike `onClick`, the
+   * configured action still executes afterwards. Used by hosts that need to react to the click
+   * themselves (e.g. the Chevron writing the selected step back to the bound property) while
+   * leaving the item's Events configuration in charge of everything else.
+   */
+  onBeforeClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
 }
 
 export const ConfigurableButton: FC<IConfigurableButtonProps> = (props) => {
@@ -59,6 +66,8 @@ export const ConfigurableButton: FC<IConfigurableButtonProps> = (props) => {
       return;
     }
 
+    props.onBeforeClick?.(event);
+
     if (props.onClick) {
       props.onClick(event);
       return;
@@ -78,7 +87,7 @@ export const ConfigurableButton: FC<IConfigurableButtonProps> = (props) => {
             setClickDisabled(false);
             debouncedLoading(false);
           });
-      } else console.warn('Action is not configured');
+      } else if (!isDefined(props.onBeforeClick)) console.warn('Action is not configured');
     } catch (error) {
       setClickDisabled(false);
       debouncedLoading(false);

--- a/shesha-reactjs/src/designer-components/chevron/chevron.tsx
+++ b/shesha-reactjs/src/designer-components/chevron/chevron.tsx
@@ -23,9 +23,11 @@ const ChevronComponent: IToolboxComponent<IChevronProps> = {
     if (model.hidden === true) return null;
     return (
       <ConfigurableFormItem<number> model={model}>
-        {(value) => (
+        {(value, onChange) => (
           <RefListItemGroupConfiguratorProvider items={model.items ?? []} referenceList={model.referenceList} readOnly={model.readOnly}>
-            <ChevronControl value={value} {...model} />
+            {/* `onChange` is passed after the model spread so clicking a step writes the selected
+                item value back to the bound property. */}
+            <ChevronControl {...model} value={value} onChange={onChange} />
           </RefListItemGroupConfiguratorProvider>
         )}
       </ConfigurableFormItem>

--- a/shesha-reactjs/src/designer-components/chevron/utils.ts
+++ b/shesha-reactjs/src/designer-components/chevron/utils.ts
@@ -7,6 +7,7 @@ export const defaultStyles = (): IStyleValue => {
       type: 'Segoe UI',
       align: 'left',
       weight: '400',
+      size: 14,
     },
     dimensions: {
       width: 'auto',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chevron controls now write the selected step back to the bound value.
  - Read-only chevrons prevent changes, and hidden steps are omitted.
  - Reference-list configurations now synchronize reliably with saved settings and persist across updates.
  - Added support for running custom behavior before configurable button actions.

- **Bug Fixes**
  - Prevented unnecessary updates when reference-list display data has not changed.
  - Improved preservation of configured item settings during reference-list refreshes.

- **Style**
  - Updated the default chevron font size to 14px.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->