### PR TITLE
fix: improve tooltip handling for sidebar menu items

### DIFF
--- a/shesha-reactjs/src/components/sidebarMenu/utils.tsx
+++ b/shesha-reactjs/src/components/sidebarMenu/utils.tsx
@@ -55,11 +55,10 @@ function getItem({ label, key, icon, children, isParent, itemType, onClick, navi
       const hasTooltip = isDefined(tooltip) && (typeof tooltip !== 'string' || !isNullOrWhiteSpace(tooltip));
       if (!hasTooltip) return baseContent;
 
-      const tooltipText = typeof tooltip === 'string' ? tooltip : undefined;
       return (
         <span style={{ display: 'inline-flex', alignItems: 'center' }}>
           {baseContent}
-          <Tooltip title={tooltipText} placement="right">
+          <Tooltip title={tooltip} placement="right">
             <QuestionCircleOutlined style={{ marginLeft: 8, fontSize: '12px', opacity: 0.6, zIndex: 1000 }} />
           </Tooltip>
         </span>

--- a/shesha-reactjs/src/components/sidebarMenu/utils.tsx
+++ b/shesha-reactjs/src/components/sidebarMenu/utils.tsx
@@ -52,22 +52,13 @@ function getItem({ label, key, icon, children, isParent, itemType, onClick, navi
           : <span className={className} onClick={clickHandler}>{label}</span>)
         : <span className={className}>{label}</span>;
 
-      // Extract text content for the overflow tooltip
-      const textContent = typeof label === 'string' ? label : undefined;
-
-      // Wrap content in tooltip for text overflow (CSS handles the ellipsis)
-      const contentWithOverflowTooltip = !isNullOrWhiteSpace(textContent) ? (
-        <Tooltip title={textContent} placement="top" mouseEnterDelay={0.5}>
-          {baseContent}
-        </Tooltip>
-      ) : baseContent;
-
-      if (!isDefined(tooltip)) return contentWithOverflowTooltip;
+      const hasTooltip = isDefined(tooltip) && (typeof tooltip !== 'string' || !isNullOrWhiteSpace(tooltip));
+      if (!hasTooltip) return baseContent;
 
       const tooltipText = typeof tooltip === 'string' ? tooltip : undefined;
       return (
         <span style={{ display: 'inline-flex', alignItems: 'center' }}>
-          {contentWithOverflowTooltip}
+          {baseContent}
           <Tooltip title={tooltipText} placement="right">
             <QuestionCircleOutlined style={{ marginLeft: 8, fontSize: '12px', opacity: 0.6, zIndex: 1000 }} />
           </Tooltip>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sidebar menu labels no longer display an automatic overflow tooltip.
  - Tooltip icons now appear only when a non-empty tooltip has been configured.
  - Labels without tooltip content—including empty or whitespace-only values—are displayed directly without additional tooltip behavior.
  - This provides a cleaner sidebar experience and prevents unnecessary tooltip interactions for labels that do not include explanatory content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->