### PR TITLE
fix: make Table Filter button a toggle instead of disabling it

### DIFF
--- a/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/advancedFilterButton.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/advancedFilterButton.tsx
@@ -66,23 +66,6 @@ export const AdvancedFilterButton: FCUnwrapped<IAdvancedFilterButtonComponentPro
             disabled={props.disabled}
             stylingBoxJson={padding}
           />
-          {/* <Button
-            type={actualButtonType}
-            ghost={isGhostType}
-            title={filterColumns.join('  ')}
-            onClick={() => toggleAdvancedFilter(true)}
-            className={styles.button}
-            danger={props.danger === true}
-            disabled={props.readOnly || isAdvancedFilterVisible}
-            icon={filterIcon}
-            size={props.size}
-            style={isAdvancedFilterVisible || props.readOnly
-              ? { ...buttonStyle, opacity: 0.5, border: ['link', 'ghost'].includes(props.buttonType) ? 'none' : buttonStyle.border }
-              : { ...buttonStyle }}
-          >
-            {props.label}
-          </Button>
-          */}
         </Badge>
       </Tooltip>
     </div>

--- a/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/advancedFilterButton.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/advancedFilterButton.tsx
@@ -49,7 +49,7 @@ export const AdvancedFilterButton: FCUnwrapped<IAdvancedFilterButtonComponentPro
   const { marginTop, marginRight, marginBottom, marginLeft, ...padding } = props.stylingBoxJson ?? { _type: 'styleBox' };
 
   return (
-    <div className={classNames(styles.buttonContainer, { disabled: props.disabled || isAdvancedFilterVisible })}>
+    <div className={classNames(styles.buttonContainer, { disabled: props.disabled, active: isAdvancedFilterVisible })}>
       <Tooltip title={props.tooltip}>
         <Badge
           count={tableFilter.length}
@@ -63,7 +63,7 @@ export const AdvancedFilterButton: FCUnwrapped<IAdvancedFilterButtonComponentPro
             icon={filterIcon}
             tooltip={filterColumns.join('  ')}
             onClick={() => toggleAdvancedFilter(!isAdvancedFilterVisible)}
-            disabled={props.disabled || isAdvancedFilterVisible}
+            disabled={props.disabled}
             stylingBoxJson={padding}
           />
           {/* <Button

--- a/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/style.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/advancedFilterButton/style.ts
@@ -13,6 +13,10 @@ export const useStyles = createStyles(({ token, cx, css }, model: IAdvancedFilte
     &.disabled {
       opacity: 0.5;
     }
+
+    &.active .ant-btn {
+      color: ${primaryColor};
+    }
   `);
 
   const button = cx("filter-btn", css`


### PR DESCRIPTION
The Table Filter button was disabled while the advanced filter panel was open, so the panel could only be closed via the sidebar collapse control. Drop isAdvancedFilterVisible from the disabled state (the click handler already toggled) and show the open state with an active style using the theme primary colour instead of the greyed-out 0.5 opacity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Advanced filter buttons remain interactive while the filter panel is open.
  - The active filter state is now visually indicated using the primary button color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->