### PR TITLE
Nhlakanipho/en/4804

### DIFF
--- a/shesha-reactjs/src/designer-components/customLayout/__tests__/index.test.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/__tests__/index.test.ts
@@ -6,7 +6,7 @@ const buildModel = (overrides: Partial<ICustomLayoutComponentProps> = {}): ICust
   type: 'customLayout',
   components: [],
   ...overrides,
-} as ICustomLayoutComponentProps);
+});
 
 const initModel = (model: ICustomLayoutComponentProps): ICustomLayoutComponentProps => {
   const init = CustomLayoutComponent.initModel;

--- a/shesha-reactjs/src/designer-components/customLayout/__tests__/index.test.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/__tests__/index.test.ts
@@ -1,0 +1,53 @@
+import CustomLayoutComponent from '../customLayoutComponent';
+import { ICustomLayoutComponentProps } from '../interfaces';
+
+const buildModel = (overrides: Partial<ICustomLayoutComponentProps> = {}): ICustomLayoutComponentProps => ({
+  id: '1',
+  type: 'customLayout',
+  components: [],
+  ...overrides,
+} as ICustomLayoutComponentProps);
+
+const initModel = (model: ICustomLayoutComponentProps): ICustomLayoutComponentProps => {
+  const init = CustomLayoutComponent.initModel;
+  if (!init) throw new Error('CustomLayoutComponent.initModel is not defined');
+  return init(model);
+};
+
+describe('CustomLayoutComponent', () => {
+  test('is registered with the expected type and capabilities', () => {
+    expect(CustomLayoutComponent.type).toBe('customLayout');
+    // Refs #4804 AC8 - a container, never an input with a value of its own
+    expect(CustomLayoutComponent.isInput).toBe(false);
+  });
+
+  test('initModel gives a visible default heading', () => {
+    const model = initModel(buildModel());
+
+    expect(model.label).toBe('Custom Layout');
+    expect(model.hideLabel).toBe(false);
+    expect(model.labelAlign).toBe('left');
+  });
+
+  // Without an explicit colour the heading inherits from the surrounding designer chrome
+  test('initModel gives the heading its own typography', () => {
+    const model = initModel(buildModel());
+
+    expect(model.headingFont).toEqual({ color: '#000', size: 14, weight: '500' });
+  });
+
+  // initModel only runs when the component is dropped, so the defaults always win
+  test('initModel applies defaults unconditionally', () => {
+    const model = initModel(buildModel({ label: 'Contact details', hideLabel: true }));
+
+    expect(model.label).toBe('Custom Layout');
+    expect(model.hideLabel).toBe(false);
+  });
+
+  test('initModel keeps unrelated settings', () => {
+    const model = initModel(buildModel({ componentName: 'customLayout1', display: 'flex' }));
+
+    expect(model.componentName).toBe('customLayout1');
+    expect(model.display).toBe('flex');
+  });
+});

--- a/shesha-reactjs/src/designer-components/customLayout/customLayoutComponent.tsx
+++ b/shesha-reactjs/src/designer-components/customLayout/customLayoutComponent.tsx
@@ -1,0 +1,45 @@
+import { GroupOutlined } from '@ant-design/icons';
+import ComponentsContainer from '@/components/formDesigner/containers/componentsContainer';
+import ParentProvider from '@/providers/parentProvider/index';
+import { getFullSizeWrapperDesignerStyle } from '@/components/formDesigner/utils/stylingUtils';
+import { useActualContextExecutionNoRefresh } from '@/hooks/formComponentHooks';
+import { getSettings } from './settingsForm';
+import { defaultStyles } from './utils';
+import { useStyles } from './styles';
+import { CustomLayoutComponentDefinition } from './interfaces';
+
+const CustomLayoutComponent: CustomLayoutComponentDefinition = {
+  showInThemeEditor: false,
+  styleGroup: 'common-containers',
+  allowInherit: true,
+  type: 'customLayout',
+  isInput: false,
+  name: 'Custom Layout',
+  icon: <GroupOutlined />,
+  emptyComponents: [],
+  getWrapperStyle: (model) => getFullSizeWrapperDesignerStyle(model),
+  Factory: ({ model }) => {
+    const { styles, cx } = useStyles(model);
+    const wrappedStyleJson = useActualContextExecutionNoRefresh(model.wrapperStyle, undefined, {});
+
+    if (model.hidden === true) return null;
+
+    return (
+      <ParentProvider model={model} name={`CustomLayoutComponent-${model.id}`}>
+        {model.hideLabel !== true && <div className={styles.heading}>{model.label}</div>}
+        <ComponentsContainer
+          containerId={model.id}
+          wrapperStyle={wrappedStyleJson}
+          style={model.styleCss}
+          className={cx(model.className, styles.customLayout)}
+          dynamicComponents={model.isDynamic === true ? model.components : CustomLayoutComponent.emptyComponents}
+        />
+      </ParentProvider>
+    );
+  },
+  initModel: (model) => ({ ...model, label: 'Custom Layout', hideLabel: false, labelAlign: 'left' }),
+  settingsFormMarkup: getSettings,
+  getDefaultStyles: defaultStyles,
+};
+
+export default CustomLayoutComponent;

--- a/shesha-reactjs/src/designer-components/customLayout/customLayoutComponent.tsx
+++ b/shesha-reactjs/src/designer-components/customLayout/customLayoutComponent.tsx
@@ -37,7 +37,14 @@ const CustomLayoutComponent: CustomLayoutComponentDefinition = {
       </ParentProvider>
     );
   },
-  initModel: (model) => ({ ...model, label: 'Custom Layout', hideLabel: false, labelAlign: 'left' }),
+  initModel: (model) => ({
+    ...model,
+    label: 'Custom Layout',
+    hideLabel: false,
+    labelAlign: 'left',
+    // Set explicitly so the heading does not inherit colour from the surrounding chrome.
+    headingFont: { color: '#000', size: 14, weight: '500' },
+  }),
   settingsFormMarkup: getSettings,
   getDefaultStyles: defaultStyles,
 };

--- a/shesha-reactjs/src/designer-components/customLayout/interfaces.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/interfaces.ts
@@ -1,0 +1,17 @@
+import { ComponentDefinition } from '@/interfaces';
+import { IConfigurableFormComponent } from '@/providers/form/models';
+import { IFontValue } from '@/designer-components/_settings/utils';
+import { ICommonContainerProps } from '../container/interfaces';
+
+export interface ICustomLayoutComponentProps extends IConfigurableFormComponent, Omit<ICommonContainerProps, 'style'> {
+  className?: string | undefined;
+  wrapperStyle?: string | undefined;
+  /** Typography of the section heading. Separate from `font` so it is not inherited by children. */
+  headingFont?: IFontValue | undefined;
+  components: IConfigurableFormComponent[]; // Only important for fluent API
+}
+
+export type CustomLayoutComponentDefinition = ComponentDefinition<"customLayout", ICustomLayoutComponentProps> & {
+  /** Static empty array to prevent unnecessary re-renders when isDynamic is false */
+  emptyComponents?: [];
+};

--- a/shesha-reactjs/src/designer-components/customLayout/settingsForm.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/settingsForm.ts
@@ -1,0 +1,68 @@
+import { nanoid } from '@/utils/uuid';
+import { FormLayout } from 'antd/lib/form/Form';
+import { SettingsFormMarkupFactory } from '@/interfaces';
+
+export const getSettings: SettingsFormMarkupFactory = ({ fbf, removeStyleRouter }) => {
+  const commonTabId = nanoid();
+  const commonStyleRouterId = nanoid();
+  const appearanceTabId = nanoid();
+  const styleRouterId = nanoid();
+  const stylePnlCustomId = nanoid();
+
+  return {
+    components: fbf()
+      .addSearchableTabs({ propertyName: 'settingsTabs', parentId: 'root', label: 'Settings', hideLabel: true, labelAlign: 'right', size: 'small',
+        tabs: [
+          { key: 'common', title: 'Common', id: commonTabId,
+            components: fbf(commonTabId)
+              .addSettingsInput({ inputType: 'textField', propertyName: 'componentName', label: 'Component Name', validate: { required: true }, jsSetting: false })
+              // No `propertyName` input: the heading is a section title, the container holds no value.
+              .addLabelConfigurator({ propertyName: 'hideLabel', label: 'Label', hideLabel: true })
+              .stdVisibleEditableInputs('full')
+              .addSettingsInput({ inputType: 'switch', propertyName: 'noDefaultStyling', label: 'No Default Styling', size: 'small', tooltip: 'If checked, the default styles and classes of the container will not be applied.', jsSetting: true })
+              .addPropertyRouter({ id: commonStyleRouterId, componentName: 'propertyRouter1', label: 'Property router1', labelAlign: 'right',
+                propertyRouteName: removeStyleRouter === true ? '' : { _mode: "code", _code: "    return contexts.canvasContext?.designerDevice || 'desktop';", _value: "" },
+                components: fbf(commonStyleRouterId)
+                  .stdLayoutPanel(removeStyleRouter !== true)
+                  .stdDimensionsPanel()
+                  .stdMarginPaddingPanel()
+                  .toJson(),
+              })
+              .toJson(),
+          },
+          { key: 'appearance', title: 'Appearance', id: appearanceTabId,
+            components: fbf(appearanceTabId)
+              .addPropertyRouter({ id: styleRouterId, componentName: 'propertyRouter2', label: 'Property router2', labelAlign: 'right',
+                propertyRouteName: removeStyleRouter === true ? '' : { _mode: "code", _code: "    return contexts.canvasContext?.designerDevice || 'desktop';", _value: "" },
+                components: fbf(styleRouterId)
+                  .stdFontPanel(removeStyleRouter !== true, 'headingFont', ['align'], 'Heading')
+                  .stdLayoutPanel(removeStyleRouter !== true)
+                  .stdDimensionsPanel()
+                  .stdBorderPanel(removeStyleRouter !== true)
+                  .stdBackgroundPanel(removeStyleRouter !== true)
+                  .stdShadowPanel()
+                  .stdMarginPaddingPanel()
+                  .addCollapsiblePanel({ label: 'Custom Styles', labelAlign: 'right', ghost: true, collapsible: 'header',
+                    content: {
+                      id: stylePnlCustomId,
+                      components: fbf(stylePnlCustomId)
+                        .addSettingsInput({ inputType: 'textField', propertyName: 'className', label: 'Custom CSS Class' })
+                        .addSettingsInput({ inputType: 'codeEditor', propertyName: 'wrapperStyle', label: 'Wrapper Style', description: 'A script that returns the style of the element as an object. This should conform to CSSProperties' })
+                        .addSettingsInput({ inputType: 'codeEditor', propertyName: 'style', label: 'Style', description: 'A script that returns the style of the element as an object. This should conform to CSSProperties' })
+                        .toJson(),
+                    },
+                  })
+                  .toJson(),
+              }).toJson(),
+          },
+        ],
+      }).toJson(),
+    formSettings: {
+      isSettingsForm: true,
+      colon: false,
+      layout: 'vertical' as FormLayout,
+      labelCol: { span: 24 },
+      wrapperCol: { span: 24 },
+    },
+  };
+};

--- a/shesha-reactjs/src/designer-components/customLayout/styles.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/styles.ts
@@ -56,6 +56,9 @@ export const useStyles = createStyles(({ css, cx }, model: ICustomLayoutComponen
     `);
 
   const heading = cx("sha-custom-layout-heading", css`
+        /* The container owns the padding, so the heading repeats it to stay aligned with the children. */
+        ${paddingStyles(model.stylingBoxJson)}
+        padding-bottom: 4px;
         ${fontStyles(model.headingFont)}
         ${isDefined(model.labelAlign) ? `text-align: ${model.labelAlign};` : ''}
     `);

--- a/shesha-reactjs/src/designer-components/customLayout/styles.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/styles.ts
@@ -1,0 +1,67 @@
+import { createStyles } from '@/styles';
+import { CSSObject } from 'antd-style';
+import { getOverflowStyle } from '../_settings/utils/overflow/util';
+import { backgroundStyles, borderStyles, dimensionsStyles, fontStyles, marginStyles, paddingStyles, shadowStyles } from '../_common/styles/utils';
+import { isDefined } from '@/utils';
+import { addPx } from '@/utils/style';
+import { getFullSizeComponentDimensions } from '@/components/formDesigner/utils/stylingUtils';
+import { ICustomLayoutComponentProps } from './interfaces';
+
+export const useStyles = createStyles(({ css, cx }, model: ICustomLayoutComponentProps) => {
+  const overflowStyles = { ...getOverflowStyle(true, false) };
+
+  const horizontalNotBlock = model.direction === 'horizontal' || model.display !== 'block';
+  const horizontalAndJustifyContent = model.direction === 'horizontal' && isDefined(model.justifyContent);
+  const grid = model.display === 'grid' || model.display === 'inline-grid';
+  const flex = model.display === 'flex';
+
+  const gridColumnWidth = addPx(model.gridColumnsWidth) ?? 'auto';
+  const gridRowHeight = addPx(model.gridRowsHeight) ?? 'auto';
+
+  const customLayout = cx("sha-custom-layout-component", css`
+        transition: all 0.2s ease;
+
+        overflow: hidden;
+        ${dimensionsStyles(getFullSizeComponentDimensions(model.dimensions))}
+        ${borderStyles(model.border)}
+        ${backgroundStyles(model.background)}
+        ${shadowStyles(model.shadow)}
+        ${marginStyles(model.stylingBoxJson)}
+
+        ${isDefined(model.alignSelf) ? `align-self: ${model.alignSelf};` : ''}
+        ${isDefined(model.justifySelf) ? `justify-self: ${model.justifySelf};` : ''}
+
+        > .sha-components-container-inner {
+          ${paddingStyles(model.stylingBoxJson)}
+          height: 100%;
+          width: 100%;
+          box-sizing: border-box;
+
+          ${overflowStyles as CSSObject}
+
+          ${isDefined(model.display) ? `display: ${model.display};` : ''}
+
+          ${horizontalNotBlock && isDefined(model.textJustify) ? `text-justify: ${model.textJustify};` : ''}
+          ${horizontalNotBlock && isDefined(model.gap) ? `gap: ${addPx(model.gap) ?? model.gap};` : ''}
+          ${(horizontalNotBlock || horizontalAndJustifyContent) && isDefined(model.justifyContent) ? `justify-content: ${model.justifyContent};` : ''}
+          ${(horizontalNotBlock || horizontalAndJustifyContent) && isDefined(model.alignItems) ? `align-items: ${model.alignItems};` : ''}
+          ${(horizontalNotBlock || horizontalAndJustifyContent) && isDefined(model.justifyItems) ? `justify-items: ${model.justifyItems};` : ''}
+
+          ${grid && isDefined(model.gridColumnsCount) && model.gridColumnsCount > 0 && Number.isInteger(model.gridColumnsCount) ? `grid-template-columns: repeat(${model.gridColumnsCount}, minmax(0, ${gridColumnWidth}));` : ''}
+          ${grid && isDefined(model.gridRowsCount) && model.gridRowsCount > 0 && Number.isInteger(model.gridRowsCount) ? `grid-template-rows: repeat(${model.gridRowsCount}, minmax(0, ${gridRowHeight}));` : ''}
+
+          ${flex && isDefined(model.flexDirection) ? `flex-direction: ${model.flexDirection};` : ''}
+          ${flex && isDefined(model.flexWrap) ? `flex-wrap: ${model.flexWrap};` : ''}
+        }
+    `);
+
+  const heading = cx("sha-custom-layout-heading", css`
+        ${fontStyles(model.headingFont)}
+        ${isDefined(model.labelAlign) ? `text-align: ${model.labelAlign};` : ''}
+    `);
+
+  return {
+    customLayout,
+    heading,
+  };
+});

--- a/shesha-reactjs/src/designer-components/customLayout/utils.ts
+++ b/shesha-reactjs/src/designer-components/customLayout/utils.ts
@@ -1,0 +1,55 @@
+import { IStyleValue } from '@/providers/form/models';
+import { ICommonContainerProps } from '../container/interfaces';
+import { ICustomLayoutComponentProps } from './interfaces';
+
+export const defaultStyles = (prev?: ICustomLayoutComponentProps): IStyleValue & ICommonContainerProps => {
+  const {
+    display,
+    direction,
+    alignItems,
+    alignSelf,
+    flexWrap,
+    flexDirection,
+    justifySelf,
+    justifyItems,
+    justifyContent,
+    textJustify,
+    noDefaultStyling,
+    gridColumnsCount,
+    gap,
+  } = prev || {};
+
+  return {
+    background: { type: 'color', color: '' },
+    dimensions: {
+      width: 'auto',
+      height: 'auto',
+      minHeight: '32px',
+      maxHeight: 'none',
+      minWidth: '0px',
+      maxWidth: 'none',
+    },
+    border: {
+      radiusType: 'all',
+      borderType: 'all',
+      border: {
+        all: { width: '1px', color: '#d9d9d9', style: 'none' },
+      },
+      radius: { all: '8' },
+    },
+    shadow: { blurRadius: 0, color: '#000000', offsetX: 0, offsetY: 0, spreadRadius: 0 },
+    display: display ?? 'block',
+    direction: direction ?? 'horizontal',
+    flexWrap: flexWrap ?? 'nowrap',
+    flexDirection: flexDirection ?? 'row',
+    justifyContent: justifyContent ?? 'left',
+    alignItems: alignItems ?? 'normal',
+    alignSelf: alignSelf ?? 'normal',
+    justifyItems: justifyItems ?? 'normal',
+    textJustify: textJustify ?? 'auto',
+    justifySelf: justifySelf ?? 'normal',
+    noDefaultStyling: noDefaultStyling ?? false,
+    gridColumnsCount: gridColumnsCount ?? undefined,
+    gap: gap,
+  };
+};

--- a/shesha-reactjs/src/providers/form/defaults/toolboxComponents.ts
+++ b/shesha-reactjs/src/providers/form/defaults/toolboxComponents.ts
@@ -67,6 +67,7 @@ import CollapsiblePanel from '@/designer-components/collapsiblePanel/collapsible
 import ConfigurableActionConfigurator from '@/designer-components/configurableActionsConfigurator';
 import ContainerComponent from '@/designer-components/container/containerComponent';
 import ContextPropertyAutocompleteComponent from '@/designer-components/contextPropertyAutocomplete';
+import CustomLayoutComponent from '@/designer-components/customLayout/customLayoutComponent';
 import DataContextSelector from '@/designer-components/dataContextSelector';
 import ChildTable from '@/designer-components/dataTable/childTable';
 import Pager from '@/designer-components/dataTable/pager/pagerComponent';
@@ -222,6 +223,7 @@ export const getToolboxComponents = (
         CollapsiblePanel,
         Columns,
         ContainerComponent,
+        CustomLayoutComponent,
         Drawer,
         KeyInformationBarComponent,
         SectionSeprator,


### PR DESCRIPTION
This pull request introduces a new `CustomLayoutComponent` to the form designer, providing a flexible container with configurable layout, appearance, and heading options. The implementation includes the component definition, designer integration, default styles, settings form, and unit tests.

**New Custom Layout Component:**

- Implemented `CustomLayoutComponent` with configurable heading, layout, and style options, and registered it in the toolbox for use in the form designer. [[1]](diffhunk://#diff-45905d71b3bed947cba6df168a06ef9e99fbaffe65b458874ac53962233b46a7R1-R52) [[2]](diffhunk://#diff-c7835af363a2a915a6257826f7a21da38ffe78a0f785db2cbbcd8094cc357292R70) [[3]](diffhunk://#diff-c7835af363a2a915a6257826f7a21da38ffe78a0f785db2cbbcd8094cc357292R226)

**Component API and Styling:**

- Defined `ICustomLayoutComponentProps` interface and component definition type, supporting custom heading typography and layout-related props.
- Added `useStyles` hook to encapsulate component and heading styling, supporting grid, flex, and other layout options.
- Provided `defaultStyles` utility for consistent default appearance and layout behavior.

**Designer Integration and Configuration:**

- Created `getSettings` form for designer configuration, allowing users to adjust layout, appearance, and custom CSS/class settings via a tabbed interface.

**Testing:**

- Added comprehensive unit tests for `CustomLayoutComponent`, covering registration, default initialization, heading behavior, and prop handling.


#4804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Custom Layout component to the designer toolbox.
  * Supports configurable labels, visibility, typography, layout, spacing, borders, backgrounds, shadows, and custom styling.
  * Supports dynamically adding and arranging child components within the layout.
* **Tests**
  * Added coverage for component registration and default label, visibility, alignment, and typography settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->