### PR TITLE
align quickview to the left

### DIFF
--- a/shesha-reactjs/src/components/quickView/__tests__/placement.test.tsx
+++ b/shesha-reactjs/src/components/quickView/__tests__/placement.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { GenericQuickView, QUICKVIEW_PLACEMENT } from '..';
+
+// antd's popup aligner needs ResizeObserver, which jsdom does not provide
+class ResizeObserverStub {
+  observe(): void {}
+
+  unobserve(): void {}
+
+  disconnect(): void {}
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+vi.mock('@/providers/configurationItemsLoader', () => ({
+  useConfigurationItemsLoader: () => ({ getEntityFormIdAsync: () => Promise.reject(new Error('no form')) }),
+}));
+
+describe('QuickView popover placement (#4973)', () => {
+  it('anchors to the left edge of the trigger rather than centring on the full-width button', async () => {
+    render(<GenericQuickView entityType={{ name: 'Address', module: 'Shesha' }} formType="Details" displayName="Short" displayProperty="name" />);
+    const trigger = await screen.findByLabelText('Quickview configuration error');
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => expect(document.querySelector('.ant-popover')).not.toBeNull());
+    expect(document.querySelector('.ant-popover')?.className).toContain(`ant-popover-placement-${QUICKVIEW_PLACEMENT}`);
+  });
+});

--- a/shesha-reactjs/src/components/quickView/index.tsx
+++ b/shesha-reactjs/src/components/quickView/index.tsx
@@ -27,6 +27,8 @@ import { isDefined } from '@/utils/nullables';
 import { extractErrorInfo } from '@/utils/errors';
 import { useDeepCompareEffect } from '@/hooks/useDeepCompareEffect';
 
+export const QUICKVIEW_PLACEMENT: PopoverProps['placement'] = 'topLeft';
+
 export interface IQuickViewProps extends PropsWithChildren {
   /** The id or guid for the entity */
   entityId?: string | undefined;
@@ -273,6 +275,7 @@ const QuickView: FC<Omit<IQuickViewProps, 'formType'>> = ({
 
   return (
     <Popover
+      placement={QUICKVIEW_PLACEMENT}
       {...(isDefined(popupClassName) ? { rootClassName: popupClassName } : {})}
       styles={{
         root: typeof cappedWidth === 'string' && /%$/.test(cappedWidth as string) ? { width: cappedWidth } : {},
@@ -338,6 +341,7 @@ export const GenericQuickView: FC<IQuickViewProps> = (props) => {
   if (formConfig === null) {
     return (
       <Popover
+        placement={QUICKVIEW_PLACEMENT}
         {...(isDefined(props.popupClassName) ? { rootClassName: props.popupClassName } : {})}
         content="Quickview not configured properly"
         title="Quickview not configured properly"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quick View popovers now consistently appear with a top-left placement.

- **Tests**
  - Added coverage to verify the placement of the Generic Quick View popover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->