### PR TITLE
Lihlumise/fix/default lookup check

### DIFF
--- a/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/ScriptsMsSql/06-notification_channel_revisions.sql
+++ b/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/ScriptsMsSql/06-notification_channel_revisions.sql
@@ -1,3 +1,16 @@
+DECLARE @DefaultPriorityColumn NVARCHAR(100);
+
+IF EXISTS (
+    SELECT 1
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID('Core_NotificationChannelConfigs')
+      AND name = 'DefaultPriorityLkp'
+)
+    SET @DefaultPriorityColumn = 'ncc.DefaultPriorityLkp';
+ELSE
+    SET @DefaultPriorityColumn = 'NULL';
+
+DECLARE @sql NVARCHAR(MAX) = N'
 INSERT INTO frwk.notification_channel_revisions
            (id
            ,default_priority_lkp
@@ -7,19 +20,25 @@ INSERT INTO frwk.notification_channel_revisions
            ,supported_format_lkp
            ,supported_mechanism_lkp
            ,supports_attachment)
-select 
-	cio.Id
-	,ncc.DefaultPriorityLkp
-	,ncc.MaxMessageSize
-	,ncc.SenderTypeName
-	,ncc.StatusLkp
-	,ncc.SupportedFormatLkp
-	,ncc.SupportedMechanismLkp
-	,ncc.SupportsAttachment
-from
-	Frwk_ConfigurationItems cio
-	inner join Core_NotificationChannelConfigs ncc on cio.Id = ncc.Id
-	inner join frwk.configuration_items cin on 
-		cin.name = cio.Name
-		and (cin.module_id = cio.ModuleId or cin.module_id is null and cio.ModuleId is null)
-		and cin.item_type = cio.ItemType
+SELECT 
+    cio.Id,
+    ' + @DefaultPriorityColumn + N' AS DefaultPriorityLkp,
+    ncc.MaxMessageSize,
+    ncc.SenderTypeName,
+    ncc.StatusLkp,
+    ncc.SupportedFormatLkp,
+    ncc.SupportedMechanismLkp,
+    ncc.SupportsAttachment
+FROM Frwk_ConfigurationItems cio
+INNER JOIN Core_NotificationChannelConfigs ncc 
+    ON cio.Id = ncc.Id
+INNER JOIN frwk.configuration_items cin 
+    ON cin.name = cio.Name
+    AND (
+        cin.module_id = cio.ModuleId 
+        OR cin.module_id IS NULL AND cio.ModuleId IS NULL
+    )
+    AND cin.item_type = cio.ItemType;
+';
+
+EXEC sp_executesql @sql;

--- a/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/ScriptsPostgreSql/06-notification_channel_revisions.sql
+++ b/shesha-core/src/Shesha.Framework/Migrations/ConfigurationStudio/ScriptsPostgreSql/06-notification_channel_revisions.sql
@@ -9,7 +9,12 @@ INSERT INTO frwk.notification_channel_revisions
            ,supports_attachment)
 select 
 	cio."Id"
-	,ncc."DefaultPriorityLkp"
+	-- M20260614111200 on releases/0.43 moves this column onto Core_NotificationTypeConfigs
+	-- and drops it here, so a database fed from that line no longer has it. Reading the row
+	-- as jsonb and looking the key up by name means the column is never resolved at parse
+	-- time: a missing key simply yields null. The MsSql variant defers it with dynamic SQL,
+	-- which has no equivalent here, and these scripts use no dollar-quoted blocks.
+	,(to_jsonb(ncc) ->> 'DefaultPriorityLkp')::bigint
 	,ncc."MaxMessageSize"
 	,ncc."SenderTypeName"
 	,ncc."StatusLkp"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification channel revision migrations to work reliably across database versions with or without the default priority field.
  - Prevented migration failures when the default priority field is unavailable, preserving revision creation with a null value instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->