### PR TITLE
Fix container migrations; groupButtons iconOny

### DIFF
--- a/shesha-reactjs/src/designer-components/button/buttonGroup/renderButton.tsx
+++ b/shesha-reactjs/src/designer-components/button/buttonGroup/renderButton.tsx
@@ -25,7 +25,7 @@ export const RenderButton: FC<IRenderButtonProps> = ({ props, buttonComponent: t
     </>
   ), [props.label, props.downIcon]);
 
-  const isIconOnly = !isDefined(props.label) || (typeof props.label === 'string' && isNullOrWhiteSpace(props.label));
+  const isIconOnly = props.itemType === 'item' && props.buttonType === 'link' && (!isDefined(props.label) || (typeof props.label === 'string' && isNullOrWhiteSpace(props.label)));
 
   return (
     <div className={shaComponentStyles.shaComponent}>

--- a/shesha-reactjs/src/designer-components/container/containerComponent.tsx
+++ b/shesha-reactjs/src/designer-components/container/containerComponent.tsx
@@ -120,7 +120,38 @@ const ContainerComponent: ContainerComponentDefinition = {
       };
     })
     .add<IContainerComponentProps>(7, (prev, ctx) => ctx.isNew === true ? prev : { ...prev, ...migratePrevStyles(prev, defaultStyles(prev)) })
-    .add<IContainerComponentProps>(8, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(migrateStylingBoxToJson(prev)))),
+    .add<IContainerComponentProps>(8, (prev) => migratePermissionsToVisiblePermissions(migrateHiddenToVisible(migrateStylingBoxToJson(prev))))
+    // fix wrong migrations (Thulasizwe changed old migrations and this lead to skip migrations for some forms)
+    // 5b13f3ad518763c7f67527a98e5686c990bc7abf
+    // e8a8cb8eaf1f72c765a767881f137f5cf5d622e6
+    // c202d0260d1522c3a715640a901b411b6dd73da1
+    .add<IContainerComponentPropsV0>(9, (prev, ctx) => {
+      if (ctx.isNew === true) return prev;
+
+      const flexAndGridStyles: Omit<ICommonContainerPropsV0, 'style'> = {
+        display: prev.display,
+        flexDirection: prev.flexDirection,
+        direction: prev.direction,
+        justifyContent: prev.justifyContent,
+        alignItems: prev.alignItems,
+        alignSelf: prev.alignSelf,
+        justifySelf: prev.justifySelf,
+        justifyItems: prev.justifyItems,
+        textJustify: prev.textJustify,
+        noDefaultStyling: prev.noDefaultStyling,
+        gridColumnsCount: prev.gridColumnsCount,
+        flexWrap: prev.flexWrap,
+        gap: prev.gap,
+        overflow: prev.overflow,
+      };
+
+      return {
+        ...prev,
+        desktop: { ...flexAndGridStyles, ...prev.desktop },
+        tablet: { ...flexAndGridStyles, ...prev.tablet },
+        mobile: { ...flexAndGridStyles, ...prev.mobile },
+      };
+    }),
 };
 
 export const isContainerComponent = (component: IConfigurableFormComponent): component is IContainerComponentProps => component.type === ContainerComponent.type;

--- a/shesha-reactjs/src/designer-components/container/data.ts
+++ b/shesha-reactjs/src/designer-components/container/data.ts
@@ -227,6 +227,6 @@ export const defaultStyles = (prev?: IContainerComponentPropsV0): IStyleValue & 
     justifySelf: justifySelf ?? "normal",
     noDefaultStyling: noDefaultStyling ?? false,
     gridColumnsCount: gridColumnsCount ?? undefined,
-    gap: gap ?? '8px',
+    gap: gap,
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button styling so icon-only treatment applies only to eligible link buttons without a visible label.
  * Preserved responsive container layout settings across desktop, tablet, and mobile configurations during migration.
  * Prevented an automatic 8px default gap from being applied when no gap value is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->