### PR TITLE
Katleho/bugfix/api call fix

### DIFF
--- a/shesha-reactjs/src/components/requestConfigModal/index.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect, useRef, useMemo } from 'react';
+import { FC, useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Modal, Tabs } from 'antd';
 import { ParamsTab } from './paramsTab';
 import { HeadersTab } from './headersTab';
@@ -14,7 +14,8 @@ import {
 } from '@/components/expressionEditor/contextMetadata';
 import { useAsyncMemo } from '@/hooks/useAsyncMemo';
 import { useAvailableConstantsMetadata } from '@/utils/metadata/hooks';
-import { SheshaConstants } from '@/utils/metadata/standardProperties';
+import { SheshaConstants, registerSelectedRowAction } from '@/utils/metadata/standardProperties';
+import { IObjectMetadataBuilder } from '@/utils/metadata/metadataBuilder';
 import { useMetadataOrUndefined } from '@/providers/metadata';
 import { asPropertiesArray } from '@/interfaces/metadata';
 
@@ -52,8 +53,15 @@ export const RequestConfigModal: FC<IRequestConfigModalProps> = ({
     wasVisible.current = visible;
   }, [visible, config]);
 
-  // Build expression context once so all tabs share the same autocomplete data.
-  const availableConstants = useAvailableConstantsMetadata({ standardConstants: STANDARD_CONSTANTS });
+  // Build expression context once so all tabs share the same autocomplete data. `selectedRow` isn't
+  // part of the app-wide standard constants set (its registration is currently disabled globally —
+  // see useMetadataBuilderFactory), but it IS actually populated at runtime whenever this action runs
+  // off a table row action button (ActionCell injects it), so it's registered here explicitly to
+  // surface it in autocomplete — the gap was in suggestions only, not evaluation.
+  const onBuildConstants = useCallback((builder: IObjectMetadataBuilder) => {
+    registerSelectedRowAction(builder, 'selectedRow');
+  }, []);
+  const availableConstants = useAvailableConstantsMetadata({ standardConstants: STANDARD_CONSTANTS, onBuild: onBuildConstants });
   const formMetadata = useMetadataOrUndefined()?.metadata;
 
   const dataPathContext = useMemo<ExpressionContext>(() => {

--- a/shesha-reactjs/src/components/requestConfigModal/index.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/index.tsx
@@ -3,7 +3,7 @@ import { Modal, Tabs } from 'antd';
 import { ParamsTab } from './paramsTab';
 import { HeadersTab } from './headersTab';
 import { BodyTab } from './bodyTab';
-import { TransformationTab, DEFAULT_TRANSFORMATION_SCRIPT } from './transformationTab';
+import { TransformationTab } from './transformationTab';
 import { IRequestConfig } from './models';
 import { useStyles } from './styles';
 import { ExpressionContext, buildExpressionContextFromPaths } from '@/components/expressionEditor';
@@ -142,12 +142,7 @@ export const RequestConfigModal: FC<IRequestConfigModalProps> = ({
               children: (
                 <TransformationTab
                   {...(localConfig.responseTransformation !== undefined ? { value: localConfig.responseTransformation } : {})}
-                  onChange={(t) => {
-                    const seeded = t.enabled && !t.script.trim()
-                      ? { ...t, script: DEFAULT_TRANSFORMATION_SCRIPT }
-                      : t;
-                    updateConfig({ responseTransformation: seeded });
-                  }}
+                  onChange={(t) => updateConfig({ responseTransformation: t })}
                 />
               ),
             },

--- a/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
+++ b/shesha-reactjs/src/components/requestConfigModal/transformationTab.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback } from 'react';
-import { Space, Switch, Tooltip, Typography } from 'antd';
+import { Space, Tooltip, Typography } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { CodeEditor as BaseCodeEditor } from '@/components/codeEditor/codeEditor';
 import { IResponseTransformationConfiguration } from './models';
@@ -27,7 +27,6 @@ export interface ITransformationTabProps {
 export const TransformationTab: FC<ITransformationTabProps> = ({ value, onChange }) => {
   const { styles } = useStyles();
 
-  const enabled = value?.enabled ?? false;
   const script = value?.script ?? '';
 
   // Declares the variables the script editor exposes for IntelliSense. We expose the standard
@@ -41,51 +40,42 @@ export const TransformationTab: FC<ITransformationTabProps> = ({ value, onChange
   }, []);
   const availableConstants = useAvailableConstantsMetadata({ addGlobalConstants: true, onBuild: onBuildConstants });
 
-  const update = (changes: Partial<IResponseTransformationConfiguration>): void => {
-    onChange({ enabled, script, ...changes });
-  };
-
-  const handleEnabledChange = (checked: boolean): void => {
-    update({ enabled: checked });
-  };
-
+  // There's no separate on/off switch — the transformation is simply applied whenever a script is
+  // present (an empty script is a no-op, mirrored by the isNullOrWhiteSpace check in
+  // applyResponseTransformation).
   const handleScriptChange = (next: string): void => {
-    update({ script: next });
+    onChange({ enabled: Boolean(next.trim()), script: next });
   };
 
-  const scriptValidation = enabled ? validateTransformationScript(script) : null;
+  const scriptValidation = script.trim() ? validateTransformationScript(script) : null;
 
   return (
     <div className={styles.bodyEditor}>
       <Space direction="vertical" size="small" style={{ width: '100%' }}>
         <Space>
-          <Switch checked={enabled} onChange={handleEnabledChange} />
-          <Text strong>Enable Transformation</Text>
-          <Tooltip title="Reshape the API response before it's used. The response is available as `response`, plus standard constants (globalState, pageContext, http, form, data). Return the transformed value.">
+          <Text strong>Transformation script</Text>
+          <Tooltip title="Reshape the API response before it's used. The response is available as `response`, plus standard constants (globalState, pageContext, http, form, data). Return the transformed value. Leave empty to skip transformation.">
             <InfoCircleOutlined style={{ color: 'rgba(0, 0, 0, 0.45)', cursor: 'help' }} />
           </Tooltip>
         </Space>
 
-        {enabled && (
-          <div>
-            <Text type="secondary">Transformation script</Text>
-            <div className={styles.codeEditorWrapper}>
-              <BaseCodeEditor
-                value={script}
-                onChange={(v) => handleScriptChange(v ?? '')}
-                language="javascript"
-                placeholder={DEFAULT_TRANSFORMATION_SCRIPT}
-                fileName="expression"
-                wrapInTemplate
-                templateSettings={{ useAsyncDeclaration: true, functionName: 'transformResponse' }}
-                availableConstants={availableConstants}
-                resultType={RESULT_TYPE}
-                style={{ height: 280 }}
-              />
-            </div>
-            {scriptValidation && <div className={styles.jsonError}>{scriptValidation}</div>}
+        <div>
+          <div className={styles.codeEditorWrapper}>
+            <BaseCodeEditor
+              value={script}
+              onChange={(v) => handleScriptChange(v ?? '')}
+              language="javascript"
+              placeholder={DEFAULT_TRANSFORMATION_SCRIPT}
+              fileName="expression"
+              wrapInTemplate
+              templateSettings={{ useAsyncDeclaration: true, functionName: 'transformResponse' }}
+              availableConstants={availableConstants}
+              resultType={RESULT_TYPE}
+              style={{ height: 280 }}
+            />
           </div>
-        )}
+          {scriptValidation && <div className={styles.jsonError}>{scriptValidation}</div>}
+        </div>
       </Space>
     </div>
   );

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -170,17 +170,24 @@ const isGlobalUrl = (url: string): boolean => {
   return !isNullOrWhiteSpace(url) && Boolean(url.match(/^(http|https):\/\//gi));
 };
 
-/** True when `url`'s effective destination is this app's own backend — either a relative path
- * (always resolved against `backendUrl`) or an absolute URL whose origin exactly matches
- * `backendUrl`'s. Standard headers (including the current user's Authorization bearer token)
- * must never be forwarded anywhere else, regardless of the "Send Standard Headers" switch —
- * otherwise pointing the action at an arbitrary absolute URL (by mistake, or by a form author
- * who shouldn't have that reach) would leak the session's credentials to a third party. */
+/** True when `url`'s effective destination is this app's own backend. Resolves `url` against
+ * `backendUrl` as the base — the same rule a browser (and axios's own `isAbsoluteURL` check) uses
+ * for any URL reference — then compares origins. Standard headers (including the current user's
+ * Authorization bearer token) must never be forwarded anywhere else, regardless of the "Send
+ * Standard Headers" switch, otherwise pointing the action at a destination outside this app's
+ * backend (by mistake, or by a form author who shouldn't have that reach) would leak the
+ * session's credentials to a third party.
+ *
+ * A scheme-anchored check like `isGlobalUrl` (`^(http|https):\/\/`) isn't enough here on its own:
+ * a protocol-relative URL such as `//attacker.example/path` doesn't match that regex, but it's
+ * still resolved as an absolute, cross-origin reference by both browsers and axios's own
+ * `isAbsoluteURL` (whose scheme group is optional). Resolving through `new URL(url, backendUrl)`
+ * handles a plain relative path, a protocol-relative URL, and a fully-qualified absolute URL
+ * uniformly, so none of those shapes can slip past this check. */
 const isApprovedDestination = (url: string, backendUrl: string): boolean => {
-  if (!isGlobalUrl(url)) return true;
   if (isNullOrWhiteSpace(backendUrl)) return false;
   try {
-    return new URL(url).origin === new URL(backendUrl).origin;
+    return new URL(url, backendUrl).origin === new URL(backendUrl).origin;
   } catch {
     return false;
   }

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -76,6 +76,15 @@ const migrateV0toV1 = (prev: IApiCallArgumentsV0): IApiCallArguments => {
   return { ...rest, verb, requestConfig };
 };
 
+/** Default "Send Standard Headers" to on. Runs for both freshly-created actions (which start at
+ * version -1 and pass through every migration step, including this one) and pre-existing configs
+ * that never had the switch set, so standard headers (incl. Authorization) are sent unless a user
+ * has explicitly turned the switch off — an explicit `false` is preserved as-is. */
+const migrateV1toV2 = (prev: IApiCallArguments): IApiCallArguments => ({
+  ...prev,
+  sendStandardHeaders: prev.sendStandardHeaders ?? true,
+});
+
 const HttpVerbs: Method[] = ['get',
   'delete',
   'head',
@@ -200,7 +209,8 @@ export const useApiCallAction = (): void => {
     hasArguments: true,
     argumentsFormMarkup: getApiCallArgumentsForm,
     migrator: (m) => m
-      .add<IApiCallArgumentsV0>(0, (prev) => migrateV0toV1(prev)),
+      .add<IApiCallArgumentsV0>(0, (prev) => migrateV0toV1(prev))
+      .add<IApiCallArguments>(1, (prev) => migrateV1toV2(prev)),
     // Evaluate arguments normally (params/headers/url get their Mustache resolved), but keep the
     // JSON/raw body template raw. A JSON body is one big string, and letting the generic pass run
     // Mustache over it can blank tags before the body data is available; instead the executer

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -170,6 +170,22 @@ const isGlobalUrl = (url: string): boolean => {
   return !isNullOrWhiteSpace(url) && Boolean(url.match(/^(http|https):\/\//gi));
 };
 
+/** True when `url`'s effective destination is this app's own backend — either a relative path
+ * (always resolved against `backendUrl`) or an absolute URL whose origin exactly matches
+ * `backendUrl`'s. Standard headers (including the current user's Authorization bearer token)
+ * must never be forwarded anywhere else, regardless of the "Send Standard Headers" switch —
+ * otherwise pointing the action at an arbitrary absolute URL (by mistake, or by a form author
+ * who shouldn't have that reach) would leak the session's credentials to a third party. */
+const isApprovedDestination = (url: string, backendUrl: string): boolean => {
+  if (!isGlobalUrl(url)) return true;
+  if (isNullOrWhiteSpace(backendUrl)) return false;
+  try {
+    return new URL(url).origin === new URL(backendUrl).origin;
+  } catch {
+    return false;
+  }
+};
+
 const hasHeader = (headers: Record<string, string>, name: string): boolean =>
   Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
 
@@ -360,7 +376,9 @@ export const useApiCallAction = (): void => {
         }
       }
 
-      const standardHeaders = sendStandardHeaders ? httpHeaders : {};
+      // Never forward standard headers (incl. Authorization) to a destination outside this app's
+      // own backend, even when the switch is on — see isApprovedDestination.
+      const standardHeaders = sendStandardHeaders && isApprovedDestination(url, backendUrl) ? httpHeaders : {};
       const allHeaders = { ...standardHeaders, ...finalHeaders };
 
       // validate arguments

--- a/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
+++ b/shesha-reactjs/src/providers/sheshaApplication/configurable-actions/api-call.ts
@@ -79,10 +79,18 @@ const migrateV0toV1 = (prev: IApiCallArgumentsV0): IApiCallArguments => {
 /** Default "Send Standard Headers" to on. Runs for both freshly-created actions (which start at
  * version -1 and pass through every migration step, including this one) and pre-existing configs
  * that never had the switch set, so standard headers (incl. Authorization) are sent unless a user
- * has explicitly turned the switch off — an explicit `false` is preserved as-is. */
-const migrateV1toV2 = (prev: IApiCallArguments): IApiCallArguments => ({
+ * has explicitly turned the switch off — an explicit `false` is preserved as-is.
+ * Registered as version 2 (not 1): many already-saved configs were hand-authored directly in the
+ * post-requestConfig shape with `version: 1` as a "nothing to migrate" marker, never having gone
+ * through migrateV0toV1. Migrator.upgrade only runs migrations whose version is strictly greater
+ * than the stored version, so registering this at version 1 would have silently skipped every one
+ * of those already-version-1 configs. */
+const migrateToV2 = (prev: IApiCallArguments): IApiCallArguments => ({
   ...prev,
-  sendStandardHeaders: prev.sendStandardHeaders ?? true,
+  // `sendStandardHeaders` is typed as a required boolean, but migration input is whatever was
+  // actually persisted — plenty of already-saved configs predate this field entirely, so it can be
+  // missing at runtime despite the type. Cast acknowledges that trust boundary.
+  sendStandardHeaders: (prev.sendStandardHeaders as boolean | undefined) ?? true,
 });
 
 const HttpVerbs: Method[] = ['get',
@@ -172,9 +180,14 @@ const setHeaderIfMissing = (headers: Record<string, string>, name: string, value
 const prepareUrlAndData = (url: string, verb: string, parameters: IDictionary<string>): { url: string; data: IDictionary<string> | undefined } => {
   const encodeAsQueryString = ['get', 'delete'].includes(verb.toLowerCase());
   if (encodeAsQueryString) {
+    // getQueryParams(url) already extracts and merges in whatever query string `url` carries, so it
+    // must be stripped from `url` itself before re-appending the merged one below — otherwise a `url`
+    // that already has a `?...` (its own literal query string, or one injected by the
+    // bodyOverridesParams branch above) ends up with the same params appended a second time, e.g.
+    // `/Delete?id=X?id=X`, which most backends reject as an invalid parameter value.
     const queryStringData = { ...getQueryParams(url), ...parameters };
     return {
-      url: `${url}?${qs.stringify(queryStringData, { allowDots: true })}`,
+      url: `${url.split('?')[0]}?${qs.stringify(queryStringData, { allowDots: true })}`,
       data: undefined,
     };
   } else {
@@ -210,7 +223,7 @@ export const useApiCallAction = (): void => {
     argumentsFormMarkup: getApiCallArgumentsForm,
     migrator: (m) => m
       .add<IApiCallArgumentsV0>(0, (prev) => migrateV0toV1(prev))
-      .add<IApiCallArguments>(1, (prev) => migrateV1toV2(prev)),
+      .add<IApiCallArguments>(2, (prev) => migrateToV2(prev)),
     // Evaluate arguments normally (params/headers/url get their Mustache resolved), but keep the
     // JSON/raw body template raw. A JSON body is one big string, and letting the generic pass run
     // Mustache over it can blank tags before the body data is available; instead the executer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Interface**
  - Transformation settings now always display the script editor.
  - Transformation is enabled when the script contains content and disabled when it is empty.
  - Removed the separate enable/disable switch.

- **Bug Fixes**
  - Configurations without an explicit standard-header setting now send standard headers by default.
  - Explicitly disabled standard headers remain disabled.
  - Standard headers are only sent to the app’s own backend.
  - Prevented duplicate query parameters when preparing API request URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->