### PR TITLE
fix(utils): format the whole ISO date-time in formatDateStringAndPrefix

### DIFF
--- a/shesha-reactjs/src/utils/formatting.test.ts
+++ b/shesha-reactjs/src/utils/formatting.test.ts
@@ -1,0 +1,33 @@
+import { formatDateStringAndPrefix } from './formatting';
+
+describe('formatDateStringAndPrefix', () => {
+  it('formats an ISO date-time without leaving the time behind', () => {
+    expect(formatDateStringAndPrefix('2004-12-01T00:00:00', 'DD/MM/YYYY')).toBe('01/12/2004');
+  });
+
+  it('formats an ISO date-time into a format that keeps the time', () => {
+    expect(formatDateStringAndPrefix('2004-12-01T09:05:30', 'DD/MM/YYYY HH:mm')).toBe('01/12/2004 09:05');
+  });
+
+  it('formats an ISO date-time embedded in surrounding text', () => {
+    expect(formatDateStringAndPrefix('Created 2004-12-01T00:00:00 by admin', 'DD/MM/YYYY')).toBe('Created 01/12/2004 by admin');
+  });
+
+  it('uses DD/MM/YYYY when no format is supplied', () => {
+    expect(formatDateStringAndPrefix('2004-12-01T00:00:00')).toBe('01/12/2004');
+  });
+
+  it('formats a compact date-time', () => {
+    expect(formatDateStringAndPrefix('20041201T090530', 'DD/MM/YYYY HH:mm')).toBe('01/12/2004 09:05');
+  });
+
+  it('formats a date without a time part', () => {
+    expect(formatDateStringAndPrefix('2004-12-01', 'DD/MM/YYYY')).toBe('01/12/2004');
+    expect(formatDateStringAndPrefix('01-12-2004', 'YYYY-MM-DD')).toBe('2004-12-01');
+  });
+
+  it('leaves text without a date untouched', () => {
+    expect(formatDateStringAndPrefix('no date here', 'DD/MM/YYYY')).toBe('no date here');
+    expect(formatDateStringAndPrefix('')).toBe('');
+  });
+});

--- a/shesha-reactjs/src/utils/formatting.ts
+++ b/shesha-reactjs/src/utils/formatting.ts
@@ -38,9 +38,11 @@ const formatDate = (dateText: string, targetFormat: string): string => {
 };
 
 export const formatDateStringAndPrefix = (content: string, dateFormat: string = DATE_TIME_FORMATS.date): string => {
-  // Match any date-like pattern
+  // Match any date-like pattern.
+  // Date-time alternatives come first: alternation is leftmost-first, so a date-only
+  // alternative placed ahead of them consumes the date and leaves the time in the output.
   const datePattern =
-    /\d{2}[-/]\d{2}[-/]\d{4}|\d{4}[-/]\d{2}[-/]\d{2}|\d{4}\d{2}\d{2}T\d{6}|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/g;
+    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}|\d{4}\d{2}\d{2}T\d{6}|\d{2}[-/]\d{2}[-/]\d{4}|\d{4}[-/]\d{2}[-/]\d{2}/g;
 
   return !isNullOrWhiteSpace(content)
     ? content.replace(datePattern, (match) => {


### PR DESCRIPTION
A date-time property shown in a QuickView popup keeps the raw time in the output. `2004-12-01T00:00:00` renders as `01/12/2004T00:00:00` instead of `01/12/2004`, and if the property's `dataFormat` keeps the time it renders as `01/12/2004 00:00T09:05:30` instead of `01/12/2004 09:05`.

## Cause

`formatDateStringAndPrefix` in `shesha-reactjs/src/utils/formatting.ts:42` scans the text with

```
/\d{2}[-/]\d{2}[-/]\d{4}|\d{4}[-/]\d{2}[-/]\d{2}|\d{4}\d{2}\d{2}T\d{6}|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/g
```

Regex alternation is leftmost-first, so at the start of `2004-12-01T00:00:00` the second alternative matches `2004-12-01` and returns. The last alternative, the only branch covering the ISO date-time, is unreachable for every input it was written for. `formatDate` then reformats the date part alone and `content.replace` leaves `T00:00:00` sitting in the result.

`SUPPORTED_DATE_FORMATS` in the same file already lists `'YYYY-MM-DDTHH:mm:ss'`, so `isValidDate` and `parseDate` handle the full value correctly once the regex hands it over.

`getFormatContent` in `shesha-reactjs/src/components/quickView/utils.tsx:16` is the caller, on the `date-time` branch.

## Fix

Move the two date-time alternatives ahead of the date-only ones. The compact form `\d{4}\d{2}\d{2}T\d{6}` was already reachable, because no date-only branch can match a string with no separators, and it stays reachable.

Adds `shesha-reactjs/src/utils/formatting.test.ts` covering the ISO date-time, the compact date-time, a date-time inside surrounding text, dates with no time part in both orders, and text with no date in it.

## Verification

Run in `shesha-reactjs` on macOS, Node 22.23.2.

`npx vitest run src/utils/formatting.test.ts` on main: 4 failed, 3 passed. The first failure is `expected '01/12/2004T00:00:00' to be '01/12/2004'`. With the change: 7 passed.

`npx vitest run --maxWorkers=3`: 33 files, 182 tests, all passed.

`npx eslint --quiet` across the package, the gate that `npm run build` runs first: exit 0, no output.

`npx tsc --noEmit`: byte-identical output with and without the change. It reports 13 pre-existing errors on main, 8 in `src/designer-components/phoneNumber/__tests__/index.test.tsx` and 5 in `src/utils/object.unproxy.test.ts`, none in the files touched here.

The .NET side is untouched and was not built.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed date-time formatting for complete ISO and compact date-time values, including fractional seconds and timezone information.
  - Improved formatting for dates embedded in surrounding text without altering text that contains no date.
  - Preserved the default `DD/MM/YYYY` format when no alternative format is specified.

- **Tests**
  - Added coverage for date-only values, date-times, embedded dates, timezone offsets, default formatting, and empty or date-free text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->