### PR TITLE
(feat) default and fallback typeface to 'Inter Variable'

### DIFF
--- a/shesha-reactjs/src/components/dataTable/index.tsx
+++ b/shesha-reactjs/src/components/dataTable/index.tsx
@@ -44,6 +44,7 @@ import { DataTableColumn, IShaDataTableProps, OnSaveHandler, OnSaveSuccessHandle
 import { ValueRenderer } from '../valueRenderer/index';
 import { IBorderValue } from '@/designer-components/_settings/utils/border/interfaces';
 import { IShadowValue } from '@/designer-components/_settings/utils/shadow/interfaces';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 import { isEqual } from 'lodash';
 import { Collapse, Typography } from 'antd';
 import { RowsReorderPayload } from '@/providers/dataTable/repository/interfaces';
@@ -212,7 +213,7 @@ export const DataTable: FC<Partial<IIndexTableProps>> = ({
   const appContext = useAvailableConstantsData();
 
   // Compute effective header font values with backward compatibility
-  const effectiveHeaderFontFamily = headerFont?.type ?? headerFontFamily;
+  const effectiveHeaderFontFamily = withFontFallback(headerFont?.type ?? headerFontFamily);
   const effectiveHeaderFontSize = headerFont?.size ? `${headerFont.size}px` : headerFontSize;
   const effectiveHeaderFontWeight = headerFont?.weight ?? headerFontWeight;
   const effectiveHeaderTextColor = headerFont?.color ?? headerTextColor;

--- a/shesha-reactjs/src/components/entityPicker/modal.tsx
+++ b/shesha-reactjs/src/components/entityPicker/modal.tsx
@@ -22,6 +22,7 @@ import { DataTable } from '../dataTable';
 import DataTableProvider from '@/providers/dataTable';
 import { ITableRowData } from '@/providers/dataTable/interfaces';
 import { isDefined, isNotNullOrWhiteSpace } from '@/utils/nullables';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 import { isNonEmptyArray } from '@/utils/array';
 import { IEntityReferenceDto } from '@/interfaces';
 
@@ -52,7 +53,7 @@ const EntityPickerModalInternal = (props: IEntityPickerModalProps): React.JSX.El
   const { styles } = useStyles(props.styleValue);
 
   const headerTextColor = props.styleValue?.font?.color ?? props.styleValue?.styleCss?.color;
-  const headerFontFamily = props.styleValue?.font?.type ?? props.styleValue?.styleCss?.fontFamily;
+  const headerFontFamily = withFontFallback(props.styleValue?.font?.type ?? props.styleValue?.styleCss?.fontFamily);
   const [modalId] = useState(nanoid()); // use generated value because formId was changed. to be reviewed
   const [state, setState] = useState<IEntityPickerState>({ showModal: true });
   const hidePickerDialog = (): void => {

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -3,7 +3,7 @@ import { addPx } from '@/utils/style';
 import { CSSProperties } from 'react';
 import { CSSInterpolation } from '@emotion/serialize';
 import { isDefined } from '@/utils/nullables';
-import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
+import { DEFAULT_FONT_FAMILY, withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 interface ModelProps {
   layout?: boolean | undefined;
@@ -72,7 +72,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     backgroundColor,
     borderStyle = 'solid',
     color,
-    fontFamily = withFontFallback('Segoe UI'),
+    fontFamily: fontFamilyProp,
     fontSize = '25px',
     fontWeight = '400',
     height,
@@ -81,6 +81,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     textAlign = 'left',
   } = style || {};
 
+  const fontFamily = withFontFallback(fontFamilyProp ?? 'Segoe UI') ?? DEFAULT_FONT_FAMILY;
   const { layout: layoutProp, isDragger, hideFileName, listType } = model;
   /**
    * First of the candidates that is actually set. CSS values treat an empty string as "not set", so

--- a/shesha-reactjs/src/components/fileUpload/styles/styles.ts
+++ b/shesha-reactjs/src/components/fileUpload/styles/styles.ts
@@ -3,6 +3,7 @@ import { addPx } from '@/utils/style';
 import { CSSProperties } from 'react';
 import { CSSInterpolation } from '@emotion/serialize';
 import { isDefined } from '@/utils/nullables';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 interface ModelProps {
   layout?: boolean | undefined;
@@ -71,7 +72,7 @@ export const useStyles = createStyles<FileUploadStylesParams, FileUploadStylesRe
     backgroundColor,
     borderStyle = 'solid',
     color,
-    fontFamily = 'Segoe UI',
+    fontFamily = withFontFallback('Segoe UI'),
     fontSize = '25px',
     fontWeight = '400',
     height,

--- a/shesha-reactjs/src/components/kanban/styles/styles.ts
+++ b/shesha-reactjs/src/components/kanban/styles/styles.ts
@@ -1,6 +1,7 @@
 import { addPx } from '@/utils/style';
 import { createStyles } from '@/styles';
 import { CSSProperties } from 'react';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 type StylesArgs = {
   isCollapsed?: boolean;
@@ -38,7 +39,7 @@ export const useStyles = createStyles(({ css, cx, prefixCls }, { isCollapsed, di
       color: ${fontStyles?.color || '#000000'};
       font-size: ${fontStyles?.fontSize || '15px'};
       font-weight: ${fontStyles?.fontWeight || '400'};
-      font-family: ${fontStyles?.fontFamily || 'Arial'};
+      font-family: ${fontStyles?.fontFamily || withFontFallback('Arial')};
       padding: 15px 15px;
       transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
       text-align: center;

--- a/shesha-reactjs/src/components/sectionSeparator/utils.ts
+++ b/shesha-reactjs/src/components/sectionSeparator/utils.ts
@@ -1,3 +1,4 @@
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 export const strings = {
   tooltip: 'You can use any unit (%, px, em, etc). px by default if without unit',
@@ -8,6 +9,6 @@ export const titleDefaultStyles = (): React.CSSProperties => {
     fontWeight: '500',
     fontSize: 14,
     color: '#000',
-    fontFamily: 'Segoe UI',
+    fontFamily: withFontFallback('Segoe UI'),
   };
 };

--- a/shesha-reactjs/src/components/tablePager/style.ts
+++ b/shesha-reactjs/src/components/tablePager/style.ts
@@ -2,6 +2,7 @@ import { createStyles } from '@/styles';
 import { ITablePagerBaseProps } from './tablePaging';
 import { isDefined, isNullOrWhiteSpace } from '@/utils';
 import { fontStyles, marginStyles, paddingStyles } from '@/designer-components/_common/styles/utils';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 export const useStyles = createStyles(({ css, cx, prefixCls }, model: Pick<ITablePagerBaseProps, 'font' | 'stylingBoxJson'>) => {
   const pagination = `${prefixCls}-pagination`;
@@ -77,7 +78,7 @@ export const useStyles = createStyles(({ css, cx, prefixCls }, model: Pick<ITabl
       * {
           ${isNullOrWhiteSpace(model.font?.color) ? '' : `--ant-color-text : ${model.font.color};`}
           ${isDefined(model.font?.size) ? `--ant-font-size : ${model.font.size};` : ''}
-          ${isNullOrWhiteSpace(model.font?.type) ? '' : `--ant-font-family : ${model.font.type};`}
+          ${isNullOrWhiteSpace(model.font?.type) ? '' : `--ant-font-family : ${withFontFallback(model.font.type)};`}
           ${fontStyles(model.font)}
       }
   `);

--- a/shesha-reactjs/src/designer-components/_common/styles/utils.ts
+++ b/shesha-reactjs/src/designer-components/_common/styles/utils.ts
@@ -3,6 +3,7 @@ import { IConfigurableFormComponent, IStyleValue, StyleBoxValue } from "../../..
 import { addPx, hasNumber } from "@/utils/style";
 import { StringBuilder } from "@/utils";
 import { isDefined, isNullOrWhiteSpace } from "@/utils/nullables";
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 import { CSSProperties } from "react";
 
 /** Properties that are unitless in CSS, so a bare number must not gain a `px` suffix. */
@@ -269,7 +270,7 @@ export const fontStyles = (model: IFontValue | undefined, customStyle?: CSSPrope
   const color = !isNullOrWhiteSpace(custom.color) ? custom.color : model?.color;
   const size = isDefined(custom.fontSize) ? custom.fontSize : (isDefined(model?.size) ? model.size : undefined);
   const weight = isDefined(custom.fontWeight) ? custom.fontWeight : model?.weight;
-  const family = !isNullOrWhiteSpace(custom.fontFamily) ? custom.fontFamily : model?.type;
+  const family = withFontFallback(!isNullOrWhiteSpace(custom.fontFamily) ? custom.fontFamily : model?.type);
   const align = isDefined(custom.textAlign) ? custom.textAlign : model?.align;
 
   if (!isNullOrWhiteSpace(color)) sb.append(`color: ${color};`);

--- a/shesha-reactjs/src/designer-components/_settings/utils/font/utils.test.ts
+++ b/shesha-reactjs/src/designer-components/_settings/utils/font/utils.test.ts
@@ -1,0 +1,28 @@
+import { getFontStyle, withFontFallback } from './utils';
+
+describe('withFontFallback', () => {
+  it('appends the bundled Inter fallback to a configured family', () => {
+    expect(withFontFallback('Segoe UI')).toBe("Segoe UI, 'Inter Variable', sans-serif");
+  });
+
+  it('does not double up when the family already ends in Inter', () => {
+    expect(withFontFallback("'Inter Variable', sans-serif")).toBe("'Inter Variable', sans-serif");
+    expect(withFontFallback('Inter Variable')).toBe('Inter Variable');
+  });
+
+  it('returns undefined for an empty family', () => {
+    expect(withFontFallback(undefined)).toBeUndefined();
+    expect(withFontFallback(null)).toBeUndefined();
+    expect(withFontFallback('   ')).toBeUndefined();
+  });
+});
+
+describe('getFontStyle', () => {
+  it('emits the font family with the Inter fallback', () => {
+    expect(getFontStyle({ type: 'Arial' }).fontFamily).toBe("Arial, 'Inter Variable', sans-serif");
+  });
+
+  it('omits fontFamily when no type is configured', () => {
+    expect(getFontStyle({ size: 12 })).not.toHaveProperty('fontFamily');
+  });
+});

--- a/shesha-reactjs/src/designer-components/_settings/utils/font/utils.test.ts
+++ b/shesha-reactjs/src/designer-components/_settings/utils/font/utils.test.ts
@@ -17,6 +17,11 @@ describe('withFontFallback', () => {
       .toBe("-apple-system, BlinkMacSystemFont, Segoe UI, 'Inter Variable', sans-serif");
   });
 
+  it('leaves an explicitly chosen generic family in first place', () => {
+    expect(withFontFallback('monospace')).toBe('monospace');
+    expect(withFontFallback('serif, Georgia')).toBe('serif, Georgia');
+  });
+
   it('returns undefined for an empty family', () => {
     expect(withFontFallback(undefined)).toBeUndefined();
     expect(withFontFallback(null)).toBeUndefined();

--- a/shesha-reactjs/src/designer-components/_settings/utils/font/utils.test.ts
+++ b/shesha-reactjs/src/designer-components/_settings/utils/font/utils.test.ts
@@ -10,6 +10,13 @@ describe('withFontFallback', () => {
     expect(withFontFallback('Inter Variable')).toBe('Inter Variable');
   });
 
+  it('inserts Inter ahead of a generic family so it is tried before the browser default', () => {
+    expect(withFontFallback('Arial, sans-serif')).toBe("Arial, 'Inter Variable', sans-serif");
+    expect(withFontFallback('Courier New, monospace')).toBe("Courier New, 'Inter Variable', monospace");
+    expect(withFontFallback('-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif'))
+      .toBe("-apple-system, BlinkMacSystemFont, Segoe UI, 'Inter Variable', sans-serif");
+  });
+
   it('returns undefined for an empty family', () => {
     expect(withFontFallback(undefined)).toBeUndefined();
     expect(withFontFallback(null)).toBeUndefined();

--- a/shesha-reactjs/src/designer-components/_settings/utils/font/utils.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/utils/font/utils.tsx
@@ -15,6 +15,8 @@ export const withFontFallback = (family: string | null | undefined): string | un
   const parts = trimmed.split(',').map((p) => p.trim()).filter((p) => p !== '');
   const genericIdx = parts.findIndex((p) => GENERIC_FAMILY.test(p));
   if (genericIdx < 0) return `${trimmed}, ${DEFAULT_FONT_FAMILY}`;
+  // A stack that starts with a generic family (e.g. a deliberate `monospace`) is an explicit choice, not a fallback.
+  if (genericIdx === 0) return trimmed;
   parts.splice(genericIdx, 0, "'Inter Variable'");
   return parts.join(', ');
 };

--- a/shesha-reactjs/src/designer-components/_settings/utils/font/utils.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/utils/font/utils.tsx
@@ -5,11 +5,18 @@ import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
 // Bundled and self-hosted, so the default look is identical on every OS.
 export const DEFAULT_FONT_FAMILY = "'Inter Variable', sans-serif";
 
-/** Appends the bundled Inter fallback so a font the OS lacks (e.g. Segoe UI on macOS) degrades to Inter, not the browser default. */
+const GENERIC_FAMILY = /^(serif|sans-serif|monospace|cursive|fantasy|system-ui|ui-[a-z-]+|emoji|math|fangsong)$/i;
+
+/** Inserts the bundled Inter fallback ahead of any generic family, so a font the OS lacks (e.g. Segoe UI on macOS) degrades to Inter, not the browser default. */
 export const withFontFallback = (family: string | null | undefined): string | undefined => {
   if (isNullOrWhiteSpace(family)) return undefined;
   const trimmed = family.trim();
-  return trimmed.includes('Inter Variable') ? trimmed : `${trimmed}, ${DEFAULT_FONT_FAMILY}`;
+  if (trimmed.includes('Inter Variable')) return trimmed;
+  const parts = trimmed.split(',').map((p) => p.trim()).filter((p) => p !== '');
+  const genericIdx = parts.findIndex((p) => GENERIC_FAMILY.test(p));
+  if (genericIdx < 0) return `${trimmed}, ${DEFAULT_FONT_FAMILY}`;
+  parts.splice(genericIdx, 0, "'Inter Variable'");
+  return parts.join(', ');
 };
 
 export const getFontStyle = (input?: IFontValue): CSSProperties => {

--- a/shesha-reactjs/src/designer-components/_settings/utils/font/utils.tsx
+++ b/shesha-reactjs/src/designer-components/_settings/utils/font/utils.tsx
@@ -1,6 +1,16 @@
 import { CSSProperties } from 'react';
 import { IFontValue } from './interfaces';
-import { isDefined } from '@/utils/nullables';
+import { isDefined, isNullOrWhiteSpace } from '@/utils/nullables';
+
+// Bundled and self-hosted, so the default look is identical on every OS.
+export const DEFAULT_FONT_FAMILY = "'Inter Variable', sans-serif";
+
+/** Appends the bundled Inter fallback so a font the OS lacks (e.g. Segoe UI on macOS) degrades to Inter, not the browser default. */
+export const withFontFallback = (family: string | null | undefined): string | undefined => {
+  if (isNullOrWhiteSpace(family)) return undefined;
+  const trimmed = family.trim();
+  return trimmed.includes('Inter Variable') ? trimmed : `${trimmed}, ${DEFAULT_FONT_FAMILY}`;
+};
 
 export const getFontStyle = (input?: IFontValue): CSSProperties => {
   if (!input) return {};
@@ -14,8 +24,9 @@ export const getFontStyle = (input?: IFontValue): CSSProperties => {
     }
   }
 
-  if (isDefined(input.type)) {
-    style.fontFamily = input.type;
+  const family = withFontFallback(input.type);
+  if (isDefined(family)) {
+    style.fontFamily = family;
   }
 
   if (isDefined(input.weight)) {

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/attachmentsEditor.tsx
@@ -26,6 +26,7 @@ import { isEntityTypeIdEmpty } from '@/providers/metadataDispatcher/entities/uti
 import { AdvancedFormats } from '@/interfaces/dataTypes';
 import { FILE_EVENTS_WITHOUT_CHANGE, getComponentEvents } from '../_common/events';
 import { isDefined, isNotNullOrWhiteSpace, isNullOrWhiteSpace } from '@/utils/nullables';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 import { getIdOrUndefined } from '@/utils/entity';
 import { addPx } from '@/utils/style';
 import CustomFile from '@/components/customFile';
@@ -250,7 +251,7 @@ const AttachmentsEditor: AttachmentsEditorComponentDefinition = {
           ...(isNotNullOrWhiteSpace(font?.color) ? { color: font.color } : {}),
           ...(isDefined(font?.size) ? { fontSize: addPx(font.size) } : {}),
           ...(isNotNullOrWhiteSpace(font?.weight) ? { fontWeight: font.weight as CSSProperties['fontWeight'] } : {}),
-          ...(isNotNullOrWhiteSpace(font?.type) ? { fontFamily: font.type } : {}),
+          ...(isNotNullOrWhiteSpace(font?.type) ? { fontFamily: withFontFallback(font.type) } : {}),
           ...(isDefined(font?.align) ? { textAlign: font.align } : {}),
           ...downloadedFileStyleCss,
         };

--- a/shesha-reactjs/src/designer-components/attachmentsEditor/styles.ts
+++ b/shesha-reactjs/src/designer-components/attachmentsEditor/styles.ts
@@ -3,6 +3,7 @@ import { createStyles } from '@/styles';
 import { IAttachmentsEditorProps } from './interfaces';
 import { fontStyles } from '../_common/styles/utils';
 import { isNotNullOrWhiteSpace } from '@/utils/nullables';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 /**
  * The evaluated nested Custom styles. The framework only executes the root `model.style` into
@@ -100,7 +101,7 @@ export const useStyles = createStyles((
      follows the configured font family. */
   const previewMask = cx('sha-file-list-preview', css`
     &&& .${prefixCls}-image-preview-operations {
-      ${isNotNullOrWhiteSpace(model.font?.type) ? `font-family: ${model.font.type};` : ''}
+      ${isNotNullOrWhiteSpace(model.font?.type) ? `font-family: ${withFontFallback(model.font.type)};` : ''}
     }
   `);
 

--- a/shesha-reactjs/src/designer-components/dataTable/table/tableWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableWrapper.tsx
@@ -128,7 +128,7 @@ export const TableWrapper: FC<TableWrapperProps> = (props) => {
 
   // Compute effective header font values with backward compatibility
   const effectiveHeaderFontFamily = useMemo(() => {
-    return props.headerFont?.type ?? props.headerFontFamily;
+    return withFontFallback(props.headerFont?.type ?? props.headerFontFamily);
   }, [props.headerFont?.type, props.headerFontFamily]);
 
   const effectiveHeaderFontSize = useMemo(() => {

--- a/shesha-reactjs/src/designer-components/dataTable/table/tableWrapper.tsx
+++ b/shesha-reactjs/src/designer-components/dataTable/table/tableWrapper.tsx
@@ -5,6 +5,7 @@ import { getStyle } from '@/providers/form/utils';
 import { ITableComponentProps } from './models';
 import { useFormComponentStyles } from '@/hooks/formComponentHooks';
 import { getShadowStyle } from '@/designer-components/_settings/utils/shadow/utils';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 import { getBackgroundImageUrl, getBackgroundStyle } from '@/designer-components/_settings/utils/background/utils';
 import { SidebarContainer } from '@/components/sidebarContainer';
 import { DataTable } from '@/components/dataTable';
@@ -225,7 +226,7 @@ export const TableWrapper: FC<TableWrapperProps> = (props) => {
 
   const { styles } = useStyles({
     // Use resolved font styles from allStyles to properly handle device-specific styling
-    fontFamily: allStyles.fontStyles.fontFamily ?? props.font?.type,
+    fontFamily: allStyles.fontStyles.fontFamily ?? withFontFallback(props.font?.type),
     fontWeight: allStyles.fontStyles.fontWeight ?? props.font?.weight,
     textAlign: allStyles.fontStyles.textAlign ?? props.font?.align,
     color: allStyles.fontStyles.color ?? props.font?.color,
@@ -550,7 +551,7 @@ export const TableWrapper: FC<TableWrapperProps> = (props) => {
             headerShadow={props.headerShadow}
             rowShadow={props.rowShadow}
             rowDividers={props.rowDividers}
-            bodyFontFamily={allStyles.fontStyles.fontFamily ?? props.font?.type as string}
+            bodyFontFamily={allStyles.fontStyles.fontFamily ?? withFontFallback(props.font?.type)}
             bodyFontSize={allStyles.fontStyles.fontSize
               ? (allStyles.fontStyles.fontSize as string)
               : (props.font?.size ? `${props.font.size}px` : undefined)}

--- a/shesha-reactjs/src/designer-components/horizontalMenu/index.tsx
+++ b/shesha-reactjs/src/designer-components/horizontalMenu/index.tsx
@@ -15,6 +15,7 @@ import { migratePrevStyles } from "../_common-migrations/migrateStyles";
 import Editor from "./modal";
 import { getSettings } from "./settings";
 import { defaultStyles } from "./utils";
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 interface IMenuListProps extends IConfigurableFormComponent, ILayoutColor {
   items?: ItemType[];
@@ -128,7 +129,7 @@ export const MenuListComponent: IToolboxComponent<IMenuListProps> = {
     const finalFontStyles = useMemo(() => {
       return {
         fontSize: model.font?.size ? `${model.font.size}px` : `${fontSize}px`,
-        fontFamily: model.font?.type,
+        fontFamily: withFontFallback(model.font?.type),
         fontWeight: model.font?.weight as CSSProperties['fontWeight'],
         color: model.font?.color,
         textAlign: model.font?.align as CSSProperties['textAlign'],

--- a/shesha-reactjs/src/designer-components/profileDropdown/index.tsx
+++ b/shesha-reactjs/src/designer-components/profileDropdown/index.tsx
@@ -32,6 +32,7 @@ import { useGlobalState } from '@/providers/globalState';
 import { useSheshaApplication } from '@/providers/sheshaApplication';
 import { ConfigurableForm } from '@/components/configurableForm';
 import { isDefined } from '@/utils/nullables';
+import { withFontFallback } from '@/designer-components/_settings/utils/font/utils';
 
 interface IProfileDropdown extends IConfigurableFormComponent {
   items?: IButtonGroupItemBase[];
@@ -86,7 +87,7 @@ const ProfileDropdown: IToolboxComponent<IProfileDropdown> = {
       color: subTextColor,
       fontSize: subTextFontSize,
       fontWeight: subTextFontWeight,
-      fontFamily: subTextFontFamily,
+      fontFamily: withFontFallback(subTextFontFamily),
       textAlign: subTextTextAlign,
       ...getStyle(subTextStyle, formData, globalState),
     };

--- a/shesha-reactjs/src/providers/theme/index.tsx
+++ b/shesha-reactjs/src/providers/theme/index.tsx
@@ -6,16 +6,13 @@ import { IConfigurableTheme, IThemeActionsContext, IThemeStateContext, THEME_CON
 import { defaultRequiredMark } from './shaRequiredMark';
 import { useSettings, useSheshaApplication } from '..';
 import { isNotNullOrWhiteSpace } from '@/utils/nullables';
+import { DEFAULT_FONT_FAMILY } from '@/designer-components/_settings/utils/font/utils';
 
 export interface ThemeProviderProps {
   prefixCls?: string;
   iconPrefixCls?: string;
   themeConfigKey?: string;
 }
-
-// Bundled and self-hosted (not a system font) so the default look is identical on every OS,
-// instead of resolving to whatever native UI font each OS happens to ship.
-const DEFAULT_FONT_FAMILY = "'Inter Variable', sans-serif";
 
 const ThemeProvider: FC<PropsWithChildren<ThemeProviderProps>> = ({
   children,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved font handling across entity pickers, file uploads, kanban boards, section separators, table pagers, data tables, menus, profile dropdowns, attachment previews, and other styled components.
  - Configured fonts now consistently receive an Inter fallback, while blank or missing font settings are handled gracefully.
  - Prevented duplicate fallback fonts when Inter is already configured.
  - Preserved intentionally selected generic font families without unnecessary fallback changes.

- **Tests**
  - Added coverage for configured, blank, missing, duplicate, and generic font fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->