### PR TITLE
Fix container for SubForm

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/containers/componentsContainerLive.tsx
+++ b/shesha-reactjs/src/components/formDesigner/containers/componentsContainerLive.tsx
@@ -2,10 +2,9 @@ import { FC, PropsWithChildren } from 'react';
 import { ConfigurableFormComponent } from '../configurableFormComponent';
 import { ShaForm } from '@/providers/form';
 import { IComponentsContainerProps } from './componentsContainer';
-import { useStyles } from '../styles/styles';
-import classNames from 'classnames';
 import { useParent } from '@/providers/parentProvider';
 import { useDeepCompareMemo } from '@/hooks';
+import { ComponentsContainerRender } from './componentsContainerRender';
 
 export const ComponentsContainerLive: FC<PropsWithChildren<IComponentsContainerProps>> = (props) => {
   const {
@@ -19,26 +18,15 @@ export const ComponentsContainerLive: FC<PropsWithChildren<IComponentsContainerP
     noDefaultStyling = false,
     additionalDomProperties,
   } = props;
-  const { styles } = useStyles();
   const parent = useParent();
   const components = ShaForm.useChildComponents(containerId.replace(`${parent.subFormIdPrefix}.`, ''));
 
-  const renderComponents = useDeepCompareMemo(() => {
-    const renderedComponents = components.map((c) => (
+  const renderedComponents = useDeepCompareMemo((): React.ReactNode | React.JSX.Element[] => {
+    const rendered = components.map((c) => (
       <ConfigurableFormComponent id={c.id} key={c.id} />
     ));
-    return typeof render === 'function' ? render(renderedComponents) : renderedComponents;
-  }, [components]);
+    return typeof render === 'function' ? render(rendered) : rendered;
+  }, [components, render]);
 
-
-  return noDefaultStyling ? (
-    <div className={styles.shaComponentsContainerInner} style={{ ...style, textJustify: 'auto' }} {...additionalDomProperties}>{renderComponents}</div>
-  ) : (
-    <div className={classNames(styles.shaComponentsContainer, direction, className)} style={wrapperStyle} {...additionalDomProperties}>
-      <div className={styles.shaComponentsContainerInner} style={style}>
-        {renderComponents}
-      </div>
-      {children}
-    </div>
-  );
+  return <ComponentsContainerRender {...{ direction, className, wrapperStyle, children, additionalDomProperties, noDefaultStyling, style, renderedComponents }}>{children}</ComponentsContainerRender>;
 };

--- a/shesha-reactjs/src/components/formDesigner/containers/componentsContainerRender.tsx
+++ b/shesha-reactjs/src/components/formDesigner/containers/componentsContainerRender.tsx
@@ -1,0 +1,37 @@
+import { CSSProperties, FC, PropsWithChildren } from "react";
+import { useStyles } from "../styles/styles";
+import classNames from "classnames";
+
+export interface IComponentsContainerRenderProps {
+  additionalDomProperties?: Record<string, unknown> | undefined;
+  noDefaultStyling?: boolean | undefined;
+  style?: CSSProperties | undefined;
+  direction?: 'horizontal' | 'vertical' | undefined;
+  className?: string | undefined;
+  wrapperStyle?: CSSProperties | undefined;
+  renderedComponents: React.ReactNode | React.JSX.Element[];
+}
+
+export const ComponentsContainerRender: FC<PropsWithChildren<IComponentsContainerRenderProps>> = ({
+  direction = 'vertical',
+  className,
+  wrapperStyle,
+  children,
+  additionalDomProperties,
+  noDefaultStyling = false,
+  style,
+  renderedComponents,
+}) => {
+  const { styles } = useStyles();
+
+  return noDefaultStyling ? (
+    <div className={styles.shaComponentsContainerInner} style={{ ...style, textJustify: 'auto' }} {...additionalDomProperties}>{renderedComponents}{children}</div>
+  ) : (
+    <div className={classNames(styles.shaComponentsContainer, direction, className)} style={wrapperStyle} {...additionalDomProperties}>
+      <div className={styles.shaComponentsContainerInner} style={style}>
+        {renderedComponents}
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/shesha-reactjs/src/designer-components/checkbox/utils.ts
+++ b/shesha-reactjs/src/designer-components/checkbox/utils.ts
@@ -28,8 +28,8 @@ export const defaultStyles = (prev?: ICheckboxComponentProps & IInputStyles): IS
       radiusType: 'all',
     },
     dimensions: {
-      width: hasDimension(prev?.width) ? prev.width : '16px',
-      height: hasDimension(prev?.height) ? prev.height : '16px',
+      width: hasDimension(prev?.width) ? prev.width : '14px',
+      height: hasDimension(prev?.height) ? prev.height : '14px',
       minHeight: '0px',
       maxHeight: 'auto',
       minWidth: '0px',

--- a/shesha-reactjs/src/designer-components/styleBox/styles/styles.ts
+++ b/shesha-reactjs/src/designer-components/styleBox/styles/styles.ts
@@ -6,6 +6,7 @@ export const useStyles = createStyles(({ css, cx }) => {
       height: 155px;
       overflow: hidden;
       min-width: 200px;
+      max-width: 300px;
       width: 100%; 
       margin-top: 10px;
 

--- a/shesha-reactjs/src/designer-components/subForm/componentsContainerSubForm.tsx
+++ b/shesha-reactjs/src/designer-components/subForm/componentsContainerSubForm.tsx
@@ -1,39 +1,49 @@
-import { FC } from 'react';
-import { getAlignmentStyle } from '@/components/formDesigner/containers/util';
-import { ICommonContainerProps } from '@/designer-components/container/interfaces';
+import { FC, useMemo } from 'react';
 import { IComponentsContainerBaseProps } from '@/interfaces';
-import { removeUndefinedProperties } from '@/utils/array';
 import { useSubForm } from '@/providers';
 import { useParent } from '@/providers/parentProvider/index';
 import FormComponent from '../../components/formDesigner/formComponent/formComponent';
+import { IComponentsContainerProps } from '@/components/formDesigner/containers/componentsContainer';
+import { ComponentsContainerRender } from '@/components/formDesigner/containers/componentsContainerRender';
 
-interface IComponentsContainerSubFormProps extends IComponentsContainerBaseProps, ICommonContainerProps { }
+interface IComponentsContainerSubFormProps extends IComponentsContainerBaseProps, IComponentsContainerProps { }
 
 export const ComponentsContainerSubForm: FC<IComponentsContainerSubFormProps> = (props) => {
-  const { containerId, readOnly } = props;
+  const {
+    containerId,
+    direction = 'vertical',
+    className,
+    render,
+    wrapperStyle,
+    style,
+    noDefaultStyling = false,
+    additionalDomProperties,
+    readOnly,
+  } = props;
+
   const { getChildComponents, context } = useSubForm();
 
   const parent = useParent();
-  const components = getChildComponents(containerId.replace(`${parent.subFormIdPrefix}.`, ''));
-  const style = getAlignmentStyle(props);
 
-  return (
-    <div style={removeUndefinedProperties(style)}>
-      {components.length > 0
-        ? components.map((model) => {
-          const componentModel = {
-            ...model,
-            context: model.context ?? context,
-            initialContext: model.context,
-            readOnly: readOnly === true ? true : model.readOnly,
-            customEnabled: '',
-          };
+  const renderedComponents = useMemo(() => {
+    const comps = getChildComponents(containerId.replace(`${parent.subFormIdPrefix}.`, ''));
+    if (comps.length === 0)
+      return null;
 
-          return <FormComponent key={model.id} componentModel={componentModel} />;
-        })
-        : null}
-    </div>
-  );
+    const components = comps.map((model) => {
+      const componentModel = {
+        ...model,
+        context: model.context ?? context,
+        initialContext: model.context,
+        readOnly: readOnly === true ? true : model.readOnly,
+        customEnabled: '',
+      };
+      return <FormComponent key={model.id} componentModel={componentModel} />;
+    });
+    return typeof render === 'function' ? render(components) : components;
+  }, [containerId, context, getChildComponents, parent.subFormIdPrefix, readOnly, render]);
+
+  return <ComponentsContainerRender {...{ direction, className, wrapperStyle, additionalDomProperties, noDefaultStyling, style, renderedComponents }}></ComponentsContainerRender>;
 };
 
 ComponentsContainerSubForm.displayName = 'ComponentsContainer(SubForm)';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Standardized component container rendering across the form designer and subforms while preserving custom styling, alignment, child content, and additional display properties.
  - Reduced default checkbox dimensions to 14px by 14px when no size is specified; explicitly configured dimensions remain unchanged.
  - Limited the style box designer’s maximum width to 300px for improved layout control and more consistent editing experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->