### PR TITLE
Temporary fix Mac fonts

### DIFF
--- a/shesha-reactjs/src/components/readOnlyDisplayFormItem/styles/styles.ts
+++ b/shesha-reactjs/src/components/readOnlyDisplayFormItem/styles/styles.ts
@@ -1,4 +1,4 @@
-import { dimensionsStyles, fontStyles, paddingStyles } from '@/designer-components/_common/styles/utils';
+import { dimensionsStyles, fontStyles } from '@/designer-components/_common/styles/utils';
 import { IStyleValue } from '@/providers';
 import { createStyles, sheshaStyles, getTextHoverEffects } from '@/styles';
 
@@ -66,8 +66,6 @@ export const useStyles = createStyles(({ css, cx, prefixCls, token }, styleValue
   `);
 
   const inputField = css`
-    padding: 4px 11px;
-    ${paddingStyles(styleValue?.stylingBoxJson)}
     margin: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/shesha-reactjs/src/components/refListStatus/styles/styles.ts
+++ b/shesha-reactjs/src/components/refListStatus/styles/styles.ts
@@ -1,4 +1,4 @@
-import { createStyles, sheshaStyles } from '@/styles';
+import { createStyles } from '@/styles';
 import { CSSObject } from 'antd-style';
 
 type StylesArgs = {
@@ -13,7 +13,7 @@ type StylesResponse = {
   shaStatusTagDisabled: string;
 };
 
-export const useStyles = createStyles<StylesArgs, StylesResponse>(({ css, cx }, { dimensionsStyles, fontStyles, readOnly }) => {
+export const useStyles = createStyles<StylesArgs, StylesResponse>(({ css, cx }, { dimensionsStyles, fontStyles }) => {
   const shaStatusTag = 'sha-status-tag';
   const shaStatusTagContainer = cx(
     'sha-status-tag-container',
@@ -21,7 +21,6 @@ export const useStyles = createStyles<StylesArgs, StylesResponse>(({ css, cx }, 
       display: flex;
       align-items: center;
       width: fit-content;
-      margin: ${readOnly ? `0 ${sheshaStyles.paddingLG}px` : '0'} !important;
       ${dimensionsStyles};
 
       > span {

--- a/shesha-reactjs/src/designer-components/_common/styles/utils.ts
+++ b/shesha-reactjs/src/designer-components/_common/styles/utils.ts
@@ -259,9 +259,9 @@ export const paddingValue = (model: StyleBoxValue | undefined): string => {
 export const normalizeFontFamily = (fontFamily: string | undefined): string | undefined => {
   const userAgent = window.navigator.userAgent;
   if (/Mac/i.test(userAgent))
-    return fontFamily === 'Segoe UI'
+    return /Segoe UI/.test(fontFamily ?? '')
       ? '-apple-system'
-      : fontFamily === 'Arial'
+      : /Arial/.test(fontFamily ?? '')
         ? 'Helvetica Neue'
         : fontFamily;
   return fontFamily;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated read-only form field and status display styling for more consistent spacing, sizing, and text overflow behavior.
  - Improved font fallback handling on macOS so font names containing “Segoe UI” or “Arial” are mapped more reliably to compatible system fonts.
  - Preserved disabled status styling, including reduced opacity and disabled pointer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->