### PR TITLE
fix: auto logoff not applied after security settings are changed (#1433)

### DIFF
--- a/shesha-reactjs/src/components/idleTimerRenderer/__tests__/idleTimerRenderer.test.tsx
+++ b/shesha-reactjs/src/components/idleTimerRenderer/__tests__/idleTimerRenderer.test.tsx
@@ -1,0 +1,130 @@
+import { render, act, screen } from '@testing-library/react';
+import { createMocks } from 'react-idle-timer';
+import { IdleTimerRenderer, ISecuritySettings } from '../index';
+import { WARNING_DURATION } from '../util';
+
+const logoutUser = vi.fn(() => Promise.resolve());
+const post = vi.fn();
+
+vi.mock('@/providers/auth', () => ({
+  useAuth: () => ({
+    logoutUser,
+    loginInfo: { id: 1, userName: 'admin' },
+    updateTokenExpiration: vi.fn(),
+    refreshAuthHeaders: vi.fn(),
+  }),
+}));
+vi.mock('@/providers', () => ({ useHttpClient: () => ({ post }) }));
+vi.mock('@/providers/dynamicModal', () => ({ useDynamicModalsOrUndefined: () => undefined }));
+vi.mock('../styles/styles', () => ({ useStyles: () => ({ styles: {} }) }));
+vi.mock('antd', () => ({
+  Modal: ({ open, title, children }: { open: boolean; title: string; children: React.ReactNode }) => (
+    open ? <div role="dialog"><h1>{title}</h1>{children}</div> : null
+  ),
+  Progress: ({ format }: { format?: () => React.ReactNode }) => <span>{format?.()}</span>,
+}));
+
+const TIMEOUT = 80;
+const PROMPT_AT = TIMEOUT - WARNING_DURATION;
+
+const settings = (over: Partial<ISecuritySettings> = {}): ISecuritySettings => ({
+  autoLogoffTimeout: TIMEOUT,
+  useAutoLogoff: true,
+  defaultEndpointAccess: 0,
+  mobileLoginPinLifetime: 60,
+  resetPasswordEmailLinkLifetime: 60,
+  resetPasswordSmsOtpLifetime: 60,
+  resetPasswordViaSecurityQuestionsNumQuestionsAllowed: 3,
+  useResetPasswordViaEmailLink: true,
+  useResetPasswordViaSecurityQuestions: true,
+  useResetPasswordViaSmsOtp: true,
+  ...over,
+});
+
+const advanceSeconds = async (seconds: number): Promise<void> => {
+  // advance in 1s steps so that cross-tab messages (MessageChannel/BroadcastChannel) get delivered in between
+  for (let i = 0; i < seconds; i++) {
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+  }
+};
+
+const dialogText = (): string | undefined => screen.queryByRole('dialog')?.textContent ?? undefined;
+
+describe('IdleTimerRenderer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // react-idle-timer binds window timers at import time, createMocks() makes it use the (fake) globals
+    createMocks();
+    logoutUser.mockClear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the warning 60s before the timeout and logs out when it elapses', async () => {
+    render(<IdleTimerRenderer securitySettings={settings()}>content</IdleTimerRenderer>);
+
+    await advanceSeconds(PROMPT_AT - 1);
+    expect(dialogText()).toBeUndefined();
+
+    await advanceSeconds(2);
+    expect(dialogText()).toContain('Session Expiring');
+    expect(logoutUser).not.toHaveBeenCalled();
+
+    await advanceSeconds(WARNING_DURATION + 1);
+    expect(logoutUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies security settings that arrive after mount (settings are loaded asynchronously)', async () => {
+    const { rerender } = render(<IdleTimerRenderer securitySettings={undefined}>content</IdleTimerRenderer>);
+    await advanceSeconds(1);
+
+    rerender(<IdleTimerRenderer securitySettings={settings()}>content</IdleTimerRenderer>);
+
+    await advanceSeconds(PROMPT_AT + 1);
+    expect(dialogText()).toContain('Session Expiring');
+
+    await advanceSeconds(WARNING_DURATION + 1);
+    expect(logoutUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when auto-logoff is disabled', async () => {
+    render(<IdleTimerRenderer securitySettings={settings({ useAutoLogoff: false })}>content</IdleTimerRenderer>);
+
+    await advanceSeconds(TIMEOUT + 5);
+    expect(dialogText()).toBeUndefined();
+    expect(logoutUser).not.toHaveBeenCalled();
+  });
+
+  it('stops the countdown when auto-logoff gets disabled at runtime', async () => {
+    const { rerender } = render(<IdleTimerRenderer securitySettings={settings()}>content</IdleTimerRenderer>);
+    await advanceSeconds(PROMPT_AT + 1);
+    expect(dialogText()).toContain('Session Expiring');
+
+    rerender(<IdleTimerRenderer securitySettings={settings({ useAutoLogoff: false })}>content</IdleTimerRenderer>);
+    expect(dialogText()).toBeUndefined();
+
+    await advanceSeconds(WARNING_DURATION + 5);
+    expect(logoutUser).not.toHaveBeenCalled();
+  });
+
+  it('works with several instances sharing the cross-tab channel (all idle -> logout)', async () => {
+    render(
+      <>
+        <IdleTimerRenderer securitySettings={settings()}>a</IdleTimerRenderer>
+        <IdleTimerRenderer securitySettings={settings()}>b</IdleTimerRenderer>
+      </>,
+    );
+
+    await advanceSeconds(PROMPT_AT + 2);
+    expect(screen.queryAllByRole('dialog').length).toBeGreaterThan(0);
+
+    await advanceSeconds(WARNING_DURATION + 2);
+    expect(logoutUser).toHaveBeenCalled();
+  });
+});

--- a/shesha-reactjs/src/components/settingsEditor/provider/index.tsx
+++ b/shesha-reactjs/src/components/settingsEditor/provider/index.tsx
@@ -4,6 +4,7 @@ import { useEffectOnce } from '@/hooks/useEffectOnce';
 import { extractAjaxResponse, IAjaxResponse, isAjaxSuccessResponse } from '@/interfaces/ajaxResponse';
 import { GetAllResponse, IGenericGetAllPayload } from '@/interfaces/gql';
 import { useHttpClient, useTheme } from '@/providers';
+import { useSettingsOrUndefined } from '@/providers/settings';
 import { GENERIC_ENTITIES_ENDPOINT } from '@/shesha-constants';
 import { buildUrl } from '@/utils';
 import { makeErrorWithMessage, throwError } from '@/utils/errors';
@@ -69,6 +70,7 @@ const SettingsEditorProvider: FC<PropsWithChildren> = ({ children }) => {
     ...SETTINGS_EDITOR_STATE_CONTEXT_INITIAL_STATE,
   };
   const httpClient = useHttpClient();
+  const settingsClient = useSettingsOrUndefined();
   const [state, dispatch] = useThunkReducer(settingsEditorReducer, initial);
 
   const { resetToApplicationTheme } = useTheme();
@@ -185,12 +187,16 @@ const SettingsEditorProvider: FC<PropsWithChildren> = ({ children }) => {
       .then((response) => {
         extractAjaxResponse(response.data);
         dispatch(setSaveStatusAction('success'));
+        // Drop the cached value so consumers (e.g. the idle timer reading security settings)
+        // pick up the change without a full page reload
+        if (!isNullOrWhiteSpace(settingId.module))
+          settingsClient?.invalidateSetting({ module: settingId.module, name: settingId.name });
       })
       .catch((error) => {
         dispatch(setSaveStatusAction('error'));
         console.error(error);
       });
-  }, [dispatch, httpClient]);
+  }, [dispatch, httpClient, settingsClient]);
 
   const setEditor = useCallback((editorBridge: IEditorBridge): void => {
     dispatch(setEditorBridgeAction(editorBridge));

--- a/shesha-reactjs/src/components/settingsEditor/provider/index.tsx
+++ b/shesha-reactjs/src/components/settingsEditor/provider/index.tsx
@@ -189,8 +189,9 @@ const SettingsEditorProvider: FC<PropsWithChildren> = ({ children }) => {
         dispatch(setSaveStatusAction('success'));
         // Drop the cached value so consumers (e.g. the idle timer reading security settings)
         // pick up the change without a full page reload
-        if (!isNullOrWhiteSpace(settingId.module))
-          settingsClient?.invalidateSetting({ module: settingId.module, name: settingId.name });
+        // Module-less settings are identified by an empty module (see SettingsClient.getSetting)
+        if (!isNullOrWhiteSpace(settingId.name))
+          settingsClient?.invalidateSetting({ module: settingId.module ?? '', name: settingId.name });
       })
       .catch((error) => {
         dispatch(setSaveStatusAction('error'));

--- a/shesha-reactjs/src/providers/settings/__tests__/settingsProvider.test.tsx
+++ b/shesha-reactjs/src/providers/settings/__tests__/settingsProvider.test.tsx
@@ -121,19 +121,68 @@ describe('SettingsProvider / useSettingValue', () => {
     expect(get).toHaveBeenCalledTimes(2);
   });
 
-  it('does not cache failed requests', async () => {
+  it('does not cache failed requests, so a retry performs a new request without invalidation', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     get.mockRejectedValueOnce(new Error('network'));
     const { client } = renderAll();
     await waitFor(() => expect(stateText()).toBe('failed'));
+    expect(get).toHaveBeenCalledTimes(1);
 
     get.mockResolvedValueOnce(ok({ useAutoLogoff: true }));
-    act(() => {
-      client().invalidateSetting(SETTING_ID);
-    });
+    const retried = await client().getSetting<{ useAutoLogoff: boolean }>(SETTING_ID);
 
-    await waitFor(() => expect(valueText()).toBe('true'));
+    expect(retried).toEqual({ useAutoLogoff: true });
     expect(get).toHaveBeenCalledTimes(2);
     consoleError.mockRestore();
+  });
+
+  it('invalidates module-less settings (empty module) locally and across tabs', async () => {
+    get.mockResolvedValue(ok({ useAutoLogoff: false }));
+    const { client } = renderAll();
+    await waitFor(() => expect(stateText()).toBe('ready'));
+
+    const moduleLessId = { module: '', name: 'ModuleLessSetting' };
+    const listener = vi.fn();
+    client().subscribe(moduleLessId, listener);
+
+    act(() => {
+      client().invalidateSetting(moduleLessId);
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // the broadcast message written by this tab must be decodable by another tab
+    const broadcast = localStorage.getItem(SETTINGS_INVALIDATION_STORAGE_KEY);
+    expect(broadcast).not.toBeNull();
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: SETTINGS_INVALIDATION_STORAGE_KEY,
+        newValue: broadcast,
+      }));
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes a distinct broadcast value for repeated invalidations within the same millisecond', async () => {
+    get.mockResolvedValue(ok({ useAutoLogoff: false }));
+    const { client } = renderAll();
+    await waitFor(() => expect(stateText()).toBe('ready'));
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        client().invalidateSetting(SETTING_ID);
+      });
+      const first = localStorage.getItem(SETTINGS_INVALIDATION_STORAGE_KEY);
+      act(() => {
+        client().invalidateSetting(SETTING_ID);
+      });
+      const second = localStorage.getItem(SETTINGS_INVALIDATION_STORAGE_KEY);
+
+      expect(first).not.toBeNull();
+      expect(second).not.toBeNull();
+      expect(second).not.toBe(first);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/shesha-reactjs/src/providers/settings/__tests__/settingsProvider.test.tsx
+++ b/shesha-reactjs/src/providers/settings/__tests__/settingsProvider.test.tsx
@@ -1,0 +1,139 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { FC, useEffect } from 'react';
+import { SettingsProvider, useSettingValue, useSettings, SETTINGS_INVALIDATION_STORAGE_KEY } from '../index';
+import { ISettingsClientContext } from '../contexts';
+
+const get = vi.fn();
+const post = vi.fn();
+
+vi.mock('../../sheshaApplication/publicApi', () => ({
+  useHttpClient: () => ({ get, post }),
+}));
+
+const SETTING_ID = { module: 'Shesha', name: 'Shesha.Security' };
+
+function ok<T>(result: T): { data: { success: true; result: T } } {
+  return { data: { success: true, result } };
+}
+
+const SettingValueView: FC = () => {
+  const { value, loadingState } = useSettingValue<{ useAutoLogoff: boolean }>(SETTING_ID);
+  return (
+    <div>
+      <span data-testid="state">{loadingState}</span>
+      <span data-testid="value">{value ? String(value.useAutoLogoff) : 'none'}</span>
+    </div>
+  );
+};
+
+const ClientCapture: FC<{ onClient: (client: ISettingsClientContext) => void }> = ({ onClient }) => {
+  const settings = useSettings();
+  useEffect(() => {
+    onClient(settings);
+  }, [settings, onClient]);
+  return null;
+};
+
+const stateText = (): string => screen.getByTestId('state').textContent;
+const valueText = (): string => screen.getByTestId('value').textContent;
+
+const renderAll = (): { client: () => ISettingsClientContext } => {
+  let captured: ISettingsClientContext | undefined;
+  render(
+    <SettingsProvider>
+      <ClientCapture onClient={(c) => {
+        captured = c;
+      }}
+      />
+      <SettingValueView />
+    </SettingsProvider>,
+  );
+  return {
+    client: () => {
+      if (!captured) throw new Error('settings client is not captured');
+      return captured;
+    },
+  };
+};
+
+describe('SettingsProvider / useSettingValue', () => {
+  beforeEach(() => {
+    get.mockReset();
+    post.mockReset();
+    localStorage.clear();
+  });
+
+  it('loads the value once and serves it from cache', async () => {
+    get.mockResolvedValue(ok({ useAutoLogoff: false }));
+    renderAll();
+
+    await waitFor(() => expect(stateText()).toBe('ready'));
+    expect(valueText()).toBe('false');
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches the value after the setting is invalidated in the same tab', async () => {
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: false }));
+    const { client } = renderAll();
+    await waitFor(() => expect(valueText()).toBe('false'));
+
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: true }));
+    act(() => {
+      client().invalidateSetting(SETTING_ID);
+    });
+
+    await waitFor(() => expect(valueText()).toBe('true'));
+    expect(stateText()).toBe('ready');
+    expect(get).toHaveBeenCalledTimes(2);
+    // invalidation is broadcast to other tabs
+    expect(localStorage.getItem(SETTINGS_INVALIDATION_STORAGE_KEY)).toContain('Shesha.Security');
+  });
+
+  it('re-fetches the value after setSetting', async () => {
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: false }));
+    post.mockResolvedValue(ok(undefined));
+    const { client } = renderAll();
+    await waitFor(() => expect(valueText()).toBe('false'));
+
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: true }));
+    await act(async () => {
+      await client().setSetting(SETTING_ID, { useAutoLogoff: true });
+    });
+
+    await waitFor(() => expect(valueText()).toBe('true'));
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches the value when another tab invalidates the setting (storage event)', async () => {
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: false }));
+    renderAll();
+    await waitFor(() => expect(valueText()).toBe('false'));
+
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: true }));
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: SETTINGS_INVALIDATION_STORAGE_KEY,
+        newValue: `${SETTING_ID.module}/${SETTING_ID.name}/${Date.now()}`,
+      }));
+    });
+
+    await waitFor(() => expect(valueText()).toBe('true'));
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed requests', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    get.mockRejectedValueOnce(new Error('network'));
+    const { client } = renderAll();
+    await waitFor(() => expect(stateText()).toBe('failed'));
+
+    get.mockResolvedValueOnce(ok({ useAutoLogoff: true }));
+    act(() => {
+      client().invalidateSetting(SETTING_ID);
+    });
+
+    await waitFor(() => expect(valueText()).toBe('true'));
+    expect(get).toHaveBeenCalledTimes(2);
+    consoleError.mockRestore();
+  });
+});

--- a/shesha-reactjs/src/providers/settings/contexts.tsx
+++ b/shesha-reactjs/src/providers/settings/contexts.tsx
@@ -6,9 +6,20 @@ export interface ILoadSettingPayload {
   name: string;
 }
 
+export type SettingChangeListener = () => void;
+
 export interface ISettingsClientContext {
   getSetting: <TValue = unknown>(settingId: ISettingIdentifier) => Promise<TValue>;
   setSetting: <TValue = unknown>(settingId: ISettingIdentifier, value: TValue, applicationKey?: string) => Promise<void>;
+  /**
+   * Drop the cached value of the setting (in this tab and, via the `storage` event, in other tabs of the same origin)
+   * and notify subscribers so they re-fetch the value.
+   */
+  invalidateSetting: (settingId: ISettingIdentifier) => void;
+  /**
+   * Subscribe to invalidations of the specified setting. Returns an unsubscribe function.
+   */
+  subscribe: (settingId: ISettingIdentifier, listener: SettingChangeListener) => () => void;
 }
 
 export const SettingsClientContext = createNamedContext<ISettingsClientContext | undefined>(undefined, "SettingsClientContext");

--- a/shesha-reactjs/src/providers/settings/index.tsx
+++ b/shesha-reactjs/src/providers/settings/index.tsx
@@ -21,19 +21,33 @@ const SETTINGS_URLS = {
 export const SETTINGS_INVALIDATION_STORAGE_KEY = 'shesha:settings:invalidated';
 
 const INVALIDATION_MESSAGE_SEPARATOR = '/';
+const INVALIDATION_MESSAGE_PARTS = 3;
+
+let invalidationCounter = 0;
 
 /**
  * Encodes the setting identifier into the value written to localStorage.
- * A timestamp is appended so that repeated invalidations of the same setting still fire the `storage` event.
+ * A unique suffix (timestamp + counter) is appended so that repeated invalidations of the same setting,
+ * even within the same millisecond, still fire the `storage` event.
  */
 const encodeInvalidationMessage = (settingId: ISettingIdentifier): string => {
-  return [encodeURIComponent(settingId.module), encodeURIComponent(settingId.name), Date.now().toString()]
-    .join(INVALIDATION_MESSAGE_SEPARATOR);
+  invalidationCounter += 1;
+  return [
+    encodeURIComponent(settingId.module),
+    encodeURIComponent(settingId.name),
+    `${Date.now()}-${invalidationCounter}`,
+  ].join(INVALIDATION_MESSAGE_SEPARATOR);
 };
 
+/**
+ * Decodes the message written by `encodeInvalidationMessage`. Module-less settings have an empty module.
+ */
 const decodeInvalidationMessage = (message: string): ISettingIdentifier | undefined => {
-  const [module, name] = message.split(INVALIDATION_MESSAGE_SEPARATOR);
-  if (isNullOrWhiteSpace(module) || isNullOrWhiteSpace(name)) return undefined;
+  const parts = message.split(INVALIDATION_MESSAGE_SEPARATOR);
+  if (parts.length !== INVALIDATION_MESSAGE_PARTS) return undefined;
+
+  const [module = '', name = ''] = parts;
+  if (isNullOrWhiteSpace(name)) return undefined;
 
   return { module: decodeURIComponent(module), name: decodeURIComponent(name) };
 };

--- a/shesha-reactjs/src/providers/settings/index.tsx
+++ b/shesha-reactjs/src/providers/settings/index.tsx
@@ -1,20 +1,41 @@
 "use client";
 
-import { FC, PropsWithChildren, useContext, useEffect, useState } from 'react';
+import { FC, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { IErrorInfo } from '@/interfaces/errorInfo';
-import { ISettingsClientContext, SettingsClientContext } from './contexts';
+import { ISettingsClientContext, SettingChangeListener, SettingsClientContext } from './contexts';
 import { ISettingIdentifier, ISettingsDictionary } from './models';
 import { throwError } from '@/utils/errors';
 import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 import { HttpClientApi, useHttpClient } from '../sheshaApplication/publicApi';
 import { buildUrl } from '@/utils';
 import { extractAjaxResponse, IAjaxResponse } from '@/interfaces';
-import { settingIdentifiersEqual } from '@/utils/settings';
 import { UpdateSettingValueInput } from './api-models';
+import { getLocalStorage } from '@/utils/storage';
 
 const SETTINGS_URLS = {
   GET_VALUE: "/api/services/app/Settings/GetValue",
   SET_VALAUE: "/api/services/app/Settings/UpdateValue",
+};
+
+/** localStorage key used to propagate setting invalidations to other browser tabs */
+export const SETTINGS_INVALIDATION_STORAGE_KEY = 'shesha:settings:invalidated';
+
+const INVALIDATION_MESSAGE_SEPARATOR = '/';
+
+/**
+ * Encodes the setting identifier into the value written to localStorage.
+ * A timestamp is appended so that repeated invalidations of the same setting still fire the `storage` event.
+ */
+const encodeInvalidationMessage = (settingId: ISettingIdentifier): string => {
+  return [encodeURIComponent(settingId.module), encodeURIComponent(settingId.name), Date.now().toString()]
+    .join(INVALIDATION_MESSAGE_SEPARATOR);
+};
+
+const decodeInvalidationMessage = (message: string): ISettingIdentifier | undefined => {
+  const [module, name] = message.split(INVALIDATION_MESSAGE_SEPARATOR);
+  if (isNullOrWhiteSpace(module) || isNullOrWhiteSpace(name)) return undefined;
+
+  return { module: decodeURIComponent(module), name: decodeURIComponent(name) };
 };
 
 class SettingsClient implements ISettingsClientContext {
@@ -22,8 +43,11 @@ class SettingsClient implements ISettingsClientContext {
 
   #settings: ISettingsDictionary;
 
+  #listeners: Map<string, Set<SettingChangeListener>>;
+
   constructor(httpClient: HttpClientApi) {
     this.#settings = {};
+    this.#listeners = new Map();
     this.#httpClient = httpClient;
   }
 
@@ -38,6 +62,8 @@ class SettingsClient implements ISettingsClientContext {
     };
     const response = await this.#httpClient.post<IAjaxResponse<void>>(SETTINGS_URLS.SET_VALAUE, payload);
     extractAjaxResponse(response.data);
+
+    this.invalidateSetting(settingId);
   };
 
   getSetting = <TValue = unknown>(settingId: ISettingIdentifier): Promise<TValue> => {
@@ -47,7 +73,7 @@ class SettingsClient implements ISettingsClientContext {
     const key = this.makeFormLoadingKey(settingId);
 
     const loadedValue = this.#settings[key];
-    if (loadedValue) return loadedValue as Promise<TValue>; // TODO: check for rejection
+    if (loadedValue) return loadedValue as Promise<TValue>;
 
     const url = buildUrl(SETTINGS_URLS.GET_VALUE, { name: settingId.name, module: settingId.module });
     const settingPromise = this.#httpClient.get<IAjaxResponse<TValue>>(url).then((response) => {
@@ -56,7 +82,72 @@ class SettingsClient implements ISettingsClientContext {
 
     this.#settings[key] = settingPromise;
 
+    // don't keep failed requests in the cache, otherwise a transient error would stick for the whole session
+    settingPromise.catch(() => {
+      if (this.#settings[key] === settingPromise)
+        delete this.#settings[key];
+    });
+
     return settingPromise;
+  };
+
+  invalidateSetting = (settingId: ISettingIdentifier): void => {
+    this.#invalidateLocal(settingId);
+    this.#broadcastInvalidation(settingId);
+  };
+
+  subscribe = (settingId: ISettingIdentifier, listener: SettingChangeListener): (() => void) => {
+    const key = this.makeFormLoadingKey(settingId);
+    let listeners = this.#listeners.get(key);
+    if (!listeners) {
+      listeners = new Set();
+      this.#listeners.set(key, listeners);
+    }
+    listeners.add(listener);
+
+    return () => {
+      const current = this.#listeners.get(key);
+      if (!current) return;
+      current.delete(listener);
+      if (current.size === 0)
+        this.#listeners.delete(key);
+    };
+  };
+
+  /**
+   * Handles `storage` events fired when another tab invalidates a setting
+   */
+  handleStorageEvent = (e: StorageEvent): void => {
+    if (e.key !== SETTINGS_INVALIDATION_STORAGE_KEY || isNullOrWhiteSpace(e.newValue)) return;
+
+    const settingId = decodeInvalidationMessage(e.newValue);
+    if (!settingId) return;
+
+    this.#invalidateLocal(settingId);
+  };
+
+  #invalidateLocal = (settingId: ISettingIdentifier): void => {
+    const key = this.makeFormLoadingKey(settingId);
+    delete this.#settings[key];
+
+    const listeners = this.#listeners.get(key);
+    if (!listeners) return;
+    // copy to allow listeners to unsubscribe while iterating
+    [...listeners].forEach((listener) => {
+      try {
+        listener();
+      } catch (err) {
+        console.error('Setting change listener failed', err);
+      }
+    });
+  };
+
+  #broadcastInvalidation = (settingId: ISettingIdentifier): void => {
+    try {
+      getLocalStorage()?.setItem(SETTINGS_INVALIDATION_STORAGE_KEY, encodeInvalidationMessage(settingId));
+    } catch (err) {
+      console.error('Failed to broadcast setting invalidation', err);
+    }
   };
 
   makeFormLoadingKey = (payload: ISettingIdentifier): string => {
@@ -67,9 +158,19 @@ class SettingsClient implements ISettingsClientContext {
 
 const SettingsProvider: FC<PropsWithChildren> = ({ children }) => {
   const httpClient = useHttpClient();
-  const [settingsClient] = useState<ISettingsClientContext>(() => {
+  const [settingsClient] = useState<SettingsClient>(() => {
     return new SettingsClient(httpClient);
   });
+
+  // cross-tab propagation of setting invalidations
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    window.addEventListener('storage', settingsClient.handleStorageEvent);
+    return () => {
+      window.removeEventListener('storage', settingsClient.handleStorageEvent);
+    };
+  }, [settingsClient]);
 
   return <SettingsClientContext.Provider value={settingsClient}>{children}</SettingsClientContext.Provider>;
 };
@@ -88,24 +189,68 @@ export interface SettingValueLoadingState<TValue = unknown> {
   error?: IErrorInfo | undefined;
 }
 
+/**
+ * Loads the value of the specified setting and keeps it up to date:
+ * the value is re-fetched whenever the setting is invalidated (e.g. saved in the settings editor,
+ * in this tab or in another tab of the same origin).
+ * The previous value is kept while the new one is loading.
+ */
+interface SettingValueInternalState<TValue> {
+  settingId: ISettingIdentifier;
+  status: 'waiting' | 'ready' | 'failed';
+  /** version of the setting the state corresponds to, see `version` in the hook */
+  version: number;
+  value?: TValue | undefined;
+  error?: IErrorInfo | undefined;
+}
+
 const useSettingValue = <TValue = unknown>(settingId: ISettingIdentifier): SettingValueLoadingState<TValue> => {
   const settings = useSettings();
-  const [state, setState] = useState<SettingValueLoadingState<TValue>>({ loadingState: 'waiting', settingId });
+  const { module, name } = settingId;
+  const [state, setState] = useState<SettingValueInternalState<TValue>>({ settingId, status: 'waiting', version: -1 });
+  // incremented on every invalidation of the setting to trigger re-fetch
+  const [version, setVersion] = useState(0);
 
   useEffect(() => {
-    if (settingIdentifiersEqual(state.settingId, settingId) && state.loadingState !== 'waiting')
-      return;
+    return settings.subscribe({ module, name }, () => {
+      setVersion((prev) => prev + 1);
+    });
+  }, [settings, module, name]);
 
-    settings.getSetting<TValue>(settingId)
+  useEffect(() => {
+    let active = true;
+    const id: ISettingIdentifier = { module, name };
+
+    settings.getSetting<TValue>(id)
       .then((response) => {
-        setState((prev) => ({ ...prev, error: undefined, value: response, loadingState: 'ready' }));
+        if (!active) return;
+        setState({ settingId: id, status: 'ready', version, value: response, error: undefined });
       })
       .catch((error) => {
         console.error('Failed to fetch setting value', error);
+        if (!active) return;
+        setState((prev) => ({ ...prev, settingId: id, status: 'failed', version }));
       });
-  }, [settingId, settings, state.loadingState, state.settingId]);
 
-  return state;
+    return () => {
+      active = false;
+    };
+  }, [settings, module, name, version]);
+
+  return useMemo<SettingValueLoadingState<TValue>>(() => {
+    const isCurrent = state.version === version && state.settingId.module === module && state.settingId.name === name;
+    const loadingState: LoadingState = isCurrent
+      ? state.status
+      : state.status === 'waiting' ? 'waiting' : 'loading';
+
+    // note: the previous value is kept while a new one is loading
+    return {
+      settingId: state.settingId,
+      loadingState,
+      value: state.value,
+      error: state.error,
+    };
+  }, [state, version, module, name]);
 };
 
 export { SettingsProvider, useSettingValue, useSettings, useSettingsOrUndefined };


### PR DESCRIPTION
https://github.com/shesha-io/shesha-framework/issues/1433
The frontend SettingsClient cached every setting value for the lifetime of the SPA with no invalidation. The settings editor saved through its own HTTP call and logout/login is a client-side redirect, so the idle timer kept reading the stale `Shesha.Security` value until a hard page reload. Enabling auto logoff (or changing its timeout) therefore appeared to do nothing.

- add `invalidateSetting` / `subscribe` to the settings client; `setSetting` invalidates after saving and invalidations are propagated to other tabs via a `storage` event
- `useSettingValue` re-fetches when its setting is invalidated and keeps the previous value while reloading
- stop caching failed setting requests for the whole session
- settings editor invalidates the saved setting after a successful save
- add tests for the idle timer (real react-idle-timer with fake timers) and for the settings provider cache invalidation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Settings changes now refresh automatically in the current tab and across other open tabs.
  - Updated setting values appear without requiring a full page reload.
  - Setting loads now report failures clearly and can retry after an error.

- **Bug Fixes**
  - Resolved stale cached settings after values are updated or invalidated.
  - Improved settings synchronization between browser tabs.

- **Tests**
  - Added coverage for idle timeout warnings, logout behavior, disabled auto-logoff, and settings caching and refresh scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->