### PR TITLE
Lihlu/fix/file list issues

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -881,6 +881,17 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
   const showStubFileName = listType !== 'text' && !hideFileName;
   const showStubExtraContent = hasExtraContent === true && isDefined(extraFormId);
 
+  /* The stub's tile and the name under it belong in one box, the way itemRender groups them for a
+     real file. Left as siblings they are two items of the gapped renderer column, so Gap — which is
+     the spacing *between* files — was inserted between a file and its own name and grew the stub by
+     that much. Past the container's max height the column then resolved the overflow by shrinking
+     its items, and the tile was squashed. Grouped, Gap no longer reaches inside the pair, and the
+     tile holds its height because it is a block child here rather than a flex item.
+
+     Only thumbnail mode is grouped: in text mode the tile is the flex item that stretches to the
+     container's width, and a box around it would take that away. */
+  const StubGroup = listType === 'thumbnail' ? 'div' : React.Fragment;
+
   const renderUploadContent = (): React.ReactNode => {
     return (
       disabled !== true && (
@@ -932,7 +943,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
             ? (isDragger
               ? <Dragger style={{ padding: 0 }} disabled><DraggerStub text={dropzoneText} /></Dragger>
               : (
-                <>
+                <StubGroup>
                   <Button
                     type="link"
                     icon={<PictureOutlined />}
@@ -942,8 +953,8 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
                   >
                     {listType === 'text' && '(press to upload)'}
                   </Button>
-                  {/* The renderer is a gapped flex column, so an empty box here would still take a
-                      gap and pad the control column out of line with the label. */}
+                  {/* Ungrouped in text mode, where an empty box would still take a gap and pad the
+                      control column out of line with the label. */}
                   {(showStubFileName || showStubExtraContent) && (
                     <div style={(listType === 'thumbnail') ? { width, minWidth, maxWidth } : {}}>
                       {showStubFileName && (
@@ -959,7 +970,7 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
                       )}
                     </div>
                   )}
-                </>
+                </StubGroup>
               )
             )
             : (props.disabled === true && fileList.length === 0

--- a/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
@@ -4,7 +4,7 @@ import { CSSProperties } from 'react';
 import { addPx } from '@/utils/style';
 import { IStyleValue } from '@/providers';
 import { backgroundStyles, borderStyles, cssPropertiesToString, dimensionsStyles, fontStyles, marginStyles, paddingStyles, shadowStyles, splitTextProperties } from '@/designer-components/_common/styles/utils';
-import { isNullOrWhiteSpace } from '@/utils/nullables';
+import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 interface IModelInterface extends IStyleValue {
   thumbnailStyle?: IStyleValue | undefined;
   thumbnailStyleCss?: CSSProperties | undefined;
@@ -27,14 +27,16 @@ export const useStyles = createStyles((
   const font = model.font;
   const textAlign = font?.align;
 
-  /* Flex equivalent of the configured text alignment. Several parts of the component are flex
+  /* Flex equivalent of a configured text alignment. Several parts of the component are flex
      containers rather than blocks of text, and `text-align` does nothing on those — their content
      is placed by `justify-content`, so the alignment has to be translated to reach them. */
-  const justifyContent = textAlign === 'center'
+  const toJustifyContent = (align: CSSProperties['textAlign']): string => align === 'center'
     ? 'center'
-    : textAlign === 'right'
+    : align === 'right'
       ? 'flex-end'
       : 'flex-start';
+
+  const justifyContent = toJustifyContent(textAlign);
 
   const isThumbnail = model.listType === "thumbnail" && model.isDragger !== true;
 
@@ -108,6 +110,14 @@ export const useStyles = createStyles((
      directly and which therefore inherits nothing, and the rest reach the row around it. */
   const { text: downloadedText, box: downloadedBox } = splitTextProperties(downloadedFileStyles);
 
+  /* Its Align needs the same translation as the root's, and for the same reason: the name sits in a
+     flex container, so the `text-align` in `downloadedText` reaches it but places nothing. Emitted
+     only when the set actually carries an alignment — an unset one has to leave the root's in place
+     rather than resetting downloaded files to the left. */
+  const downloadedJustifyContent = isDefined(downloadedText.textAlign)
+    ? toJustifyContent(downloadedText.textAlign)
+    : undefined;
+
   const storedFilesRendererBtnContainer = "sha-stored-files-renderer-btn-container";
   const shaThumbnail = "sha-thumbnail";
 
@@ -180,6 +190,14 @@ export const useStyles = createStyles((
       color: ${downloadedColor};
       ${cssPropertiesToString(downloadedText)}
     }
+
+    /* The root Font's alignment sits on this very element as an important justify-content, so the
+       doubled class alone is not enough to displace it — the override has to be important too and
+       win on specificity. Kept off the selector above: the name itself is not a flex container, and
+       the property would do nothing there. */
+    ${isDefined(downloadedJustifyContent)
+      ? `&& .sha-item-file-name { justify-content: ${downloadedJustifyContent} !important; }`
+      : ''}
 
     .${prefixCls}-upload-list-item-action .anticon-download {
       color: ${downloadedColor};

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/__tests__/newComponentInheritsStyles.test.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/__tests__/newComponentInheritsStyles.test.ts
@@ -1,0 +1,56 @@
+import { Migrator } from '@/utils/fluentMigrator/migrator';
+import { IConfigurableFormComponent, SettingsMigrationContext } from '@/interfaces';
+import { IFlatComponentsStructure } from '@/providers/form/models';
+import AttachmentsEditor from '../attachmentsEditor';
+import { IAttachmentsEditorProps } from '../interfaces';
+
+/**
+ * A setting is drawn as Overridden when the component model holds a value for it and the default
+ * model supplies one too — see `DefaultModelInstance.getValueInfo`. A component straight out of the
+ * toolbox has overridden nothing, so its model must carry no device styles at all and inherit the
+ * whole Appearance tab from `getDefaultStyles()`.
+ *
+ * Migrations that bake defaults into `desktop`/`tablet`/`mobile` therefore have to skip a new
+ * component. Style Downloaded Files and Downloaded Icon were written unconditionally and came up as
+ * Overridden the moment a File List was dropped on a form.
+ */
+describe('a newly dropped File List', () => {
+  const newComponentModel = (): IAttachmentsEditorProps => {
+    const migrator = new Migrator<IConfigurableFormComponent, IConfigurableFormComponent, SettingsMigrationContext>();
+    const fluent = AttachmentsEditor.migrator(migrator);
+    const context: SettingsMigrationContext = {
+      isNew: true,
+      formSettings: undefined,
+      /* Spelled out rather than taken from `getEmptyFlatMarkup`, whose module is not initialised by
+         the time this file's imports resolve. None of these migrations read the structure anyway. */
+      flatStructure: { allComponents: {}, componentRelations: {}, parents: {} } satisfies IFlatComponentsStructure,
+      componentId: 'attachments-editor',
+    };
+
+    return fluent.migrator.upgrade(
+      { id: 'attachments-editor', type: AttachmentsEditor.type, propertyName: 'documents', version: -1 },
+      context,
+    ) as IAttachmentsEditorProps;
+  };
+
+  it.each(['desktop', 'tablet', 'mobile'] as const)('carries no %s style model', (device) => {
+    expect(newComponentModel()[device]).toBeUndefined();
+  });
+
+  /* Named separately from the blanket check above: these two are the settings the bug was reported
+     against, and a later migration writing either one back would go unnoticed otherwise. */
+  it.each(['styleDownloadedFiles', 'downloadedIcon'] as const)('leaves %s to the defaults', (setting) => {
+    const model = newComponentModel();
+    expect(model[setting]).toBeUndefined();
+    expect(model.desktop?.[setting]).toBeUndefined();
+  });
+
+  /* The defaults the model is now free to inherit — no longer reachable through the model itself,
+     so the toolbox definition has to keep supplying them. */
+  it('still gets the downloaded-file defaults from the component definition', () => {
+    const defaults = AttachmentsEditor.getDefaultStyles?.() as IAttachmentsEditorProps | undefined;
+
+    expect(defaults?.styleDownloadedFiles).toBe(false);
+    expect(defaults?.downloadedIcon).toBe('CheckCircleOutlined');
+  });
+});

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/__tests__/newComponentInheritsStyles.test.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/__tests__/newComponentInheritsStyles.test.ts
@@ -1,6 +1,7 @@
 import { Migrator } from '@/utils/fluentMigrator/migrator';
 import { IConfigurableFormComponent, SettingsMigrationContext } from '@/interfaces';
 import { IFlatComponentsStructure } from '@/providers/form/models';
+import { isDefined } from '@/utils/nullables';
 import AttachmentsEditor from '../attachmentsEditor';
 import { IAttachmentsEditorProps } from '../interfaces';
 
@@ -16,8 +17,13 @@ import { IAttachmentsEditorProps } from '../interfaces';
  */
 describe('a newly dropped File List', () => {
   const newComponentModel = (): IAttachmentsEditorProps => {
-    const migrator = new Migrator<IConfigurableFormComponent, IConfigurableFormComponent, SettingsMigrationContext>();
-    const fluent = AttachmentsEditor.migrator(migrator);
+    const migrator = new Migrator<IConfigurableFormComponent, IAttachmentsEditorProps, SettingsMigrationContext>();
+
+    /* Declared optional on the toolbox component, so it is checked rather than asserted — a File
+       List that had lost its migrator would otherwise fail these as an unrelated crash. */
+    const fluent = AttachmentsEditor.migrator?.(migrator);
+    if (!isDefined(fluent)) throw new Error('The File List component defines no migrator.');
+
     const context: SettingsMigrationContext = {
       isNew: true,
       formSettings: undefined,
@@ -27,10 +33,16 @@ describe('a newly dropped File List', () => {
       componentId: 'attachments-editor',
     };
 
-    return fluent.migrator.upgrade(
-      { id: 'attachments-editor', type: AttachmentsEditor.type, propertyName: 'documents', version: -1 },
-      context,
-    ) as IAttachmentsEditorProps;
+    /* Typed rather than passed as a literal: `upgrade` takes an IHasVersion, which the rest of a
+       component model is excess to. */
+    const dropped: IConfigurableFormComponent = {
+      id: 'attachments-editor',
+      type: AttachmentsEditor.type,
+      propertyName: 'documents',
+      version: -1,
+    };
+
+    return fluent.migrator.upgrade(dropped, context);
   };
 
   it.each(['desktop', 'tablet', 'mobile'] as const)('carries no %s style model', (device) => {

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -552,24 +552,31 @@ const AttachmentsEditor: AttachmentsEditorComponentDefinition = {
       return result;
     })
     .add<IAttachmentsEditorProps>(14, (prev, context) => ({ ...prev, downloadZip: context.isNew ?? false ? false : prev.downloadZip }))
-    .add<IAttachmentsEditorProps>(15, (prev) => ({
-      ...prev,
-      desktop: {
-        ...prev.desktop,
-        filesLayout: prev.desktop?.filesLayout ?? prev.filesLayout ?? 'horizontal',
-        gap: prev.desktop?.gap ?? prev.gap ?? 8,
-      },
-      mobile: {
-        ...prev.mobile,
-        filesLayout: prev.mobile?.filesLayout ?? prev.filesLayout ?? 'horizontal',
-        gap: prev.mobile?.gap ?? prev.gap ?? 8,
-      },
-      tablet: {
-        ...prev.tablet,
-        filesLayout: prev.tablet?.filesLayout ?? prev.filesLayout ?? 'horizontal',
-        gap: prev.tablet?.gap ?? prev.gap ?? 8,
-      },
-    }))
+    /* Only an already-saved component gets the layout baked into its devices. Writing it on a newly
+       dropped one would put a value in the model identical to the default, which the settings panel
+       then reports as an override of a setting nobody touched. */
+    .add<IAttachmentsEditorProps>(15, (prev, context) => {
+      if (context.isNew === true) return prev;
+
+      return {
+        ...prev,
+        desktop: {
+          ...prev.desktop,
+          filesLayout: prev.desktop?.filesLayout ?? prev.filesLayout ?? 'horizontal',
+          gap: prev.desktop?.gap ?? prev.gap ?? 8,
+        },
+        mobile: {
+          ...prev.mobile,
+          filesLayout: prev.mobile?.filesLayout ?? prev.filesLayout ?? 'horizontal',
+          gap: prev.mobile?.gap ?? prev.gap ?? 8,
+        },
+        tablet: {
+          ...prev.tablet,
+          filesLayout: prev.tablet?.filesLayout ?? prev.filesLayout ?? 'horizontal',
+          gap: prev.tablet?.gap ?? prev.gap ?? 8,
+        },
+      };
+    })
     /* Freeze the appearance of every already-saved component by baking the real defaults into all
        three device models, so a later change to `defaultStyles()` cannot shift how an existing form
        renders. A newly dropped component skips this and inherits from metadata instead. */
@@ -581,7 +588,11 @@ const AttachmentsEditor: AttachmentsEditorComponentDefinition = {
     .add<IAttachmentsEditorProps>(17, (prev) => {
       return swapContainerAndThumbnailStyles(prev);
     })
-    .add<IAttachmentsEditorProps>(18, (prev) => {
+    /* Same reason as 15: a new component has no device models to fill, and creating them here would
+       pin every thumbnail property to the default it already inherits. */
+    .add<IAttachmentsEditorProps>(18, (prev, context) => {
+      if (context.isNew === true) return prev;
+
       const withThumbnail = (device: IAttachmentsEditorDeviceStyles | undefined): IAttachmentsEditorDeviceStyles | undefined =>
         isDefined(device)
           ? { ...device, thumbnailStyle: { ...thumbnailDefaultStyles(), ...device.thumbnailStyle } }
@@ -597,7 +608,13 @@ const AttachmentsEditor: AttachmentsEditorComponentDefinition = {
   /* Rename-only step: runs for new and old alike, and carries the permissions that used to live on
        the Security tab onto the Visible / Interaction Mode settings. */
     .add<IAttachmentsEditorProps>(19, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(migrateStylingBoxToJson(prev))))
-    .add<IAttachmentsEditorProps>(20, (prev) => {
+    /* Carries the two downloaded-file settings onto the devices of a saved component, where the flag
+       used to sit at the root. A newly dropped one is skipped: it has no root value to carry, and a
+       written-out `false` / `CheckCircleOutlined` is what made Style Downloaded Files and Downloaded
+       Icon come up as Overridden on a component straight out of the toolbox. */
+    .add<IAttachmentsEditorProps>(20, (prev, context) => {
+      if (context.isNew === true) return prev;
+
       const withDownloadedFlags = (device: IAttachmentsEditorDeviceStyles | undefined): IAttachmentsEditorDeviceStyles | undefined =>
         isDefined(device)
           ? {

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/settingsForm.ts
@@ -160,7 +160,7 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                   ],
                 }))
               .stdCollapsiblePanel('Data', (fb) => fb
-                .addSettingsInput({ inputType: 'propertyAutocomplete', propertyName: 'ownerName', label: 'Owner', autoFillProps: false })
+                .addSettingsInput({ inputType: 'propertyAutocomplete', propertyName: 'ownerName', label: 'Bound Property', autoFillProps: false })
                 .addSettingsInput({ inputType: 'entityTypeAutocomplete', propertyName: 'ownerType', label: 'Parent Entity Type', jsSetting: true })
                 .addSettingsInputRow({
                   inputs: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Downloaded-file text alignment now correctly controls its layout while preserving default behavior when no alignment is set.
  - Newly added Attachments Editor components now correctly inherit appearance defaults instead of storing unnecessary device-specific overrides.
  - File thumbnails and names now maintain proper spacing and sizing in the designer.

- **UI Improvements**
  - Renamed the Attachments Editor settings label from “Owner” to “Bound Property” for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->