### PR TITLE
fix formItem marginBottom

### DIFF
--- a/shesha-reactjs/src/components/formDesigner/styles/shaComponentStyles.ts
+++ b/shesha-reactjs/src/components/formDesigner/styles/shaComponentStyles.ts
@@ -6,7 +6,6 @@ import { IToolboxComponent } from "@/interfaces";
 import { useMemo } from "react";
 import { deepMergeValues } from "@/utils/object";
 import { DEFAULT_DESIGNER_PADDING } from "../utils/stylingUtils";
-import { isNullOrWhiteSpace } from "@/utils";
 
 const getShaComponentStyles = createStyles(({ css, cx, token }, wrapperStyle: IStyleValue) => {
   const wrapperMargin = marginStyles(wrapperStyle.stylingBoxJson);
@@ -19,8 +18,6 @@ const getShaComponentStyles = createStyles(({ css, cx, token }, wrapperStyle: IS
     ${wrapperMargin}
 
     >.ant-form-item {
-      ${isNullOrWhiteSpace(wrapperPadding) ? 'margin-bottom: 0;' : ''}
-      
       .ant-form-item-label {
         padding-bottom: 3px;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated form layout styling when wrapper padding is empty.
  - Form items no longer receive a forced zero bottom margin in this scenario, preserving the standard spacing between fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->