### PR TITLE
Apply downloaded font colour in thumbnail mode

### DIFF
--- a/shesha-reactjs/src/components/storedFilesRendererBase/__tests__/downloaded-file-styles.test.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/__tests__/downloaded-file-styles.test.tsx
@@ -61,4 +61,53 @@ describe('Downloaded Files styling', () => {
     expect(computed.fontSize).toBe('14px');
     expect(computed.fontWeight).toBe('400');
   });
+
+  /**
+   * In thumbnail mode the name is a sibling under the tile, not inside it, so no descendant selector
+   * from the downloaded class reached it and the name stayed on the root Font.
+   */
+  const renderThumbnailName = (downloadedFileStyles: React.CSSProperties): CSSStyleDeclaration => {
+    const { result } = renderHook(() => useStyles({
+      model: { listType: 'thumbnail', layout: true, hasFiles: true, font: { ...ROOT_FONT } },
+      downloadedFileStyles,
+    }));
+
+    const s = result.current.styles;
+    /* The thumbnail nesting: the tile carries the downloaded class, the name is the sibling after it. */
+    document.body.innerHTML = `
+      <div class="${s.shaStoredFilesRenderer}">
+        <div>
+          <div class="${s.downloadedFile} ${s.shaThumbnail}"></div>
+          <div>
+            <div class="${s.shaItemFileName} ${s.downloadedFileName}">
+              <span id="target" class="ant-typography">file.pdf</span>
+            </div>
+          </div>
+        </div>
+      </div>`;
+
+    return getComputedStyle(document.getElementById('target')!);
+  };
+
+  it('overrides the root Font on a downloaded file in thumbnail mode', () => {
+    const computed = renderThumbnailName({
+      color: 'rgb(1, 2, 3)',
+      fontSize: '27px',
+      fontWeight: '700',
+      fontFamily: 'Comic Sans MS',
+    });
+
+    expect(computed.color).toBe('rgb(1, 2, 3)');
+    expect(computed.fontSize).toBe('27px');
+    expect(computed.fontWeight).toBe('700');
+    expect(computed.fontFamily.replace(/"/g, '')).toBe('Comic Sans MS');
+  });
+
+  it('leaves the root Font in place in thumbnail mode for the properties it does not set', () => {
+    const computed = renderThumbnailName({ color: 'rgb(1, 2, 3)' });
+
+    expect(computed.color).toBe('rgb(1, 2, 3)');
+    expect(computed.fontSize).toBe('14px');
+    expect(computed.fontWeight).toBe('400');
+  });
 });

--- a/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/index.tsx
@@ -786,9 +786,14 @@ export const StoredFilesRendererBase: FC<IStoredFilesRendererBaseProps> = ({
         {renderContent()}
         {listType === 'thumbnail' && !isDragger && !hideFileName && (
           <div>
+            {/* The name sits outside the tile here, so the downloaded set cannot reach it through
+                the wrapper as it does in text mode and is applied to the name itself. */}
             <FileNameDisplay
               file={shaFile}
-              className={styles.shaItemFileName}
+              className={classNames(
+                styles.shaItemFileName,
+                isDownloaded && styleDownloadedFiles ? styles.downloadedFileName : '',
+              )}
             />
           </div>
         )}

--- a/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
+++ b/shesha-reactjs/src/components/storedFilesRendererBase/styles/styles.ts
@@ -209,6 +209,22 @@ export const useStyles = createStyles((
     }
   `);
 
+  /* The downloaded set applied to the file name directly: in thumbnail mode the name is a sibling
+     under the tile, so no descendant selector from `downloadedFile` can reach it. Tripled to clear
+     the root Font's three-class restatement in the container set below, which is emitted later. */
+  const downloadedFileName = cx("sha-downloaded-file-name", css`
+    &&& {
+      color: ${downloadedColor};
+      ${cssPropertiesToString(downloadedText)}
+      ${isDefined(downloadedJustifyContent) ? `justify-content: ${downloadedJustifyContent} !important;` : ''}
+    }
+
+    &&& > .${prefixCls}-typography {
+      color: ${downloadedColor};
+      ${cssPropertiesToString(downloadedText)}
+    }
+  `);
+
   const downloadedIcon = cx("sha-downloaded-icon", css`
     position: ${layout ? 'absolute' : 'relative'};
     top: 4px;
@@ -586,6 +602,7 @@ export const useStyles = createStyles((
     shaStoredFilesRendererVertical,
     shaStoredFilesRendererGrid,
     downloadedFile,
+    downloadedFileName,
     downloadedIcon,
     actionsPopover,
     shaThumbnail,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thumbnail-mode downloaded file names so custom color, size, weight, and font family styling is applied correctly.
  * Ensured unspecified file-name styles continue inheriting values from the root font configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->