### PR TITLE
refactor: update header background color in EntityPickerModal

### DIFF
--- a/shesha-reactjs/src/components/entityPicker/modal.tsx
+++ b/shesha-reactjs/src/components/entityPicker/modal.tsx
@@ -253,7 +253,7 @@ const EntityPickerModalInternal = (props: IEntityPickerModalProps): React.JSX.El
           options={{ omitClick: true }}
           rowDividers
           rowAlternateBackgroundColor={getTableDefaults().rowAlternateBackgroundColor}
-          headerBackgroundColor="transparent"
+          headerBackgroundColor={getTableDefaults().headerBackgroundColor}
           {...(isNotNullOrWhiteSpace(headerTextColor) ? { headerTextColor } : {})}
           {...(isNotNullOrWhiteSpace(headerFontFamily) ? { headerFontFamily } : {})}
         />

--- a/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/settingsForm.ts
@@ -19,8 +19,11 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
               .addContextPropertyAutocomplete({ propertyName: 'propertyName', label: 'Property Name', styledLabel: true, size: 'small', validate: { required: true } })
               .addLabelConfigurator({ propertyName: 'hideLabel', label: 'Label', hideLabel: true })
               .stdPlaceholderDescriptionInputs()
-              .stdVisibleEditableInputs('full')
-
+              .addSettingsInputRow({
+                inputs: [
+                  { type: 'switch', propertyName: 'visible', label: 'Visible', jsSetting: true, layout: 'horizontal', permissionSettings: true },
+                ],
+              })
               .stdCollapsiblePanel('Entity', (fb) => fb
                 .addSettingsInput({
                   inputType: 'entityTypeAutocomplete', propertyName: 'entityType', label: 'Entity Type',

--- a/shesha-reactjs/src/designer-components/entityReference/utils.ts
+++ b/shesha-reactjs/src/designer-components/entityReference/utils.ts
@@ -17,7 +17,6 @@ export const defaultStyles = (): IStyleValue => {
     font: {
       weight: '400',
       size: 14,
-      color: '#1677ff',
       type: 'Segoe UI',
       align: 'left',
     },

--- a/shesha-reactjs/src/designer-components/radio/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/radio/settingsForm.ts
@@ -80,11 +80,11 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
             key: 'appearance', title: 'Appearance', id: appearanceTabId,
             components: [
               ...fbf(appearanceTabId)
-                .addSettingsInput({ inputType: 'dropdown', propertyName: 'direction', label: 'Direction', size: 'small', jsSetting: true, dropdownOptions: directionOptions })
                 .addPropertyRouter({ id: commonStyleRouterId, propertyName: 'propertyRouter1', componentName: 'propertyRouter', label: 'Property router1', labelAlign: 'right',
                   propertyRouteName: removeStyleRouter === true ? '' : { _mode: "code", _code: "    return contexts.canvasContext?.designerDevice || 'desktop';", _value: "" },
                   components: [
                     ...fbf(commonStyleRouterId)
+                      .addSettingsInput({ inputType: 'dropdown', propertyName: 'direction', label: 'Direction', size: 'small', jsSetting: true, dropdownOptions: directionOptions })
                       .stdFontPanel(undefined, 'font', ['align'])
                       .stdDimensionsPanel('dimensions')
                       .stdBorderPanel(removeStyleRouter !== true, 'border')

--- a/shesha-reactjs/src/designer-components/statusTag/events.ts
+++ b/shesha-reactjs/src/designer-components/statusTag/events.ts
@@ -1,10 +1,14 @@
 import { StandardEventHandler, StandardEventHandlerWithoutChange } from '../_common/events';
 
 /**
- * On Click and On Mouse Move only — the component is display-only, so the editing events
+ * On Click and hover only — the component is display-only, so the editing events
  * (change/focus/blur/keys) have nothing to fire on.
+ *
+ * Hover is the enter/leave pair rather than `onMouseMove`, which fires continuously while the
+ * pointer moves, or `onMouseOver`/`onMouseOut`, which bubble and so re-fire when the pointer crosses
+ * between the tag and its own icon or label.
  */
-export const STATUS_TAG_EVENTS: readonly StandardEventHandler[] = ['onClick', 'onMouseMove'];
+export const STATUS_TAG_EVENTS: readonly StandardEventHandler[] = ['onClick', 'onMouseEnter', 'onMouseLeave'];
 
 /** Derived so the settings list and the runtime list cannot drift. */
 export const STATUS_TAG_EVENTS_WITHOUT_CHANGE: readonly StandardEventHandlerWithoutChange[] =

--- a/shesha-reactjs/src/designer-components/statusTag/settings.ts
+++ b/shesha-reactjs/src/designer-components/statusTag/settings.ts
@@ -8,7 +8,6 @@ const refListHiddenJs = "return getSettingValue(data.dataSourceType) !== 'refere
 const valuesVisibleJs = "return getSettingValue(data.dataSourceType) === 'values';";
 const refListVisibleJs = "return getSettingValue(data.dataSourceType) === 'referenceList';";
 // Disabled values needs both a reference list and the Disable Item Value toggle.
-const disabledValuesHiddenOrNotRefListJs = "return getSettingValue(data.dataSourceType) !== 'referenceList' || !getSettingValue(data.disableItemValue);";
 
 export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter }) => {
   const searchableTabsId = nanoid();
@@ -70,12 +69,6 @@ export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter 
                    affordance the spec describes, shown only for a reference list. */
                 .stdCollapsiblePanel('Advanced', (fb) => fb
                   .addSettingsInput({ inputType: 'queryBuilder', propertyName: 'filter', label: 'Filter', isDynamic: true, validate: {}, modelType: 'Shesha.Framework.ReferenceListItem', hidden: { _code: refListHiddenJs, _mode: 'code', _value: false } })
-                  .addSettingsInput({ inputType: 'switch', propertyName: 'disableItemValue', tooltip: 'Disable reference list from selection', label: 'Disable Item Value', jsSetting: true, layout: 'horizontal', hidden: { _code: refListHiddenJs, _mode: 'code', _value: false } })
-                  .addSettingsInput({
-                    inputType: 'textArea', propertyName: 'disabledValues', label: 'Disabled values', allowClear: true, jsSetting: true,
-                    tooltip: 'Pass an array of positive integers to disable specific values. For example: [1, 2, 3].',
-                    hidden: { _code: disabledValuesHiddenOrNotRefListJs, _mode: 'code', _value: false },
-                  })
                   .addSettingsInput({
                     inputType: 'textArea', propertyName: 'ignoredValues', label: 'Hidden values', allowClear: true, jsSetting: true,
                     tooltip: 'Pass an array of positive integers to hide specific values. For example: [1, 2, 3].',


### PR DESCRIPTION

- Changed headerBackgroundColor in EntityPickerModal to use dynamic value from getTableDefaults().
- Added a switch input for visibility in the settings form of entityReference.
- Removed unused color property from defaultStyles in utils.
- Reintroduced dropdown input for direction in radio settings form.
- Updated statusTag events to use onMouseEnter and onMouseLeave for better hover handling.
- Cleaned up settings for statusTag by removing unnecessary disabled values logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Entity picker table headers now use the standard header background color.
  - Status tags now respond more reliably to mouse-enter and mouse-leave interactions.
  - Radio button direction settings now adapt by device type.
  - Unconfigured Entity References no longer apply an explicit font color by default.

- **Settings Updates**
  - Entity Reference settings now provide a visibility option without the Editable toggle.
  - Removed the Status Tag “Disable Item Value” and related “Disabled values” settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->