### PR TITLE
fix(form): stop data-access proxies leaking into form data; strip NHibernate proxy names from entity references

### DIFF
--- a/shesha-core/src/Shesha.Framework/DynamicEntities/ObjectToJsonExtension.cs
+++ b/shesha-core/src/Shesha.Framework/DynamicEntities/ObjectToJsonExtension.cs
@@ -80,7 +80,7 @@ namespace Shesha.DynamicEntities
             if (obj != null && obj.IsEntity())
             {
                 if (!jobj.Properties().Any(x => x.Name == nameof(IHasClassNameField._className)))
-                    jobj.Add(nameof(IHasClassNameField._className), obj?.GetType().FullName);
+                    jobj.Add(nameof(IHasClassNameField._className), obj?.GetClassName());
                 if (!jobj.Properties().Any(x => x.Name == nameof(IHasDisplayNameField._displayName)))
                     jobj.Add(nameof(IHasDisplayNameField._displayName), obj?.GetEntityDisplayName());
             }
@@ -136,7 +136,7 @@ namespace Shesha.DynamicEntities
                 var jref = new JObject
                 {
                     { nameof(EntityReferenceDto<int>._displayName).ToCamelCase(), JToken.FromObject(val.GetEntityDisplayName() ?? string.Empty) },
-                    { nameof(EntityReferenceDto<int>._className).ToCamelCase(), JToken.FromObject((val.GetType() ?? propType).GetRequiredFullName()) },
+                    { nameof(EntityReferenceDto<int>._className).ToCamelCase(), JToken.FromObject(val.GetType().StripCastleProxyType().GetRequiredFullName()) },
                     { nameof(EntityReferenceDto<int>.Id).ToCamelCase(), JToken.FromObject(val.GetId().NotNull()) }
                 };
                 return jref;

--- a/shesha-core/src/Shesha.Framework/Extensions/ObjectExtensions.cs
+++ b/shesha-core/src/Shesha.Framework/Extensions/ObjectExtensions.cs
@@ -18,7 +18,8 @@ namespace Shesha.Extensions
 
         public static string? GetClassName(this object obj)
         {
-            return obj == null ? null : obj.GetType().FullName;
+            // lazily loaded entities are NHibernate proxies, report the real entity type
+            return obj == null ? null : obj.GetType().StripCastleProxyType().FullName;
         }
 
         /// <summary>

--- a/shesha-reactjs/src/providers/form/store/shaFormInstance.tsx
+++ b/shesha-reactjs/src/providers/form/store/shaFormInstance.tsx
@@ -28,7 +28,7 @@ import { executeScript, getComponentsAndSettings, IApplicationContext, isSameFor
 import { Form, FormInstance } from "antd";
 import { IFormApi } from "../formApi";
 import { ISetFormDataPayload } from "../contexts";
-import { deepMergeValues, setValueByPropertyName } from "@/utils/object";
+import { deepMergeValues, setValueByPropertyName, unproxyDeep } from "@/utils/object";
 import { makeObservableProxy } from "../observableProxy";
 import { IMetadataDispatcher } from "@/providers/metadataDispatcher/contexts";
 import { isEntityTypeIdEmpty } from "@/providers/metadataDispatcher/entities/utils";
@@ -393,13 +393,15 @@ class ShaFormInstance<Values extends object = object> implements IShaFormInstanc
   };
 
   setFormData = (payload: ISetFormDataPayload<Values>): void => {
-    const { values, mergeValues } = payload;
+    const { mergeValues } = payload;
+    // scripts may pass `{...form.data}`, whose nested objects are proxies; storing those corrupts the form data
+    const values = unproxyDeep(payload.values);
     if (isEmpty(values) && mergeValues)
       return;
 
     const newData = typeof this.getMergedOrValue === "function"
-      ? this.getMergedOrValue(payload, this)
-      : payload.mergeValues && this.formData
+      ? this.getMergedOrValue({ ...payload, values }, this)
+      : mergeValues && this.formData
         ? deepMergeValues(this.formData, values)
         : values;
 

--- a/shesha-reactjs/src/utils/object.ts
+++ b/shesha-reactjs/src/utils/object.ts
@@ -36,30 +36,33 @@ export const isProxy = <TValue>(value: TValue): boolean => {
   );
 };
 
-const resolveProxy = <TValue>(value: TValue): TValue => {
-  if (!isDefined(value)) return value;
+const resolveProxy = (value: unknown): unknown => {
   if (value instanceof TouchableProperty ||
     value instanceof TouchableArrayProperty ||
     value instanceof TouchableProxy ||
     value instanceof StorageProperty ||
     value instanceof StorageArrayProperty)
-    return value.getData() as TValue;
+    return value.getData();
   if (value instanceof ShaArrayAccessProxy || value instanceof ShaObjectAccessProxy)
-    return value.getAccessorValue() as TValue;
+    return value.getAccessorValue();
   if (value instanceof ObservableProxy)
-    return (Array.isArray(value) ? [...value] : { ...value }) as TValue;
+    return Array.isArray(value) ? [...value] : { ...value };
   return value;
 };
 
+/**
+ * Resolves a proxy (or a chain of proxies) to the data it points at. Callers keep the declared `TValue`
+ * because the proxies are typed as the data they wrap; the resolved data is what that type describes.
+ */
 export const unproxyValue = <TValue = unknown>(value: TValue): TValue => {
   // a proxy may resolve to another proxy; stop at the first one seen twice so a cycle cannot recurse forever
   const seen = new Set<unknown>();
-  let current = value;
+  let current: unknown = value;
   while (isProxy(current) && !seen.has(current)) {
     seen.add(current);
     current = resolveProxy(current);
   }
-  return current;
+  return current as TValue;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => isPlainObject(value);

--- a/shesha-reactjs/src/utils/object.ts
+++ b/shesha-reactjs/src/utils/object.ts
@@ -36,58 +36,73 @@ export const isProxy = <TValue>(value: TValue): boolean => {
   );
 };
 
-export const unproxyValue = <TValue = unknown>(value: TValue): TValue => {
-  const result = isDefined(value)
-    ? value instanceof TouchableProperty ||
+const resolveProxy = <TValue>(value: TValue): TValue => {
+  if (!isDefined(value)) return value;
+  if (value instanceof TouchableProperty ||
     value instanceof TouchableArrayProperty ||
     value instanceof TouchableProxy ||
     value instanceof StorageProperty ||
-    value instanceof StorageArrayProperty
-      ? value.getData() as TValue
-      : value instanceof ShaArrayAccessProxy ||
-        value instanceof ShaObjectAccessProxy
-        ? value.getAccessorValue() as TValue
-        : value instanceof ObservableProxy
-          ? Array.isArray(value) ? [...value] : { ...value }
-          : value
-    : value;
+    value instanceof StorageArrayProperty)
+    return value.getData() as TValue;
+  if (value instanceof ShaArrayAccessProxy || value instanceof ShaObjectAccessProxy)
+    return value.getAccessorValue() as TValue;
+  if (value instanceof ObservableProxy)
+    return (Array.isArray(value) ? [...value] : { ...value }) as TValue;
+  return value;
+};
 
-  // a proxy that resolves to itself has lost its data, stop instead of recursing forever
-  return isProxy(result) && result !== value ? unproxyValue<TValue>(result as TValue) : result as TValue;
+export const unproxyValue = <TValue = unknown>(value: TValue): TValue => {
+  // a proxy may resolve to another proxy; stop at the first one seen twice so a cycle cannot recurse forever
+  const seen = new Set<unknown>();
+  let current = value;
+  while (isProxy(current) && !seen.has(current)) {
+    seen.add(current);
+    current = resolveProxy(current);
+  }
+  return current;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => isPlainObject(value);
+
+const isOpaqueObject = (value: object): boolean =>
+  moment.isMoment(value) || value instanceof Date || (typeof Blob !== 'undefined' && value instanceof Blob);
+
+const containsProxy = (value: unknown, seen: WeakSet<object>): boolean => {
+  if (!isDefined(value) || typeof value !== 'object') return false;
+  if (isProxy(value)) return true;
+  if (isOpaqueObject(value) || seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) return value.some((item) => containsProxy(item, seen));
+  return isRecord(value) && Object.values(value).some((item) => containsProxy(item, seen));
+};
+
+const unproxyTree = (value: unknown, results: WeakMap<object, unknown>): unknown => {
+  if (!isDefined(value) || typeof value !== 'object') return value;
+  const plain = unproxyValue(value);
+  if (!isDefined(plain) || typeof plain !== 'object' || isProxy(plain) || isOpaqueObject(plain)) return plain;
+  if (results.has(plain)) return results.get(plain);
+
+  if (Array.isArray(plain)) {
+    const result: unknown[] = [];
+    results.set(plain, result); // registered before the children so cycles and shared references resolve to this copy
+    plain.forEach((item) => result.push(unproxyTree(item, results)));
+    return result;
+  }
+  if (!isRecord(plain)) return plain;
+  const result: Record<string, unknown> = {};
+  results.set(plain, result);
+  Object.entries(plain).forEach(([key, item]) => {
+    result[key] = unproxyTree(item, results);
+  });
+  return result;
 };
 
 /**
  * Replaces every data-access proxy inside `value` with the plain data it points at.
- * Returns the same reference when nothing had to change, so untouched values keep their identity.
+ * Returns the same reference when the tree holds no proxy, so untouched values keep their identity.
  */
-export const unproxyDeep = <TValue = unknown>(value: TValue, seen: WeakSet<object> = new WeakSet()): TValue => {
-  if (!isDefined(value) || typeof value !== 'object')
-    return value;
-  const plain = isProxy(value) ? unproxyValue(value) : value;
-  if (!isDefined(plain) || typeof plain !== 'object' || isProxy(plain) || seen.has(plain))
-    return plain;
-  if (moment.isMoment(plain) || plain instanceof Date || (typeof Blob !== 'undefined' && plain instanceof Blob))
-    return plain;
-  seen.add(plain);
-
-  let changed = plain !== value;
-  if (Array.isArray(plain)) {
-    const items = plain.map((item: unknown) => {
-      const result = unproxyDeep(item, seen);
-      if (result !== item) changed = true;
-      return result;
-    });
-    return (changed ? items : plain) as TValue;
-  }
-  if (!isPlainObject(plain))
-    return plain;
-  const result: Record<string, unknown> = {};
-  Object.entries(plain as Record<string, unknown>).forEach(([key, item]) => {
-    const itemResult = unproxyDeep(item, seen);
-    if (itemResult !== item) changed = true;
-    result[key] = itemResult;
-  });
-  return (changed ? result : plain) as TValue;
+export const unproxyDeep = <TValue = unknown>(value: TValue): TValue => {
+  return containsProxy(value, new WeakSet()) ? unproxyTree(value, new WeakMap()) as TValue : value;
 };
 
 export const deepMergeSkipUndefinedFunc = (objValue: unknown, srcValue: unknown, _key: string): unknown => srcValue === undefined ? objValue : undefined;

--- a/shesha-reactjs/src/utils/object.ts
+++ b/shesha-reactjs/src/utils/object.ts
@@ -1,6 +1,6 @@
 import { isDefined, isNullOrWhiteSpace } from "@/utils/nullables";
 import cleanDeep from "clean-deep";
-import { mergeWith } from "lodash";
+import { isPlainObject, mergeWith } from "lodash";
 import moment from "moment";
 import { Path, PathValue } from "./dotnotation";
 import { TouchableArrayProperty, TouchableProperty } from "@/providers/form/touchableProperty";
@@ -52,7 +52,42 @@ export const unproxyValue = <TValue = unknown>(value: TValue): TValue => {
           : value
     : value;
 
-  return isProxy(result) ? unproxyValue<TValue>(result as TValue) : result as TValue;
+  // a proxy that resolves to itself has lost its data, stop instead of recursing forever
+  return isProxy(result) && result !== value ? unproxyValue<TValue>(result as TValue) : result as TValue;
+};
+
+/**
+ * Replaces every data-access proxy inside `value` with the plain data it points at.
+ * Returns the same reference when nothing had to change, so untouched values keep their identity.
+ */
+export const unproxyDeep = <TValue = unknown>(value: TValue, seen: WeakSet<object> = new WeakSet()): TValue => {
+  if (!isDefined(value) || typeof value !== 'object')
+    return value;
+  const plain = isProxy(value) ? unproxyValue(value) : value;
+  if (!isDefined(plain) || typeof plain !== 'object' || isProxy(plain) || seen.has(plain))
+    return plain;
+  if (moment.isMoment(plain) || plain instanceof Date || (typeof Blob !== 'undefined' && plain instanceof Blob))
+    return plain;
+  seen.add(plain);
+
+  let changed = plain !== value;
+  if (Array.isArray(plain)) {
+    const items = plain.map((item: unknown) => {
+      const result = unproxyDeep(item, seen);
+      if (result !== item) changed = true;
+      return result;
+    });
+    return (changed ? items : plain) as TValue;
+  }
+  if (!isPlainObject(plain))
+    return plain;
+  const result: Record<string, unknown> = {};
+  Object.entries(plain as Record<string, unknown>).forEach(([key, item]) => {
+    const itemResult = unproxyDeep(item, seen);
+    if (itemResult !== item) changed = true;
+    result[key] = itemResult;
+  });
+  return (changed ? result : plain) as TValue;
 };
 
 export const deepMergeSkipUndefinedFunc = (objValue: unknown, srcValue: unknown, _key: string): unknown => srcValue === undefined ? objValue : undefined;

--- a/shesha-reactjs/src/utils/object.unproxy.test.ts
+++ b/shesha-reactjs/src/utils/object.unproxy.test.ts
@@ -11,6 +11,16 @@ const formProxy = (getData: () => Data): Data => {
   return GetShaFormDataAccessor(api) as unknown as Data;
 };
 
+type FieldGetter = { getFieldValue: (name: string) => unknown };
+// `in` is answered by the proxy's `has` trap for the form data, so read the accessor member instead
+const hasGetFieldValue = (value: unknown): value is FieldGetter =>
+  typeof value === 'object' && value !== null && typeof Reflect.get(value, 'getFieldValue') === 'function';
+const fieldGetter = (getData: () => Data): FieldGetter['getFieldValue'] => {
+  const proxy = formProxy(getData);
+  if (!hasGetFieldValue(proxy)) throw new Error('form proxy has no getFieldValue');
+  return proxy.getFieldValue;
+};
+
 describe('unproxyDeep', () => {
   it('replaces nested data-access proxies produced by spreading form.data', () => {
     const formData: Data = { item: 'a', referenceList: { id: '1', _displayName: 'RL' }, tags: [{ id: 't1' }] };
@@ -47,14 +57,14 @@ describe('unproxyDeep', () => {
     const formData: Data = { referenceList: { id: '1' } };
     const shared = { nested: formProxy(() => formData).referenceList };
     const plain = unproxyDeep({ first: shared, second: shared });
-    expect(isProxy((plain.first as Data).nested)).toBe(false);
-    expect(isProxy((plain.second as Data).nested)).toBe(false);
+    expect(isProxy(plain.first.nested)).toBe(false);
+    expect(isProxy(plain.second.nested)).toBe(false);
     expect(plain.first).toBe(plain.second);
   });
 
   it('unproxyValue stops on two proxies that resolve to each other', () => {
     let formData: Data = {};
-    const getField = (formProxy(() => formData) as { getFieldValue: (n: string) => unknown }).getFieldValue;
+    const getField = fieldGetter(() => formData);
     formData = { a: { id: 'a' }, b: { id: 'b' } };
     const proxyA = getField('a');
     const proxyB = getField('b');
@@ -65,7 +75,7 @@ describe('unproxyDeep', () => {
 
   it('unproxyValue returns a self-referencing proxy instead of recursing', () => {
     let formData: Data = {};
-    const nested = (formProxy(() => formData) as { getFieldValue: (n: string) => unknown }).getFieldValue;
+    const nested = fieldGetter(() => formData);
     formData = { referenceList: { id: '1' } };
     const proxy = nested('referenceList');
     formData = { referenceList: proxy };

--- a/shesha-reactjs/src/utils/object.unproxy.test.ts
+++ b/shesha-reactjs/src/utils/object.unproxy.test.ts
@@ -1,0 +1,54 @@
+import moment from 'moment';
+import { GetShaFormDataAccessor } from '@/providers/dataContextProvider/contexts/shaDataAccessProxy';
+import { IFormApi } from '@/providers/form/formApi';
+import { hasFiles } from './form';
+import { deepMergeValues, isProxy, unproxyDeep, unproxyValue } from './object';
+
+type Data = Record<string, unknown>;
+
+const formProxy = (getData: () => Data): Data => {
+  const api = { getFormData: getData, setFieldsValue: () => undefined, setFieldValue: () => undefined } as unknown as IFormApi<Data>;
+  return GetShaFormDataAccessor(api) as unknown as Data;
+};
+
+describe('unproxyDeep', () => {
+  it('replaces nested data-access proxies produced by spreading form.data', () => {
+    const formData: Data = { item: 'a', referenceList: { id: '1', _displayName: 'RL' }, tags: [{ id: 't1' }] };
+    const spread = { description: '', ...formProxy(() => formData) };
+    expect(isProxy(spread.referenceList)).toBe(true);
+
+    const plain = unproxyDeep(spread);
+    expect(isProxy(plain.referenceList)).toBe(false);
+    expect(plain).toEqual({ description: '', item: 'a', referenceList: { id: '1', _displayName: 'RL' }, tags: [{ id: 't1' }] });
+  });
+
+  it('keeps the same reference when nothing is a proxy', () => {
+    const value = { a: 1, nested: { b: [1, 2] }, when: moment('2026-01-01'), date: new Date(0) };
+    expect(unproxyDeep(value)).toBe(value);
+  });
+
+  it('stops the merge from storing a proxy that would later loop forever', () => {
+    let formData: Data = { item: 'a', referenceList: { id: '1' } };
+    const spread = { ...formProxy(() => formData) };
+
+    const corrupted = deepMergeValues({ item: 'b' }, spread);
+    formData = corrupted;
+    expect(isProxy(corrupted.referenceList)).toBe(true);
+    expect(() => hasFiles(corrupted)).toThrow(RangeError);
+
+    formData = { item: 'a', referenceList: { id: '1' } };
+    const safe = deepMergeValues({ item: 'b' }, unproxyDeep({ ...formProxy(() => formData) }));
+    formData = safe;
+    expect(isProxy(safe.referenceList)).toBe(false);
+    expect(hasFiles(safe)).toBe(false);
+  });
+
+  it('unproxyValue returns a self-referencing proxy instead of recursing', () => {
+    let formData: Data = {};
+    const nested = (formProxy(() => formData) as { getFieldValue: (n: string) => unknown }).getFieldValue;
+    formData = { referenceList: { id: '1' } };
+    const proxy = nested('referenceList');
+    formData = { referenceList: proxy };
+    expect(() => unproxyValue(proxy)).not.toThrow();
+  });
+});

--- a/shesha-reactjs/src/utils/object.unproxy.test.ts
+++ b/shesha-reactjs/src/utils/object.unproxy.test.ts
@@ -43,6 +43,26 @@ describe('unproxyDeep', () => {
     expect(hasFiles(safe)).toBe(false);
   });
 
+  it('gives shared references the same proxy-free copy', () => {
+    const formData: Data = { referenceList: { id: '1' } };
+    const shared = { nested: formProxy(() => formData).referenceList };
+    const plain = unproxyDeep({ first: shared, second: shared });
+    expect(isProxy((plain.first as Data).nested)).toBe(false);
+    expect(isProxy((plain.second as Data).nested)).toBe(false);
+    expect(plain.first).toBe(plain.second);
+  });
+
+  it('unproxyValue stops on two proxies that resolve to each other', () => {
+    let formData: Data = {};
+    const getField = (formProxy(() => formData) as { getFieldValue: (n: string) => unknown }).getFieldValue;
+    formData = { a: { id: 'a' }, b: { id: 'b' } };
+    const proxyA = getField('a');
+    const proxyB = getField('b');
+    formData = { a: proxyB, b: proxyA };
+    expect(() => unproxyValue(proxyA)).not.toThrow();
+    expect(() => unproxyDeep({ a: proxyA })).not.toThrow();
+  });
+
   it('unproxyValue returns a self-referencing proxy instead of recursing', () => {
     let formData: Data = {};
     const nested = (formProxy(() => formData) as { getFieldValue: (n: string) => unknown }).getFieldValue;


### PR DESCRIPTION
Editing a reference list item in Configuration Studio failed with `Submit failed: RangeError: Maximum call stack size exceeded` (QA report on #5051, form `reference-list-item-edit`). Reproduced with Playwright against the QA environment; two separate defects sit behind the one message.

## Frontend: data-access proxies leaking into form data

The migrated `onAfterDataLoad` script does `form.setFieldsValue({ ..., ...form.data })`. Spreading `form.data` yields a data-access proxy for every nested object (`referenceList` here). When the merge target lacks that key, lodash stores the proxy itself in the form data. From then on, enumerating that proxy asks the form for `referenceList`, gets the proxy back, and recurses until the stack overflows. Every form that went through the initial-values migration carries the same spread, so this is not specific to reference lists.

- `setFormData` now runs incoming values through a new `unproxyDeep`, which swaps every proxy for the plain data it points at and returns the same reference when nothing changed. All script-facing writes (`form.data =`, `setFieldValue`, `setFieldsValue`) funnel through it.
- `unproxyValue` stops instead of recursing when a proxy resolves to itself.
- Tests in `src/utils/object.unproxy.test.ts` cover the spread, identity preservation, the corrupted-merge case, and the self-referencing guard.

## Backend: entity references serialised with the NHibernate proxy type name

With the overflow gone the update reaches the server and is rejected: `Entity with class name or alias 'ReferenceListProxy' not found`. `ReferenceListItem/Get` returns `referenceList._className: "ReferenceListProxy"` because `ObjectToJsonExtension` takes the class name from the runtime type of a lazily loaded reference. `GetClassName` and the entity-reference branch now strip the proxy type first. Verified against the API that `{ id }` and the real class name are accepted; only the proxy name is rejected.

## Testing

- `npx vitest run src/utils/object.unproxy.test.ts src/providers/form src/providers/dataContextProvider` passes (27 tests).
- `npm run type-check` passes, eslint reports no errors on the changed files.
- `dotnet build shesha-core/src/Shesha.Framework` succeeds. Backend tests need Docker and were not run.
- Playwright against the local build with API calls proxied to QA: the item edit no longer overflows and the submit reaches the server. The backend half cannot be verified until deployed.
- Harness forms on QA reproduce both the crash and the config-level workaround: `t-reflist-item-edit-harness` in Boxfusion.SheshaFunctionalTests.Web.

Refs #5051

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Entity data now reports the correct class name, including for lazily loaded records.
  - Form updates correctly process nested data before merging, improving reliability with wrapped values.
  - Prevented infinite recursion when processing self-referencing or cyclic data.
  - Improved handling of nested object values while preserving unaffected data references.

- **Tests**
  - Added coverage for nested data processing, reference preservation, deep merging, and self-referencing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->