### PR TITLE
fix(datatable): resolve {{selectedRow.id}} in row event actions at event time (#5051)

### DIFF
--- a/shesha-reactjs/src/designer-components/dataTable/table/tableComponent.actualModelFilter.test.ts
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableComponent.actualModelFilter.test.ts
@@ -1,0 +1,21 @@
+import TableComponent, { ROW_EVENT_ACTION_PROPERTIES } from './tableComponent';
+
+const filter = TableComponent.actualModelPropertyFilter!;
+const navigateAction = {
+  actionName: 'Navigate',
+  actionOwner: 'shesha.common',
+  actionArguments: { queryParameters: [{ key: 'id', value: '{{selectedRow.id}}' }] },
+};
+
+describe('datatable actualModelPropertyFilter', () => {
+  it('leaves row event actions for evaluation at event time', () => {
+    ROW_EVENT_ACTION_PROPERTIES.forEach((name) => expect(filter(name, navigateAction)).toBe(false));
+  });
+
+  it('still pre-evaluates ordinary and styling properties', () => {
+    expect(filter('caption', 'Members')).toBe(true);
+    expect(filter('rowDimensions', { height: '40px' })).toBe(true);
+    expect(filter('items', { _mode: 'code', _code: 'return [];' })).toBe(true);
+    expect(filter('items', [{ columnType: 'data' }])).toBe(false);
+  });
+});

--- a/shesha-reactjs/src/designer-components/dataTable/table/tableComponent.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableComponent.tsx
@@ -78,6 +78,11 @@ const TableComponentFactory: React.FC<{ model: ITableComponentProps; columnsMism
   return <TableWrapper {...model} columnsMismatch={columnsMismatch} />;
 };
 
+export const ROW_EVENT_ACTION_PROPERTIES = [
+  'onRowClick', 'onRowDoubleClick', 'onRowHover', 'onRowSelect', 'onSelectionChange',
+  'onRowSaveSuccessAction', 'onRowDeleteSuccessAction', 'dblClickActionConfiguration',
+];
+
 const TableComponent: TableComponentDefinition = {
   type: 'datatable',
   isInput: true,
@@ -383,6 +388,10 @@ const TableComponent: TableComponentDefinition = {
     .add<ITableComponentProps>(30, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(prev)))
     .add<ITableComponentProps>(31, (prev) => ({ ...prev, visible: prev.visible ?? true })),
   actualModelPropertyFilter: (name, value) => {
+    // row event actions carry templates like {{selectedRow.id}} that only resolve when the event fires
+    if (ROW_EVENT_ACTION_PROPERTIES.includes(name))
+      return false;
+
     // Allow all styling properties through to the settings form
     const allowedStyleProperties = [
       // Old properties (deprecated but kept for backward compatibility)

--- a/shesha-reactjs/src/designer-components/dataTable/tableContext/tableContextComponent.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/tableContext/tableContextComponent.tsx
@@ -42,7 +42,8 @@ const TableContextComponent: TableContextComponentDefinition = {
 
     return initialModel;
   },
-  actualModelPropertyFilter: (name) => name !== 'permanentFilter',
+  // reorder actions carry templates that only resolve when the event fires
+  actualModelPropertyFilter: (name) => !['permanentFilter', 'onBeforeRowReorder', 'onAfterRowReorder'].includes(name),
   settingsFormMarkup: (data) => getSettings(data),
 
   getFieldsToFetch: (propertyName, rawModel) => {


### PR DESCRIPTION
QA item on #5051: On Row Click / On Row Double-Click configured with `{{selectedRow.id}}` did not work. Reproduced with Playwright on the QA form `fujj`: the Navigate action ran, but landed on `fujiDetails?id=` with an empty id.

## Cause

The row events already put `selectedRow` into the action's evaluation context. The template never reached them. On render the table component's model is pre-evaluated against the page context, and that pass rendered `{{selectedRow.id}}` to an empty string while no row was selected. By the time the event fired, the action's arguments held a literal `""`.

## Fix

Components list props holding templates in `actualModelPropertyFilter` so the render-time pass leaves them alone. The table's filter did not list its row events.

- `tableComponent.tsx`: the filter now skips `onRowClick`, `onRowDoubleClick`, `onRowHover`, `onRowSelect`, `onSelectionChange`, `onRowSaveSuccessAction`, `onRowDeleteSuccessAction` and `dblClickActionConfiguration`, so they are evaluated with the row context when the event fires.
- `tableContextComponent.tsx`: the same for `onBeforeRowReorder` and `onAfterRowReorder`.
- A small test pins the filter behaviour.

## Verification

Playwright on QA data, form `t5051-rowclick-noinline` (a copy of `fujj` with inline editing off, kept on QA for verification):

| | Current QA build | This branch |
|---|---|---|
| single click | `fujiDetails?id=` | `fujiDetails?id=<row id>` |
| double click | `fujiDetails?id=` | `fujiDetails?id=<row id>` |

On `fujj` itself every row is in inline edit mode and the table intentionally does not fire row single-click while a row is being edited; double-click fires and now carries the id.

Datatable tests, eslint and `npm run type-check` pass.

Refs #5051

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated data table configuration filtering to prevent row event action templates from appearing as regular settings.
  - Excluded row reorder callbacks and permanent filters from standard property configuration.
  - Preserved access to ordinary display and styling properties, while continuing to distinguish code-based item definitions from data-driven item lists.

- **Tests**
  - Added coverage confirming correct filtering for row actions, reorder events, styling properties, and item configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->